### PR TITLE
Initial fix to MPES structure on html page

### DIFF
--- a/manual/source/classes/contributed_definitions/mpes-structure.rst
+++ b/manual/source/classes/contributed_definitions/mpes-structure.rst
@@ -19,7 +19,7 @@ Introduction
 
 Set of data storage objects to describe photoemission experiments including x-ray photoelectron spectroscopy (XPS), ultraviolet photoelectron spectroscopy (UPS),
 hard x-ray photoelectron spectroscopy (HAXPES), angle-resolved photoemission spectroscopy (ARPES), two-photon photoemission (2PPE) 
-and photoemission electron microscopy (PEEM). We also included descriptors for advanced specializations, such as spin-resolution, time resolution, 
+and photoemission electron microscopy (PEEM). Also includes descriptors for advanced specializations, such as spin-resolution, time resolution, 
 near-ambient pressure conditions, dichroism etc.
 
 .. _MpesAppDef:
@@ -27,18 +27,15 @@ near-ambient pressure conditions, dichroism etc.
 Application Definitions
 #######################
 
-We created two new application definitions:
-
-    :ref:`NXmpes`:
-       A general appdef with minimalistic metadata requirements, apt to describe all photemission experiments.
+:ref:`NXmpes`:
+   A general appdef with minimalistic metadata requirements, apt to describe all photemission experiments.
 
 .. _MpesBC:
 
 Base Classes
 ############
 
-We developed entirely new base classes:
-
+New base classes:
     :ref:`NXelectronanalyser`:
        A base class to describe electron kinetic energy analizers. Contains the collective characteristics of the instrument such as energy resolution, and includes the following subclasses:
 
@@ -55,7 +52,7 @@ We developed entirely new base classes:
        A base class to describe the complex manipulators used in photoemission experiments, often with > 4 degrees of freedom, 
        cryogenic cooling and other advanced features.
 
-We developed three base classes to describe data processing, which can be used as subclasses of :ref:`NXprocess` if describing post-processing or as subclasses of :ref:`NXdetector` if describing live, electronics level processing:
+Three base classes to describe data processing, which can be used as subclasses of :ref:`NXprocess` if describing post-processing or as subclasses of :ref:`NXdetector` if describing live, electronics level processing:
 
     :ref:`NXcalibration`:
        A base class to describe the 1D calibration of an axis, with a function mapping a raw data scale to a calibrated scale with the same number of points.
@@ -71,7 +68,7 @@ We developed three base classes to describe data processing, which can be used a
 Common Base Classes
 ###################
 
-We developed two classes that are common to other techniques:
+There are two related base classes that are common to other techniques:
 
     :ref:`NXlens_em`:
        A class to describe all types of lenses. Includes electrostatic lenses for electron energy analysers.
@@ -84,7 +81,7 @@ We developed two classes that are common to other techniques:
 Base Classes Extended in Application Definitions
 ################################################
 
-We use existent base classes in application definitions and add descriptors:
+The following existent base classes are used in application definitions (with added descriptors):
 
     :ref:`NXaperture`
        Added fileds to describe analyser apertures and slits.

--- a/manual/source/classes/contributed_definitions/mpes-structure.rst
+++ b/manual/source/classes/contributed_definitions/mpes-structure.rst
@@ -35,22 +35,21 @@ Application Definitions
 Base Classes
 ############
 
-New base classes:
-    :ref:`NXelectronanalyser`:
-       A base class to describe electron kinetic energy analizers. Contains the collective characteristics of the instrument such as energy resolution, and includes the following subclasses:
+:ref:`NXelectronanalyser`:
+   A base class to describe electron kinetic energy analizers. Contains the collective characteristics of the instrument such as energy resolution, and includes the following subclasses:
 
-          :ref:`NXcollectioncolumn`:
-             Base class to describe the set of electronic lenses in the electron collection column (standard, PEEM, momentum-microscope, etc.).
+      :ref:`NXcollectioncolumn`:
+         Base class to describe the set of electronic lenses in the electron collection column (standard, PEEM, momentum-microscope, etc.).
 
-          :ref:`NXenergydispersion`:
-             Base class to describe the energy dispersion sytem (hemispherical, time-of-flight, etc.).
+      :ref:`NXenergydispersion`:
+         Base class to describe the energy dispersion sytem (hemispherical, time-of-flight, etc.).
 
-          :ref:`NXspindispersion`:
-             Base class to describe the set of electronic lenses in the electron collection column.
+      :ref:`NXspindispersion`:
+         Base class to describe the set of electronic lenses in the electron collection column.
 
-    :ref:`NXmanipulator`:
-       A base class to describe the complex manipulators used in photoemission experiments, often with > 4 degrees of freedom, 
-       cryogenic cooling and other advanced features.
+:ref:`NXmanipulator`:
+   A base class to describe the complex manipulators used in photoemission experiments, often with > 4 degrees of freedom, 
+   cryogenic cooling and other advanced features.
 
 Three base classes to describe data processing, which can be used as subclasses of :ref:`NXprocess` if describing post-processing or as subclasses of :ref:`NXdetector` if describing live, electronics level processing:
 
@@ -74,35 +73,4 @@ There are two related base classes that are common to other techniques:
        A class to describe all types of lenses. Includes electrostatic lenses for electron energy analysers.
 
     :ref:`NXdeflector`
-       A class to describe all kinds of deflectors, including electrostatic and magnetostatic deflectors for electron energy analysers.  
-
-.. _MpesExtendedBC:
-
-Base Classes Extended in Application Definitions
-################################################
-
-The following existent base classes are used in application definitions (with added descriptors):
-
-    :ref:`NXaperture`
-       Added fileds to describe analyser apertures and slits.
-
-    :ref:`NXbeam`
-       Adedd fields to describe utrafast laser beams.
-
-    :ref:`NXdetector`
-       Added fields to describe electron detectors (MCP+Phospor screen, delay lines etc.).
-
-    :ref:`NXentry`
-       Added fields to describe an experiment.
-
-    :ref:`NXprocess`
-       Added subclasses and collective processing descriptors.
-
-    :ref:`NXsample`
-       Added descriptors specific to photoemission experiments.
-
-    :ref:`NXsource`
-       Added descriptors for laboratory sources (X-ray, UV lamps) but mostly for ultrafast lasers with complex time structures.
-
-    :ref:`NXinstrument`
-      Added descriptors for the overall resolutions of the experiment (energy, momentum, angular, spatial, temporal).
+       A class to describe all kinds of deflectors, including electrostatic and magnetostatic deflectors for electron energy analysers.


### PR DESCRIPTION
Remove unnecessary references on NXmpes NeXus page.
- Remove information about developers ('we', 'FAIRmat', ...)
- Remove reference to already standardised definitions
- Improve wording