### PR TITLE
Add Nexus/NXmpes documentation

### DIFF
--- a/docs/how-tos/overview.md
+++ b/docs/how-tos/overview.md
@@ -1,0 +1,8 @@
+# How-tos we want to write
+
+This is just an overview of how tos we [agreed](https://github.com/FAIRmat-NFDI/data-modeling/blob/main/mpes/meetings/2023-10-04_documentation.md#decisions) to write for nexus. Eventually, there should be a documentation file/page for each of them.
+
+- I have a nexus file, how to upload to nomad
+- I have a nexus file and additional metadata, what do I do?
+- I have a supported vendor file but no eln data how can I make a corresponding nomad eln?
+- I have multiple nexus files and want to combine them into one nexus (master) file which is compliant to an application definition (future discussion: how do we want to support/distribute this in nomad/pynxtools?)

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 hide: toc
 ---
 
-# FAIRmat nexus documentation
+# FAIRmat NeXus documentation
 
 <!-- A single sentence that says what the product is, succinctly and memorably -->
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,43 @@
+---
+hide: toc
+---
+
+# FAIRmat nexus documentation
+
+<!-- A single sentence that says what the product is, succinctly and memorably -->
+
+<!-- A paragraph of one to three short sentences, that describe what the product does. -->
+
+<!-- A third paragraph of similar length, this time explaining what need the product meets -->
+
+<!-- Finally, a paragraph that describes whom the product is useful for. -->
+
+<div markdown="block" class="home-grid">
+<div markdown="block">
+
+### Tutorial
+
+
+</div>
+<div markdown="block">
+
+### How-to guides
+
+
+</div>
+
+<div markdown="block">
+
+### Learn
+
+
+</div>
+<div markdown="block">
+
+### Reference
+
+
+</div>
+</div>
+
+<h2>Project and community</h2>

--- a/docs/macros.py
+++ b/docs/macros.py
@@ -1,0 +1,16 @@
+"""
+MKdocs macros for the documentation
+"""
+
+def define_env(env):
+    """
+    This is the hook for defining variables, macros and filters
+
+    - variables: the dictionary that contains the environment variables
+    - macro: a decorator function, to declare a macro.
+    - filter: a function with one of more arguments,
+        used to perform a transformation
+    """
+
+    # add to the dictionary of variables available to markdown pages:
+    env.variables['version'] = "2023.10" # Figure out from setuptools-scm eventually

--- a/docs/reference/definitions.md
+++ b/docs/reference/definitions.md
@@ -1,3 +1,3 @@
-# Nexus definitions
+# NeXus definitions
 
-This should link to or integrate the nexus sphinx documentation
+This should link to or integrate the NeXus sphinx documentation

--- a/docs/reference/definitions.md
+++ b/docs/reference/definitions.md
@@ -1,0 +1,3 @@
+# Nexus definitions
+
+This should link to or integrate the nexus sphinx documentation

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,69 @@
+
+.md-header__button.md-logo :where(img,svg) {
+    width: 100%;
+    height: 30px;
+}
+
+.md-header, .md-header__inner {
+    background-color: #fff;
+    color: #2A4CDF;
+}
+
+.md-header[data-md-state=shadow] {
+    box-shadow: 0px 2px 4px -1px rgb(0 0 0 / 20%), 0px 4px 5px 0px rgb(0 0 0 / 14%), 0px 1px 10px 0px rgb(0 0 0 / 12%);
+    transition: box-shadow 200ms linear;
+}
+
+.md-header__inner {
+    height: 80px;
+}
+
+.md-header__topic {
+    font-size: 24px;
+}
+
+.md-footer {
+    background-color: #2A4CDF;
+}
+
+.md-search__form:hover {
+    background-color: rgba(0,0,0,.13);
+}
+
+.md-typeset h1 {
+    color: black;
+    font-weight: 700;
+}
+
+.youtube {
+    position: relative;
+    width: 100%;
+    height: 0;
+    padding-bottom: 56.25%;
+}
+
+.youtube iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.home-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-column-gap: 24px;
+    row-gap: 24px;
+}
+
+.home-grid div {
+    border-radius: 4px;
+    padding: 24px;
+    background-color: #f3e9d9;
+}
+
+.home-grid h3 {
+    margin-top: 0;
+    font-weight: 700;
+}

--- a/docs/tutorial/nexus-primer.md
+++ b/docs/tutorial/nexus-primer.md
@@ -1,0 +1,1 @@
+# A primer on nexus

--- a/docs/tutorial/nexus-primer.md
+++ b/docs/tutorial/nexus-primer.md
@@ -1,1 +1,1 @@
-# A primer on nexus
+# A primer on NeXus

--- a/docs/tutorial/nexus-to-nomad.md
+++ b/docs/tutorial/nexus-to-nomad.md
@@ -1,0 +1,1 @@
+# Generate a nexus file and upload it to nomad

--- a/docs/tutorial/nexus-to-nomad.md
+++ b/docs/tutorial/nexus-to-nomad.md
@@ -1,1 +1,1 @@
-# Generate a nexus file and upload it to nomad
+# Generate a NeXus file and upload it to nomad

--- a/mkdocs-requirements.txt
+++ b/mkdocs-requirements.txt
@@ -1,0 +1,4 @@
+mkdocs
+mkdocs-material
+mkdocs-material-extensions
+mkdocs-macros-plugin

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -4,6 +4,13 @@ site_description: |
 site_author: The FAIRmat authors
 nav:
   - Home: index.md
+  - Tutorials:
+    - A primer on nexus: tutorial/nexus-primer.md
+    - Nexus to nomad: tutorial/nexus-to-nomad.md
+    - Storing an experiment geometry in NeXus: tutorial/transformations.md
+  - Reference:
+    - Application definitions: reference/definitions.md
+  - How-tos: how-tos/overview.md
 theme:
   name: material
   features:

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,6 +1,6 @@
-site_name: FAIRmat nexus
+site_name: FAIRmat NeXus
 site_description: |
-  The documentation the FAIRmat flavor of the nexus definitions
+  The documentation the FAIRmat flavor of the NeXus definitions
 site_author: The FAIRmat authors
 nav:
   - Home: index.md

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,0 +1,38 @@
+site_name: FAIRmat nexus
+site_description: |
+  The documentation the FAIRmat flavor of the nexus definitions
+site_author: The FAIRmat authors
+nav:
+  - Home: index.md
+theme:
+  name: material
+  features:
+    - content.code.copy
+    - content.code.annotate
+markdown_extensions:
+  - attr_list
+  - md_in_html
+  - admonition
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - toc:
+      permalink: True
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.emoji
+  - pymdownx.extra
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+use_directory_urls: false
+plugins:
+    - search
+    - macros:
+        module_name: docs/macros
+extra_css:
+  - stylesheets/extra.css


### PR DESCRIPTION
This is just a proposal to start writing documentation. It could be as a standalone version to be integrated automatically into nomads mkdocs with the [mkdocs monorepo plugin](https://github.com/backstage/mkdocs-monorepo-plugin) or we can just eventually copy this over to nomad.

The benefit of maintaining this here is that we don't have to sync our PRs and can have everything in one place. It will then also get only updated in nomad when the submodule is updated, so we can also keep the appropriate version in the appropriate place (but some documentation may also not tied to a change in definitions/base classes). I also feel that github is a better place for external collaborators to join and review what we are doing.

TL;DR/I just want to see it: `pip install -r mkdocs-requirements.txt`, `mkdocs serve`, open http://localhost:8000 (yes, it live-reloads 😎)

@sanbrock @lukaspie @sherjeelshabih @mkuehbach @RubelMozumder @RonHildebrandt (btw is there a @FAIRmat/TeamB shortcut for this!? 😅)