### PR TITLE
Refine makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,14 @@ BUILD_DIR = "build"
 BASE_CLASS_DIR := base_classes
 CONTRIB_DIR := contributed_definitions
 APPDEF_DIR := applications
-NXDL_DIRS := $(BASE_CLASS_DIR) $(CONTRIB_DIR) $(APPDEF_DIR)
 NYAML_SUBDIR := nyaml
-NYAML_APPENDIX := _parsed
 
-NXDL_BC := $(wildcard $(BASE_CLASS_DIR)/*.nxdl.xml)
-NXDL_CONTRIB := $(wildcard $(CONTRIB_DIR)/*.nxdl.xml)
-NXDL_APPDEF := $(wildcard $(APPDEF_DIR)/*.nxdl.xml)
+YBC_NXDL = $(patsubst %.yaml,%.nxdl.xml,$(subst /nyaml/,/, $(wildcard $(BASE_CLASS_DIR)/nyaml/*.yaml)))
+YCONTRIB_NXDL = $(patsubst %.yaml,%.nxdl.xml,$(subst /nyaml/,/, $(wildcard $(CONTRIB_DIR)/nyaml/*.yaml)))
+YAPPDEF_NXDL = $(patsubst %.yaml,%.nxdl.xml,$(subst /nyaml/,/, $(wildcard $(APPDEF_DIR)/nyaml/*.yaml)))
 
-.PHONY: help install style autoformat test clean prepare html pdf impatient-guide all local nyaml nxdl
+
+.PHONY: help install style autoformat test clean prepare html pdf impatient-guide all local nxdl
 
 help ::
 	@echo ""
@@ -99,27 +98,16 @@ all ::
 	@echo "PDF built: `ls -lAFgh $(BUILD_DIR)/manual/build/latex/nexus-fairmat.pdf`"
 
 $(BASE_CLASS_DIR)/%.nxdl.xml : $(BASE_CLASS_DIR)/$(NYAML_SUBDIR)/%.yaml
-	nyaml2nxdl $<
-	mv $(BASE_CLASS_DIR)/$(NYAML_SUBDIR)/$*.nxdl.xml $@
+	nyaml2nxdl $< --output-file $@
 
 $(CONTRIB_DIR)/%.nxdl.xml : $(CONTRIB_DIR)/$(NYAML_SUBDIR)/%.yaml
-	nyaml2nxdl $<
-	mv $(CONTRIB_DIR)/$(NYAML_SUBDIR)/$*.nxdl.xml $@
+	nyaml2nxdl $< --output-file $@
 
 $(APPDEF_DIR)/%.nxdl.xml : $(APPDEF_DIR)/$(NYAML_SUBDIR)/%.yaml
-	nyaml2nxdl $<
-	mv $(APPDEF_DIR)/$(NYAML_SUBDIR)/$*.nxdl.xml $@
+	nyaml2nxdl $< --output-file $@
 
-NXDLS := $(NXDL_APPDEF) $(NXDL_CONTRIB) $(NXDL_BC)
-nyaml :
-	for file in $(NXDLS); do\
-		mkdir -p "$${file%/*}/nyaml";\
-		nyaml2nxdl $${file};\
-		FNAME=$${file##*/};\
-		mv -- "$${file%.nxdl.xml}_parsed.yaml" "$${file%/*}/nyaml/$${FNAME%.nxdl.xml}.yaml";\
-	done
+nxdl: $(YBC_NXDL) $(YCONTRIB_NXDL) $(YAPPDEF_NXDL)
 
-nxdl: $(NXDL_APPDEF) $(NXDL_CONTRIB) $(NXDL_BC)
 
 # NeXus - Neutron and X-ray Common Data Format
 #

--- a/Makefile
+++ b/Makefile
@@ -5,15 +5,15 @@
 
 PYTHON = python3
 SPHINX = sphinx-build
-BUILD_DIR = "build"
-BASE_CLASS_DIR := base_classes
-CONTRIB_DIR := contributed_definitions
-APPDEF_DIR := applications
-NYAML_SUBDIR := nyaml
+BUILD_DIR = build
+BASE_CLASS_DIR = base_classes
+CONTRIB_DIR = contributed_definitions
+APPDEF_DIR = applications
+NYAML_SUBDIR = nyaml
 
-YBC_NXDL = $(patsubst %.yaml,%.nxdl.xml,$(subst /nyaml/,/, $(wildcard $(BASE_CLASS_DIR)/nyaml/*.yaml)))
-YCONTRIB_NXDL = $(patsubst %.yaml,%.nxdl.xml,$(subst /nyaml/,/, $(wildcard $(CONTRIB_DIR)/nyaml/*.yaml)))
-YAPPDEF_NXDL = $(patsubst %.yaml,%.nxdl.xml,$(subst /nyaml/,/, $(wildcard $(APPDEF_DIR)/nyaml/*.yaml)))
+YBC_NXDL_TARGETS = $(patsubst %.yaml,%.nxdl.xml,$(subst /nyaml/,/, $(wildcard $(BASE_CLASS_DIR)/nyaml/*.yaml)))
+YCONTRIB_NXDL_TARGETS = $(patsubst %.yaml,%.nxdl.xml,$(subst /nyaml/,/, $(wildcard $(CONTRIB_DIR)/nyaml/*.yaml)))
+YAPPDEF_NXDL_TARGETS = $(patsubst %.yaml,%.nxdl.xml,$(subst /nyaml/,/, $(wildcard $(APPDEF_DIR)/nyaml/*.yaml)))
 
 
 .PHONY: help install style autoformat test clean prepare html pdf impatient-guide all local nxdl nyaml
@@ -28,12 +28,15 @@ help ::
 	@echo "make autoformat         Format all files to the coding style conventions."
 	@echo "make test               Run NXDL syntax and documentation tests."
 	@echo "make clean              Remove all build files."
+	@echo "make clean-nyaml        Remove all nyaml files."
 	@echo "make prepare            (Re)create all build files."
 	@echo "make html               Build HTML version of manual. Requires prepare first."
 	@echo "make pdf                Build PDF version of manual. Requires prepare first."
 	@echo "make impatient-guide    Build html & PDF versions of the Guide for the Impatient. Requires prepare first."
 	@echo "make all                Builds complete web site for the manual (in build directory)."
 	@echo "make local              (Developer use) Test, prepare and build the HTML manual."
+	@echo "make nxdl               Build NXDL files from NYAML files in nyaml subdirectories."
+	@echo "make nyaml              Build NYAML files to nyaml subdirectories from NXDL files."
 	@echo ""
 	@echo "Note:  All builds of the manual will occur in the 'build/' directory."
 	@echo "   For a complete build, run 'make all' in the root directory."
@@ -106,7 +109,7 @@ $(CONTRIB_DIR)/%.nxdl.xml : $(CONTRIB_DIR)/$(NYAML_SUBDIR)/%.yaml
 $(APPDEF_DIR)/%.nxdl.xml : $(APPDEF_DIR)/$(NYAML_SUBDIR)/%.yaml
 	nyaml2nxdl $< --output-file $@
 
-nxdl: $(YBC_NXDL) $(YCONTRIB_NXDL) $(YAPPDEF_NXDL)
+nxdl: $(YBC_NXDL_TARGETS) $(YCONTRIB_NXDL_TARGETS) $(YAPPDEF_NXDL_TARGETS)
 
 nyaml:
 	$(MAKE) -f nyaml.mk

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ YCONTRIB_NXDL = $(patsubst %.yaml,%.nxdl.xml,$(subst /nyaml/,/, $(wildcard $(CON
 YAPPDEF_NXDL = $(patsubst %.yaml,%.nxdl.xml,$(subst /nyaml/,/, $(wildcard $(APPDEF_DIR)/nyaml/*.yaml)))
 
 
-.PHONY: help install style autoformat test clean prepare html pdf impatient-guide all local nxdl
+.PHONY: help install style autoformat test clean prepare html pdf impatient-guide all local nxdl nyaml
 
 help ::
 	@echo ""
@@ -107,6 +107,9 @@ $(APPDEF_DIR)/%.nxdl.xml : $(APPDEF_DIR)/$(NYAML_SUBDIR)/%.yaml
 	nyaml2nxdl $< --output-file $@
 
 nxdl: $(YBC_NXDL) $(YCONTRIB_NXDL) $(YAPPDEF_NXDL)
+
+nyaml:
+	$(MAKE) -f nyaml.mk
 
 
 # NeXus - Neutron and X-ray Common Data Format

--- a/README.md
+++ b/README.md
@@ -48,6 +48,24 @@ Note: If set this will increase the build time of the documentation by approxima
 
     setenv GH_TOKEN <access token>
 
+### Working with nyaml files
+
+There exists a simplified format of nxdl, which is called nyaml.
+There is a [tool](https://github.com/FAIRmat-NFDI/nyaml) (`nyaml2nxdl`) available to convert between nxdl and nyaml.
+This tool is already installed when you installed the requirements for this repository and it is conveniently available from the make command.
+
+You can build nyaml files for all nxdl files with invoking
+
+    make nyaml
+
+which will created `.yaml` files in a subfolder called `nyaml` in the respective directory.
+
+From this you can do your changes and create nxdl files with
+
+    make nxdl
+
+from the yaml files.
+
 ## Repository content
 
 These are the components that define the structure of NeXus data files 

--- a/nyaml.mk
+++ b/nyaml.mk
@@ -1,0 +1,20 @@
+BASE_CLASS_DIR := base_classes
+CONTRIB_DIR := contributed_definitions
+APPDEF_DIR := applications
+NYAML_SUBDIR := nyaml
+NXDL_BC = $(addprefix $(BASE_CLASS_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.yaml,$(wildcard $(BASE_CLASS_DIR)/*.nxdl.xml))))
+NXDL_APPDEF = $(addprefix $(APPDEF_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.yaml,$(wildcard $(APPDEF_DIR)/*.nxdl.xml))))
+NXDL_CONTRIB = $(addprefix $(CONTRIB_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.yaml,$(wildcard $(CONTRIB_DIR)/*.nxdl.xml))))
+
+.PHONY: nyaml
+
+$(BASE_CLASS_DIR)/$(NYAML_SUBDIR)/%.yaml : $(BASE_CLASS_DIR)/%.nxdl.xml
+	nyaml2nxdl $< --output-file $@
+
+$(CONTRIB_DIR)/$(NYAML_SUBDIR)/%.yaml : $(CONTRIB_DIR)/%.nxdl.xml
+	nyaml2nxdl $< --output-file $@
+
+$(APPDEF_DIR)/$(NYAML_SUBDIR)/%.yaml : $(APPDEF_DIR)/%.nxdl.xml
+	nyaml2nxdl $< --output-file $@
+
+nyaml: $(NXDL_BC) $(NXDL_APPDEF) $(NXDL_CONTRIB)

--- a/nyaml.mk
+++ b/nyaml.mk
@@ -6,7 +6,7 @@ NXDL_BC = $(addprefix $(BASE_CLASS_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.
 NXDL_APPDEF = $(addprefix $(APPDEF_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.yaml,$(wildcard $(APPDEF_DIR)/*.nxdl.xml))))
 NXDL_CONTRIB = $(addprefix $(CONTRIB_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.yaml,$(wildcard $(CONTRIB_DIR)/*.nxdl.xml))))
 
-.PHONY: nyaml
+.PHONY: all nyaml
 
 $(BASE_CLASS_DIR)/$(NYAML_SUBDIR)/%.yaml : $(BASE_CLASS_DIR)/%.nxdl.xml
 	nyaml2nxdl $< --output-file $@
@@ -18,3 +18,5 @@ $(APPDEF_DIR)/$(NYAML_SUBDIR)/%.yaml : $(APPDEF_DIR)/%.nxdl.xml
 	nyaml2nxdl $< --output-file $@
 
 nyaml: $(NXDL_BC) $(NXDL_APPDEF) $(NXDL_CONTRIB)
+
+all: nyaml

--- a/nyaml.mk
+++ b/nyaml.mk
@@ -2,21 +2,24 @@ BASE_CLASS_DIR := base_classes
 CONTRIB_DIR := contributed_definitions
 APPDEF_DIR := applications
 NYAML_SUBDIR := nyaml
-NXDL_BC = $(addprefix $(BASE_CLASS_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.yaml,$(wildcard $(BASE_CLASS_DIR)/*.nxdl.xml))))
-NXDL_APPDEF = $(addprefix $(APPDEF_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.yaml,$(wildcard $(APPDEF_DIR)/*.nxdl.xml))))
-NXDL_CONTRIB = $(addprefix $(CONTRIB_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.yaml,$(wildcard $(CONTRIB_DIR)/*.nxdl.xml))))
+NXDL_BC_TARGETS = $(addprefix $(BASE_CLASS_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.yaml,$(wildcard $(BASE_CLASS_DIR)/*.nxdl.xml))))
+NXDL_APPDEF_TARGETS = $(addprefix $(APPDEF_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.yaml,$(wildcard $(APPDEF_DIR)/*.nxdl.xml))))
+NXDL_CONTRIB_TARGETS = $(addprefix $(CONTRIB_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.yaml,$(wildcard $(CONTRIB_DIR)/*.nxdl.xml))))
 
 .PHONY: all nyaml
 
 $(BASE_CLASS_DIR)/$(NYAML_SUBDIR)/%.yaml : $(BASE_CLASS_DIR)/%.nxdl.xml
-	nyaml2nxdl $< --output-file $@
+@mkdir -p $(@D)
+nyaml2nxdl $< --output-file $@
 
 $(CONTRIB_DIR)/$(NYAML_SUBDIR)/%.yaml : $(CONTRIB_DIR)/%.nxdl.xml
-	nyaml2nxdl $< --output-file $@
+@mkdir -p $(@D)
+nyaml2nxdl $< --output-file $@
 
 $(APPDEF_DIR)/$(NYAML_SUBDIR)/%.yaml : $(APPDEF_DIR)/%.nxdl.xml
-	nyaml2nxdl $< --output-file $@
+@mkdir -p $(@D)
+nyaml2nxdl $< --output-file $@
 
-nyaml: $(NXDL_BC) $(NXDL_APPDEF) $(NXDL_CONTRIB)
+nyaml: $(NXDL_BC_TARGETS) $(NXDL_APPDEF_TARGETS) $(NXDL_CONTRIB_TARGETS)
 
 all: nyaml


### PR DESCRIPTION
This adds several things:

- Proper build of `nxdl.xml` files even if they are not present. This is now completely based on the available yaml files
- Removal of `nyaml` for loop
- Add a new Makefile `nyaml.mk` for building nyaml targets to be invoked like this `make -f nyaml.mk`