### PR TITLE
Fixes makefile pickung up nxdl rules for `make nyaml`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,8 @@ $(APPDEF_DIR)/%.nxdl.xml : $(APPDEF_DIR)/$(NYAML_SUBDIR)/%.yaml
 	mv $(APPDEF_DIR)/$(NYAML_SUBDIR)/$*.nxdl.xml $@
 
 NXDLS := $(foreach dir,$(NXDL_DIRS),$(wildcard $(dir)/*.nxdl.xml))
-nyaml : $(DIRS) $(NXDLS)
-	for file in $^; do\
+nyaml : $(DIRS)
+	for file in $(NXDLS); do\
 		mkdir -p "$${file%/*}/nyaml";\
 		nyaml2nxdl --input-file $${file};\
 		FNAME=$${file##*/};\


### PR DESCRIPTION
This fixes `make nyaml` breaking the build on second run (when yaml files are present), because it picks up the nyaml rules.
This PR removes the dependency in the make rule because we don't need it there and can simply use it as a variable.

As this was reported by @RubelMozumder : Can you check if everything is fine now?

This change was also committed to https://github.com/nexusformat/definitions/pull/1303