### PR TITLE
Allow xref in root-level docstring

### DIFF
--- a/dev_tools/nyaml2nxdl/nyaml2nxdl_backward_tools.py
+++ b/dev_tools/nyaml2nxdl/nyaml2nxdl_backward_tools.py
@@ -336,7 +336,7 @@ class Nxdl2yaml:
     def check_and_handle_doc_xref_and_other_doc(self, text, indent):
         """Check for xref doc which comes as a block of text.
 
-        The doc part bellow is the example how xref comes:
+        The doc part below is the example how xref comes:
         '''
         This concept is related to term `<term>`_ of the <spec> standard.
         .. _<term>: <url>

--- a/dev_tools/nyaml2nxdl/nyaml2nxdl_forward_tools.py
+++ b/dev_tools/nyaml2nxdl/nyaml2nxdl_forward_tools.py
@@ -1201,9 +1201,11 @@ application and base are valid categories!"
         del yml_appdef["symbols"]
         del yml_appdef["__line__symbols"]
     if isinstance(yml_appdef["doc"], str):
-        assert (yml_appdef["doc"] != ""), "Doc has to be a non-empty string!"
+        assert yml_appdef["doc"] != "", "Doc has to be a non-empty string!"
     elif isinstance(yml_appdef["doc"], list):
-        assert (any(yml_appdef["doc"])), "One of the doc elements has to be a non-empty string!"
+        assert any(
+            yml_appdef["doc"]
+        ), "One of the doc elements has to be a non-empty string!"
 
     line_number = "__line__doc"
     line_loc_no = yml_appdef[line_number]

--- a/dev_tools/nyaml2nxdl/nyaml2nxdl_forward_tools.py
+++ b/dev_tools/nyaml2nxdl/nyaml2nxdl_forward_tools.py
@@ -1200,9 +1200,10 @@ application and base are valid categories!"
 
         del yml_appdef["symbols"]
         del yml_appdef["__line__symbols"]
-    assert (
-        isinstance(yml_appdef["doc"], str) and yml_appdef["doc"] != ""
-    ), "Doc has to be a non-empty string!"
+    if isinstance(yml_appdef["doc"], str):
+        assert (yml_appdef["doc"] != ""), "Doc has to be a non-empty string!"
+    elif isinstance(yml_appdef["doc"], list):
+        assert (any(yml_appdef["doc"])), "One of the doc elements has to be a non-empty string!"
 
     line_number = "__line__doc"
     line_loc_no = yml_appdef[line_number]

--- a/dev_tools/tests/data/doc_yaml2nxdl.yaml
+++ b/dev_tools/tests/data/doc_yaml2nxdl.yaml
@@ -1,13 +1,19 @@
 category: application
-doc: |
-  This is a definition for data to be archived by ICAT (http://www.icatproject.org/).
-  
-  .. text from the icatproject.org site
-  
-          the database (with supporting software) that provides an
-          interface to all ISIS experimental data and will provide
-          a mechanism to link all aspects of ISIS research from
-          proposal through to publication.
+doc:
+  - |
+    This is a definition for data to be archived by ICAT (http://www.icatproject.org/).
+    
+    .. text from the icatproject.org site
+    
+            the database (with supporting software) that provides an
+            interface to all ISIS experimental data and will provide
+            a mechanism to link all aspects of ISIS research from
+            proposal through to publication.
+  - |
+    xref:
+      spec: ISO 18115-1:2023
+      term: 1.1
+      url: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:1.1
 type: group
 NXarchive(NXobject):
   (NXentry)entry:

--- a/dev_tools/tests/data/ref_doc_yaml2nxdl.nxdl.xml
+++ b/dev_tools/tests/data/ref_doc_yaml2nxdl.nxdl.xml
@@ -31,6 +31,9 @@
        		interface to all ISIS experimental data and will provide
        		a mechanism to link all aspects of ISIS research from
        		proposal through to publication.
+       
+           This concept is related to term `1.1`_ of the ISO 18115-1:2023 standard.
+       .. _1.1: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:1.1
   </doc>
   <group type="NXentry" name="entry">
     <attribute name="index"/>


### PR DESCRIPTION
Allows for writing multiple list items in root-level docstring of a nyaml file.
- nyaml2nxdl_forward_tool:
  - Check if root-level doc is a string and non-empty (this was implemented before).
  - Check if root-level doc is instead a list and _one_ of the list elements is not empty.
    - If true, the doc is handled as any other multi-component doc (this includes any xref docs).
- The test data for the forward tool has also been extended to cover this use case.
- Typo fix in backwards tool.

Fixes #119.

