### PR TITLE
Fix NXroot nxdl

### DIFF
--- a/base_classes/NXroot.nxdl.xml
+++ b/base_classes/NXroot.nxdl.xml
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 # 
-# Copyright (C) 2014-2022 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2014-2023 NeXus International Advisory Committee (NIAC)
 # 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -22,123 +22,123 @@
 # For further information, see http://www.nexusformat.org
 -->
 <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXroot" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+  <doc>
+       Definition of the root NeXus group.
+  </doc>
+  <attribute name="NX_class">
     <doc>
-         Definition of the root NeXus group.
+         The root of any NeXus data file is an ``NXroot`` class
+         (no other choice is allowed for a valid NeXus data file).
+         This attribute cements that definition.
     </doc>
-    <attribute name="NX_class">
-        <doc>
-             The root of any NeXus data file is an ``NXroot`` class
-             (no other choice is allowed for a valid NeXus data file).
-             This attribute cements that definition.
-        </doc>
-        <enumeration>
-            <item value="NXroot"/>
-        </enumeration>
-    </attribute>
-    <attribute name="file_time" type="NX_DATE_TIME">
-        <doc>
-             Date and time file was originally created
-        </doc>
-    </attribute>
-    <attribute name="file_name">
-        <doc>
-             File name of original NeXus file
-        </doc>
-    </attribute>
-    <attribute name="file_update_time" type="NX_DATE_TIME">
-        <doc>
-             Date and time of last file change at close
-        </doc>
-    </attribute>
-    <attribute name="NeXus_repository">
-        <doc>
-             A repository containing the application definitions
-             used for creating this file.
-             If the NeXus_version attribute contains a commit distance and hash
-             this should refer to this repository.
-        </doc>
-    </attribute>
-    <attribute name="NeXus_version">
-        <doc>
-             Version of NeXus definitions used in writing the file.
-             This may either be a date based version tag of the form `vYYYY.MM`
-             or a version tag with a commit distance and source control (e.g., git) hash of
-             the form `vYYYY.MM.post1.dev&lt;commit-distance&gt;.g&lt;git-hash&gt;`.
-             It may contain an additional `.dYYYYMMDD` timestamp appendix
-             for dirty repositories.
-             If the version contains a commit distance and hash the
-             NeXus_repository attribute should be written with the 
-             repository url containing this version.
-             
-             Only used when the NAPI or pynxtools has written the file.
-             Note that this is different from the version of the
-             base class or application definition version number.
-        </doc>
-    </attribute>
-    <attribute name="partial">
-        <doc>
-             A list of concepts in an application definition this file describes.
-             This is for partially filling an application definition.
-             If this attribute is not present the application definition is assumed
-             to be valid, if not only the specified concepts/paths are assumed to be valid.
-        </doc>
-    </attribute>
-    <attribute name="HDF_version">
-        <doc>
-             Version of HDF (version 4) library used in writing the file
-        </doc>
-    </attribute>
-    <attribute name="HDF5_Version">
-        <doc>
-             Version of HDF5 library used in writing the file.
-             
-             Note this attribute is spelled with uppercase &quot;V&quot;,
-             different than other version attributes.
-        </doc>
-    </attribute>
-    <attribute name="XML_version">
-        <doc>
-             Version of XML support library used in writing the XML file
-        </doc>
-    </attribute>
-    <attribute name="h5py_version">
-        <doc>
-             Version of h5py Python package used in writing the file
-        </doc>
-    </attribute>
-    <attribute name="creator">
-        <doc>
-             facility or program where file originated
-        </doc>
-    </attribute>
-    <attribute name="creator_version">
-        <doc>
-             Version of facility or program used in writing the file
-        </doc>
-    </attribute>
-    <group type="NXentry" minOccurs="1">
-        <doc>
-             entries
-        </doc>
-    </group>
-    <attribute name="default">
-        <doc>
-             .. index:: find the default plottable data
-             .. index:: plotting
-             .. index:: default attribute value
-             
-             Declares which :ref:`NXentry` group contains
-             the data to be shown by default.
-             It is used to resolve ambiguity when
-             more than one :ref:`NXentry` group exists.
-             The value :ref:`names &lt;validItemName&gt;` the default :ref:`NXentry` group.  The
-             value must be the name of a child of the current group. The child must be a
-             NeXus group or a link to a NeXus group.
-             
-             It is recommended (as of NIAC2014) to use this attribute
-             to help define the path to the default dataset to be plotted.
-             See https://www.nexusformat.org/2014_How_to_find_default_data.html
-             for a summary of the discussion.
-        </doc>
-    </attribute>
+    <enumeration>
+      <item value="NXroot"/>
+    </enumeration>
+  </attribute>
+  <attribute name="file_time" type="NX_DATE_TIME">
+    <doc>
+         Date and time file was originally created
+    </doc>
+  </attribute>
+  <attribute name="file_name">
+    <doc>
+         File name of original NeXus file
+    </doc>
+  </attribute>
+  <attribute name="file_update_time" type="NX_DATE_TIME">
+    <doc>
+         Date and time of last file change at close
+    </doc>
+  </attribute>
+  <attribute name="NeXus_repository">
+    <doc>
+         A repository containing the application definitions
+         used for creating this file.
+         If the NeXus_version attribute contains a commit distance and hash
+         this should refer to this repository.
+    </doc>
+  </attribute>
+  <attribute name="NeXus_version">
+    <doc>
+         Version of NeXus definitions used in writing the file.
+         This may either be a date based version tag of the form `vYYYY.MM`
+         or a version tag with a commit distance and source control (e.g., git) hash of
+         the form `vYYYY.MM.post1.dev&lt;commit-distance&gt;.g&lt;git-hash&gt;`.
+         It may contain an additional `.dYYYYMMDD` timestamp appendix
+         for dirty repositories.
+         If the version contains a commit distance and hash the
+         NeXus_repository attribute should be written with the 
+         repository url containing this version.
+         
+         Only used when the NAPI or pynxtools has written the file.
+         Note that this is different from the version of the
+         base class or application definition version number.
+    </doc>
+  </attribute>
+  <attribute name="partial">
+    <doc>
+         A list of concepts in an application definition this file describes.
+         This is for partially filling an application definition.
+         If this attribute is not present the application definition is assumed
+         to be valid, if not only the specified concepts/paths are assumed to be valid.
+    </doc>
+  </attribute>
+  <attribute name="HDF_version">
+    <doc>
+         Version of HDF (version 4) library used in writing the file
+    </doc>
+  </attribute>
+  <attribute name="HDF5_Version">
+    <doc>
+         Version of HDF5 library used in writing the file.
+         
+         Note this attribute is spelled with uppercase "V",
+         different than other version attributes.
+    </doc>
+  </attribute>
+  <attribute name="XML_version">
+    <doc>
+         Version of XML support library used in writing the XML file
+    </doc>
+  </attribute>
+  <attribute name="h5py_version">
+    <doc>
+         Version of h5py Python package used in writing the file
+    </doc>
+  </attribute>
+  <attribute name="creator">
+    <doc>
+         facility or program where file originated
+    </doc>
+  </attribute>
+  <attribute name="creator_version">
+    <doc>
+         Version of facility or program used in writing the file
+    </doc>
+  </attribute>
+  <group type="NXentry" minOccurs="1">
+    <doc>
+         entries
+    </doc>
+  </group>
+  <attribute name="default">
+    <doc>
+         .. index:: find the default plottable data
+         .. index:: plotting
+         .. index:: default attribute value
+         
+         Declares which :ref:`NXentry` group contains
+         the data to be shown by default.
+         It is used to resolve ambiguity when
+         more than one :ref:`NXentry` group exists.
+         The value :ref:`names &lt;validItemName&gt;` the default :ref:`NXentry` group.  The
+         value must be the name of a child of the current group. The child must be a
+         NeXus group or a link to a NeXus group.
+         
+         It is recommended (as of NIAC2014) to use this attribute
+         to help define the path to the default dataset to be plotted.
+         See https://www.nexusformat.org/2014_How_to_find_default_data.html
+         for a summary of the discussion.
+    </doc>
+  </attribute>
 </definition>


### PR DESCRIPTION
There was a difference for the NXroot generated by the `nyaml2nxdl` in the fairmat branch and the one from #101. This commit fixes NXroot to work with `nyaml2nxdl@fairmat`