### PR TITLE
Define usage of NXtransformations and NXcoordinate_system(_set)

### DIFF
--- a/base_classes/NXtransformations.nxdl.xml
+++ b/base_classes/NXtransformations.nxdl.xml
@@ -210,47 +210,47 @@
                vertical:NXdetector
                  depends_on=position/distance
                  position:NXtransformations
-                   distance=10           # move downstream from the sample
+                   distance=10         # move downstream from the sample
                      @depends_on=polar
                      @units=cm
                      @vector=[1 0 0]
-                   polar=5               # title above the horizontal plane
+                   polar=5             # title above the horizontal plane
                      @depends_on=azimuth
                      @units=degrees
                      @vector=[0 -1 0]
-                   azimuth=0           # stay in the vertical plane
+                   azimuth=0         # stay in the vertical plane
                      @depends_on=/entry/coordinate_system/beam
                      @units=degrees
                      @vector=[-1 0 0]
                horizontal:NXdetector
                  depends_on=position/distance
                  position:NXtransformations
-                   distance=11           # move downstream from the sample
+                   distance=11         # move downstream from the sample
                      @depends_on=polar
                      @units=cm
                      @vector=[1 0 0]
-                   polar=6               # title above the horizontal plane
+                   polar=6             # title above the horizontal plane
                      @depends_on=azimuth
                      @units=degrees
                      @vector=[0 -1 0]
-                   azimuth=90             # rotate to the horizontal plane
+                   azimuth=90           # rotate to the horizontal plane
                      @depends_on=/entry/coordinate_system/beam
                      @units=degrees
                      @vector=[-1 0 0]
                transmission:NXdetector
                  depends_on=position/distance
                  position:NXtransformations
-                   distance=20           # move downstream from the sample
+                   distance=20         # move downstream from the sample
                      @depends_on=/entry/coordinate_system/beam
                      @units=cm
                      @vector=[1 0 0]
              coordinate_system:NXtransformations
-               beam=NaN                 # value is never used
+               beam=NaN               # value is never used
                  @depends_on=gravity
-                 @vector=[1 0 0]       # X-axis points in the beam direction
-               gravity=NaN               # value is never used
-                 @depends_on=.           # end of the chain
-                 @vector=[0 0 -1]         # Z-axis points up
+                 @vector=[1 0 0]     # X-axis points in the beam direction
+               gravity=NaN             # value is never used
+                 @depends_on=.         # end of the chain
+                 @vector=[0 0 -1]       # Z-axis points up
     </doc>
     <field name="AXISNAME" type="NX_NUMBER" nameType="any" units="NX_TRANSFORMATION" maxOccurs="unbounded">
         <doc>

--- a/base_classes/NXtransformations.nxdl.xml
+++ b/base_classes/NXtransformations.nxdl.xml
@@ -324,8 +324,8 @@
 		</attribute>
 		<attribute name="depends_on" type="NX_CHAR">
 			<doc>
-				Points to the path to a field defining the axis on which this
-				depends or the string ".". It can also point to an instance of
+				Points to the path of a field defining the axis on which this instance of
+				NXtransformations depends or the string ".". It can also point to an instance of
 				``NX_coordinate_system`` if this transformation depends on it.
 			</doc>
 		</attribute>
@@ -357,7 +357,7 @@
 			the corresponding axis moves during the exposure of a frame.  Ideally, the
 			value of this field added to each value of ``AXISNAME`` would agree with the
 			corresponding values of ``AXISNAME_end``, but there is a possibility of significant
-			differences.  Use of ``AXISNAME_end`` is recommended.
+			differences. Use of ``AXISNAME_end`` is recommended.
 		</doc>
 	</field>
     <attribute name="default">

--- a/base_classes/NXtransformations.nxdl.xml
+++ b/base_classes/NXtransformations.nxdl.xml
@@ -325,7 +325,8 @@
 		<attribute name="depends_on" type="NX_CHAR">
 			<doc>
 				Points to the path to a field defining the axis on which this
-				depends or the string "." when at the end of the chain.
+				depends or the string ".". It can also point to an instance of
+				``NX_coordinate_system`` if this transformation depends on it.
 			</doc>
 		</attribute>
 		<attribute name="equipment_component" type="NX_CHAR">

--- a/base_classes/NXtransformations.nxdl.xml
+++ b/base_classes/NXtransformations.nxdl.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl" ?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format
-# 
-# Copyright (C) 2014-2022 NeXus International Advisory Committee (NIAC)
-# 
+#
+# Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+#
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -21,356 +21,344 @@
 #
 # For further information, see http://www.nexusformat.org
 -->
-<definition xmlns="http://definition.nexusformat.org/nxdl/3.1"
-	category="base"
-	name="NXtransformations"
-	type="group"
-	extends="NXobject"
-	ignoreExtraGroups="true"
-	ignoreExtraFields="true"
-	ignoreExtraAttributes="true"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
-	>
-
-	<doc>
-		Collection of axis-based translations and rotations to describe a geometry.
-		May also contain axes that do not move and therefore do not have a transformation
-		type specified, but are useful in understanding coordinate frames within which
-		transformations are done, or in documenting important directions, such as the
-		direction of gravity.
-
-		A nested sequence of transformations lists the translation and rotation steps
-		needed to describe the position and orientation of any movable or fixed device.
-
-		There will be one or more transformations (axes) defined by one or more fields
-		for each transformation. Transformations can also be described by NXlog groups when
-		the values change with time. The all-caps name ``AXISNAME`` designates the
-		particular axis generating a transformation (e.g. a rotation axis or a translation
-		axis or a general axis).   The attribute ``units="NX_TRANSFORMATION"`` designates the
-		units will be appropriate to the ``transformation_type`` attribute:
-
-		* ``NX_LENGTH`` for ``translation``
-		* ``NX_ANGLE`` for ``rotation``
-		* ``NX_UNITLESS`` for axes for which no transformation type is specified
-
-		This class will usually contain all axes of a sample stage or goniometer or
-		a detector. The NeXus default :ref:`McSTAS coordinate frame&lt;Design-CoordinateSystem&gt;`
-		is assumed, but additional useful coordinate axes may be defined by using axes for which
-		no transformation type has been specified.
-
-		**Transformation chain**
-
-		The entry point of a chain of transformations is a field called ``depends_on``
-		will be outside of this class and points to a field in here. Following the chain may
-		also require following ``depends_on`` links to transformations outside, for example
-		to a common base table.  If a relative path is given, it is relative to the group
-		enclosing the ``depends_on`` specification.
-
-		For a chain of three transformations, where :math:`T_1` depends on :math:`T_2`
-		which in turn depends on :math:`T_3`, the final *active* transformation
-		matrix :math:`T_f` is
-
-		.. math:: T_f = T_3 . T_2 . T_1
-
-		For example when positioning a flat detector, its pixel positions in the laboratory
-		reference frame (:ref:`McSTAS coordinate frame&lt;Design-CoordinateSystem&gt;` by default)
-		can be calculated by
-
-		.. math:: X_\text{lab} = T_f . X_\text{pixel} = T_3 . T_2 . T_1 . X_\text{pixel}
-
-		Note that :math:`T_1` comes first in the *depends-on* chain and is also applied first
-		to the pixel coordinates.
-
-		When we say transformation :math:`A` *depends on* transformation :math:`B` we mean that
-		the physical motor that realizes :math:`A` is *stacked on top of* the motor that realizes :math:`B`.
-		So the activate coordinate transformation :math:`A` needs to be applied to a coordinate
-		before applying :math:`B`. In other words :math:`X' = B . A . X`.
-
-		**Transformation matrix**
-
-		In explicit terms, the transformations are a subset of affine transformations expressed as
-		4x4 active transformation matrices that act on homogeneous coordinates, :math:`X=[x,y,z,1]^T`.
-
-		For rotation and translation,
-
-		.. math:: T_r &amp;= \begin{pmatrix} R &amp; o \\ 0_3 &amp; 1 \end{pmatrix} \\ T_t &amp;= \begin{pmatrix} I_3  &amp; t + o \\ 0_3 &amp; 1 \end{pmatrix}
-
-		where :math:`R` is the usual 3x3 rotation matrix, :math:`o` is an offset vector,
-		:math:`0_3` is a row of 3 zeros, :math:`I_3` is the 3x3 identity matrix and
-		:math:`t` is the translation vector.
-
-		:math:`o` is given by the ``offset`` attribute, :math:`t` is given by the ``vector``
-		attribute multiplied by the field value, and :math:`R` is defined as a rotation
-		about an axis in the direction of ``vector``, of angle of the field value.
-
-		**Usage**
-
-		One possible use of ``NXtransformations`` is to define the motors and
-		transformations for a diffractometer (goniometer).  Such use is mentioned
-		in the ``NXinstrument`` base class.  Use one ``NXtransformations`` group 
-		for each diffractometer and name the group appropriate to the device.
-		Collecting the motors of a sample table or xyz-stage in an NXtransformations
-		group is equally possible.
-
-		Following the section on the general description of axis in NXtransformations is a section which
-		documents the fields commonly used within NeXus for positioning purposes and their meaning. Whenever
-		there is a need for positioning a beam line component please use the existing names. Use as many fields
-		as needed in order to position the component. Feel free to add more axis if required. In the description
-		given below, only those atttributes which are defined through the name are spcified. Add the other attributes
-		of the full set:
-
-		* vector
-		* offset
-		* transformation_type
-		* depends_on
-
-		as needed.
-
-		**Example 1: goniometer**
-
-		Position a sample mounted on a goniometer in the :ref:`McSTAS coordinate frame&lt;Design-CoordinateSystem&gt;`.
-
-		The sample is oriented as follows
-
-		.. math:: X_\text{lab} = R(\vec{v}_\omega, \omega) . 
-								 T(\vec{v}_z, \text{sam}_z) . 
-								 T(\vec{v}_y, \text{sam}_y) . 
-								 T(\vec{v}_x, \text{sam}_x) . 
-								 R(\vec{v}_\chi, \chi) . 
-								 R(\vec{v}_\varphi, \varphi) . X_s
-
-		where
-
-		* :math:`R(\vec{v},a)` is a rotation around vector :math:`\vec{v}` with angle :math:`a`
-		* :math:`T(\vec{u},t)` is a translation along vector :math:`\vec{u}` over a distance :math:`t`
-		* :math:`X_s` a coordinate in the sample reference frame.
-
-		.. code-block::
-
-		  entry:NXentry
-		    sample:NXsample
-		      depends_on=transformations/phi
-		      transformations:NXtransformations
-		        phi=0
-		          @depends_on=chi
-		          @transformation_type=rotation
-		          @vector=[-1 -0.0037 -0.002]
-		          @units=degrees
-		        chi=0
-		          @depends_on=sam_x
-		          @transformation_type=rotation
-		          @vector=[0.0046 0.0372 0.9993]
-		          @units=degrees
-		        sam_x=0
-		          @depends_on=sam_y
-		          @transformation_type=translation
-		          @vector=[1 0 0]
-		          @units=mm
-		        sam_y=0
-		          @depends_on=sam_z
-		          @transformation_type=translation
-		          @vector=[0 1 0]
-		          @units=mm
-		        sam_z=0
-		          @depends_on=omega
-		          @transformation_type=translation
-		          @vector=[0 0 1]
-		          @units=mm
-		        omega=174
-		          @depends_on=.
-		          @transformation_type=rotation
-		          @vector=[-1 0 0]
-		          @units=degrees
-
-		**Example 2: different coordinate system**
-
-		Define a laboratory reference frame with the X-axis along the beam and the Z-axis opposite to the direction of gravity.
-		Three point detectors are positioned in this reference:
-
-		* *transmission*:
-			* point detector in the beam
-			* 20 cm downstream from the sample (the origin of the reference frame)
-		* *vertical*:
-			* point detector 10 cm downstream from the sample
-			* making an angle of 5 degrees with the beam w.r.t. the sample
-			* positioned in the XZ-plane above the XY-plane
-		* *horizontal*:
-			* point detector 11 cm downstream from the sample
-			* making an angle of 6 degrees with the beam w.r.t. the sample
-			* positioned in the XY-plane above the XZ-plane
-
-		The coordinates of the point detectors in the laboratory reference frame are
-
-		* *transmission*: :math:`X_\text{lab} = T_x(20) . X_d`
-		* *vertical*: :math:`X_\text{lab} = R_y(-5) . T_x(10) . X_d`
-		* *horizontal*: :math:`X_\text{lab} = R_x(-90) . R_y(-6) . T_x(11) . X_d`
-
-		where
-
-		* :math:`T_x`, :math:`T_y`, :math:`T_z`: active transformation matrices for translation along the X, Y and Z axes
-		* :math:`R_x`, :math:`R_y`, :math:`R_z`: active transformation matrices for rotation around the X, Y and Z axes
-		* :math:`X_d` is a coordinate in the detector reference frame.
-
-		Note that as these are point detectors, we only have one coordinate :math:`X_d=[0,0,0,1]^T`.
-
-		.. code-block::
-
-		  entry:NXentry
-		    instrument:NXinstrument
-		      vertical:NXdetector
-		        depends_on=position/distance
-		        position:NXtransformations
-		          distance=10            # move downstream from the sample
-		            @depends_on=polar
-		            @units=cm
-		            @vector=[1 0 0]
-		          polar=5                # title above the horizontal plane
-		            @depends_on=azimuth
-		            @units=degrees
-		            @vector=[0 -1 0]
-		          azimuth=0              # stay in the vertical plane
-		            @depends_on=/entry/coordinate_system/beam
-		            @units=degrees
-		            @vector=[-1 0 0]
-		      horizontal:NXdetector
-		        depends_on=position/distance
-		        position:NXtransformations
-		          distance=11            # move downstream from the sample
-		            @depends_on=polar
-		            @units=cm
-		            @vector=[1 0 0]
-		          polar=6                # title above the horizontal plane
-		            @depends_on=azimuth
-		            @units=degrees
-		            @vector=[0 -1 0]
-		          azimuth=90             # rotate to the horizontal plane
-		            @depends_on=/entry/coordinate_system/beam
-		            @units=degrees
-		            @vector=[-1 0 0]
-		      transmission:NXdetector
-		        depends_on=position/distance
-		        position:NXtransformations
-		          distance=20            # move downstream from the sample
-		            @depends_on=/entry/coordinate_system/beam
-		            @units=cm
-		            @vector=[1 0 0]
-		    coordinate_system:NXtransformations
-		      beam=NaN                   # value is never used
-		        @depends_on=gravity
-		        @vector=[1 0 0]          # X-axis points in the beam direction
-		      gravity=NaN                # value is never used
-		        @depends_on=.            # end of the chain
-		        @vector=[0 0 -1]         # Z-axis points up
-
-	</doc>
-	<field name="AXISNAME" nameType="any" units="NX_TRANSFORMATION" type="NX_NUMBER" maxOccurs="unbounded">
-		<doc>
-			Units need to be appropriate for translation or rotation
-
-			The name of this field is not forced.  The user is free to use any name
-			that does not cause confusion.  When using more than one ``AXISNAME`` field,
-			make sure that each field name is unique in the same group, as required
-			by HDF5.
-
-			The values given should be the start points of exposures for the corresponding
-			frames.  The end points should be given in ``AXISNAME_end``.
-		</doc>
-		<attribute name="transformation_type" optional="true">
-			<doc>
-				The transformation_type may be ``translation``, in which case the
-				values are linear displacements along the axis, ``rotation``,
-				in which case the values are angular rotations around the axis.
-
-				If this attribute is omitted, this is an axis for which there
-				is no motion to be specifies, such as the direction of gravity,
-				or the direction to the source, or a basis vector of a
-				coordinate frame.
-			</doc>
-			<enumeration>
-				<item value="translation" />
-				<item value="rotation" />
-				<!-- <item value="general" /> -->
-			</enumeration>
-		</attribute>
-		<attribute name="vector" optional="false" type="NX_NUMBER">
-			<doc>
-				Three values that define the axis for this transformation.
-				The axis should be normalized to unit length, making it
-				dimensionless.  For ``rotation`` axes, the direction should be
-				chosen for a right-handed rotation with increasing angle.
-				For ``translation`` axes the direction should be chosen for
-				increasing displacement. For general axes, an appropriate direction
-				should be chosen.
-			</doc>
-			<dimensions rank="1">
-				<dim index="1" value="3" />
-			</dimensions>
-		</attribute>
-		<attribute name="offset" type="NX_NUMBER">
-			<doc>
-				A fixed offset applied before the transformation (three vector components).
-				This is not intended to be a substitute for a fixed ``translation`` axis but, for example,
-				as the mechanical offset from mounting the axis to its dependency.
-			</doc>
-			<dimensions rank="1">
-				<dim index="1" value="3" />
-			</dimensions>
-		</attribute>
-		<attribute name="offset_units" type="NX_CHAR">
-			<doc>
-				Units of the offset.  Values should be consistent with NX_LENGTH.
-			</doc>
-		</attribute>
-		<attribute name="depends_on" type="NX_CHAR">
-			<doc>
-				Points to the path of a field defining the axis on which this instance of
-				NXtransformations depends or the string ".". It can also point to an instance of
-				``NX_coordinate_system`` if this transformation depends on it.
-			</doc>
-		</attribute>
-		<attribute name="equipment_component" type="NX_CHAR">
-			<doc>
-				An arbitrary identifier of a component of the equipment to which
-				the transformation belongs, such as 'detector_arm' or 'detector_module'.
-				NXtransformations with the same equipment_component label form a logical
-				grouping which can be combined together into a single change-of-basis
-				operation.
-			</doc>
-		</attribute>
-	</field>
-	<field name="AXISNAME_end" units="NX_TRANSFORMATION" nameType="any" type="NX_NUMBER" minOccurs="0">
-		<doc>
-			``AXISNAME_end`` is a placeholder for a name constructed from the actual
-			name of an axis to which ``_end`` has been appended.
-
-			The values in this field are the end points of the motions that start
-			at the corresponding positions given in the ``AXISNAME`` field.
-		</doc>
-	</field>
-	<field name="AXISNAME_increment_set" units="NX_TRANSFORMATION"  nameType="any" type="NX_NUMBER" minOccurs="0">
-		<doc>
-			``AXISNAME_increment_set`` is a placeholder for a name constructed from the actual
-			name of an axis to which ``_increment_set`` has been appended.
-
-			The value of this optional field is the intended average range through which
-			the corresponding axis moves during the exposure of a frame.  Ideally, the
-			value of this field added to each value of ``AXISNAME`` would agree with the
-			corresponding values of ``AXISNAME_end``, but there is a possibility of significant
-			differences. Use of ``AXISNAME_end`` is recommended.
-		</doc>
-	</field>
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" ignoreExtraGroups="true" ignoreExtraFields="true" ignoreExtraAttributes="true" name="NXtransformations" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+    <doc>
+         Collection of axis-based translations and rotations to describe a geometry.
+         May also contain axes that do not move and therefore do not have a transformation
+         type specified, but are useful in understanding coordinate frames within which
+         transformations are done, or in documenting important directions, such as the
+         direction of gravity.
+         
+         A nested sequence of transformations lists the translation and rotation steps
+         needed to describe the position and orientation of any movable or fixed device.
+         
+         There will be one or more transformations (axes) defined by one or more fields
+         for each transformation. Transformations can also be described by NXlog groups when
+         the values change with time. The all-caps name ``AXISNAME`` designates the
+         particular axis generating a transformation (e.g. a rotation axis or a translation
+         axis or a general axis).   The attribute ``units="NX_TRANSFORMATION"`` designates the
+         units will be appropriate to the ``transformation_type`` attribute:
+         
+         * ``NX_LENGTH`` for ``translation``
+         * ``NX_ANGLE`` for ``rotation``
+         * ``NX_UNITLESS`` for axes for which no transformation type is specified
+         
+         This class will usually contain all axes of a sample stage or goniometer or
+         a detector. The NeXus default :ref:`McSTAS coordinate frame&lt;Design-CoordinateSystem&gt;`
+         is assumed, but additional useful coordinate axes may be defined by using axes for which
+         no transformation type has been specified.
+         
+         **Transformation chain**
+         
+         The entry point of a chain of transformations is a field called ``depends_on``
+         will be outside of this class and points to a field in here. Following the chain may
+         also require following ``depends_on`` links to transformations outside, for example
+         to a common base table.  If a relative path is given, it is relative to the group
+         enclosing the ``depends_on`` specification.
+         
+         For a chain of three transformations, where :math:`T_1` depends on :math:`T_2`
+         which in turn depends on :math:`T_3`, the final *active* transformation
+         matrix :math:`T_f` is
+         
+         .. math:: T_f = T_3 . T_2 . T_1
+         
+         For example when positioning a flat detector, its pixel positions in the laboratory
+         reference frame (:ref:`McSTAS coordinate frame&lt;Design-CoordinateSystem&gt;` by default)
+         can be calculated by
+         
+         .. math:: X_\text{lab} = T_f . X_\text{pixel} = T_3 . T_2 . T_1 . X_\text{pixel}
+         
+         Note that :math:`T_1` comes first in the *depends-on* chain and is also applied first
+         to the pixel coordinates.
+         
+         When we say transformation :math:`A` *depends on* transformation :math:`B` we mean that
+         the physical motor that realizes :math:`A` is *stacked on top of* the motor that realizes :math:`B`.
+         So the activate coordinate transformation :math:`A` needs to be applied to a coordinate
+         before applying :math:`B`. In other words :math:`X' = B . A . X`.
+         
+         **Transformation matrix**
+         
+         In explicit terms, the transformations are a subset of affine transformations expressed as
+         4x4 active transformation matrices that act on homogeneous coordinates, :math:`X=[x,y,z,1]^T`.
+         
+         For rotation and translation,
+         
+         .. math:: T_r &amp;= \begin{pmatrix} R &amp; o \\ 0_3 &amp; 1 \end{pmatrix} \\ T_t &amp;= \begin{pmatrix} I_3  &amp; t + o \\ 0_3 &amp; 1 \end{pmatrix}
+         
+         where :math:`R` is the usual 3x3 rotation matrix, :math:`o` is an offset vector,
+         :math:`0_3` is a row of 3 zeros, :math:`I_3` is the 3x3 identity matrix and
+         :math:`t` is the translation vector.
+         
+         :math:`o` is given by the ``offset`` attribute, :math:`t` is given by the ``vector``
+         attribute multiplied by the field value, and :math:`R` is defined as a rotation
+         about an axis in the direction of ``vector``, of angle of the field value.
+         
+         **Usage**
+         
+         One possible use of ``NXtransformations`` is to define the motors and
+         transformations for a diffractometer (goniometer).  Such use is mentioned
+         in the ``NXinstrument`` base class.  Use one ``NXtransformations`` group
+         for each diffractometer and name the group appropriate to the device.
+         Collecting the motors of a sample table or xyz-stage in an NXtransformations
+         group is equally possible.
+         
+         Following the section on the general description of axis in NXtransformations is a section which
+         documents the fields commonly used within NeXus for positioning purposes and their meaning. Whenever
+         there is a need for positioning a beam line component please use the existing names. Use as many fields
+         as needed in order to position the component. Feel free to add more axis if required. In the description
+         given below, only those atttributes which are defined through the name are spcified. Add the other attributes
+         of the full set:
+         
+         * vector
+         * offset
+         * transformation_type
+         * depends_on
+         
+         as needed.
+         
+         **Example 1: goniometer**
+         
+         Position a sample mounted on a goniometer in the :ref:`McSTAS coordinate frame&lt;Design-CoordinateSystem&gt;`.
+         
+         The sample is oriented as follows
+         
+         .. math:: X_\text{lab} = R(\vec{v}_\omega, \omega) .
+                                  T(\vec{v}_z, \text{sam}_z) .
+                                  T(\vec{v}_y, \text{sam}_y) .
+                                  T(\vec{v}_x, \text{sam}_x) .
+                                  R(\vec{v}_\chi, \chi) .
+                                  R(\vec{v}_\varphi, \varphi) . X_s
+         
+         where
+         
+         * :math:`R(\vec{v},a)` is a rotation around vector :math:`\vec{v}` with angle :math:`a`
+         * :math:`T(\vec{u},t)` is a translation along vector :math:`\vec{u}` over a distance :math:`t`
+         * :math:`X_s` a coordinate in the sample reference frame.
+         
+         .. code-block::
+         
+           entry:NXentry
+             sample:NXsample
+               depends_on=transformations/phi
+               transformations:NXtransformations
+                 phi=0
+                   @depends_on=chi
+                   @transformation_type=rotation
+                   @vector=[-1 -0.0037 -0.002]
+                   @units=degrees
+                 chi=0
+                   @depends_on=sam_x
+                   @transformation_type=rotation
+                   @vector=[0.0046 0.0372 0.9993]
+                   @units=degrees
+                 sam_x=0
+                   @depends_on=sam_y
+                   @transformation_type=translation
+                   @vector=[1 0 0]
+                   @units=mm
+                 sam_y=0
+                   @depends_on=sam_z
+                   @transformation_type=translation
+                   @vector=[0 1 0]
+                   @units=mm
+                 sam_z=0
+                   @depends_on=omega
+                   @transformation_type=translation
+                   @vector=[0 0 1]
+                   @units=mm
+                 omega=174
+                   @depends_on=.
+                   @transformation_type=rotation
+                   @vector=[-1 0 0]
+                   @units=degrees
+         
+         **Example 2: different coordinate system**
+         
+         Define a laboratory reference frame with the X-axis along the beam and the Z-axis opposite to the direction of gravity.
+         Three point detectors are positioned in this reference:
+         
+         * *transmission*:
+             * point detector in the beam
+             * 20 cm downstream from the sample (the origin of the reference frame)
+         * *vertical*:
+             * point detector 10 cm downstream from the sample
+             * making an angle of 5 degrees with the beam w.r.t. the sample
+             * positioned in the XZ-plane above the XY-plane
+         * *horizontal*:
+             * point detector 11 cm downstream from the sample
+             * making an angle of 6 degrees with the beam w.r.t. the sample
+             * positioned in the XY-plane above the XZ-plane
+         
+         The coordinates of the point detectors in the laboratory reference frame are
+         
+         * *transmission*: :math:`X_\text{lab} = T_x(20) . X_d`
+         * *vertical*: :math:`X_\text{lab} = R_y(-5) . T_x(10) . X_d`
+         * *horizontal*: :math:`X_\text{lab} = R_x(-90) . R_y(-6) . T_x(11) . X_d`
+         
+         where
+         
+         * :math:`T_x`, :math:`T_y`, :math:`T_z`: active transformation matrices for translation along the X, Y and Z axes
+         * :math:`R_x`, :math:`R_y`, :math:`R_z`: active transformation matrices for rotation around the X, Y and Z axes
+         * :math:`X_d` is a coordinate in the detector reference frame.
+         
+         Note that as these are point detectors, we only have one coordinate :math:`X_d=[0,0,0,1]^T`.
+         
+         .. code-block::
+         
+           entry:NXentry
+             instrument:NXinstrument
+               vertical:NXdetector
+                 depends_on=position/distance
+                 position:NXtransformations
+                   distance=10           # move downstream from the sample
+                     @depends_on=polar
+                     @units=cm
+                     @vector=[1 0 0]
+                   polar=5               # title above the horizontal plane
+                     @depends_on=azimuth
+                     @units=degrees
+                     @vector=[0 -1 0]
+                   azimuth=0           # stay in the vertical plane
+                     @depends_on=/entry/coordinate_system/beam
+                     @units=degrees
+                     @vector=[-1 0 0]
+               horizontal:NXdetector
+                 depends_on=position/distance
+                 position:NXtransformations
+                   distance=11           # move downstream from the sample
+                     @depends_on=polar
+                     @units=cm
+                     @vector=[1 0 0]
+                   polar=6               # title above the horizontal plane
+                     @depends_on=azimuth
+                     @units=degrees
+                     @vector=[0 -1 0]
+                   azimuth=90             # rotate to the horizontal plane
+                     @depends_on=/entry/coordinate_system/beam
+                     @units=degrees
+                     @vector=[-1 0 0]
+               transmission:NXdetector
+                 depends_on=position/distance
+                 position:NXtransformations
+                   distance=20           # move downstream from the sample
+                     @depends_on=/entry/coordinate_system/beam
+                     @units=cm
+                     @vector=[1 0 0]
+             coordinate_system:NXtransformations
+               beam=NaN                 # value is never used
+                 @depends_on=gravity
+                 @vector=[1 0 0]       # X-axis points in the beam direction
+               gravity=NaN               # value is never used
+                 @depends_on=.           # end of the chain
+                 @vector=[0 0 -1]         # Z-axis points up
+    </doc>
+    <field name="AXISNAME" type="NX_NUMBER" nameType="any" units="NX_TRANSFORMATION" maxOccurs="unbounded">
+        <doc>
+             Units need to be appropriate for translation or rotation
+             
+             The name of this field is not forced.  The user is free to use any name
+             that does not cause confusion.  When using more than one ``AXISNAME`` field,
+             make sure that each field name is unique in the same group, as required
+             by HDF5.
+             
+             The values given should be the start points of exposures for the corresponding
+             frames.  The end points should be given in ``AXISNAME_end``.
+        </doc>
+        <attribute name="transformation_type" optional="true">
+            <doc>
+                 The transformation_type may be ``translation``, in which case the
+                 values are linear displacements along the axis, ``rotation``,
+                 in which case the values are angular rotations around the axis.
+                 
+                 If this attribute is omitted, this is an axis for which there
+                 is no motion to be specifies, such as the direction of gravity,
+                 or the direction to the source, or a basis vector of a
+                 coordinate frame.
+            </doc>
+            <!--<item value="general" />-->
+            <enumeration>
+                <item value="translation"/>
+                <item value="rotation"/>
+            </enumeration>
+        </attribute>
+        <attribute name="vector" optional="true" type="NX_NUMBER">
+            <doc>
+                 Three values that define the axis for this transformation.
+                 The axis should be normalized to unit length, making it
+                 dimensionless.  For ``rotation`` axes, the direction should be
+                 chosen for a right-handed rotation with increasing angle.
+                 For ``translation`` axes the direction should be chosen for
+                 increasing displacement. For general axes, an appropriate direction
+                 should be chosen.
+            </doc>
+            <dimensions rank="1">
+                <dim index="1" value="3"/>
+            </dimensions>
+        </attribute>
+        <attribute name="offset" type="NX_NUMBER">
+            <doc>
+                 A fixed offset applied before the transformation (three vector components).
+                 This is not intended to be a substitute for a fixed ``translation`` axis but, for example,
+                 as the mechanical offset from mounting the axis to its dependency.
+            </doc>
+            <dimensions rank="1">
+                <dim index="1" value="3"/>
+            </dimensions>
+        </attribute>
+        <attribute name="offset_units" type="NX_CHAR">
+            <doc>
+                 Units of the offset.  Values should be consistent with NX_LENGTH.
+            </doc>
+        </attribute>
+        <attribute name="depends_on" type="NX_CHAR">
+            <doc>
+                 Points to the path of a field defining the axis on which this instance of
+                 NXtransformations depends or the string ".". It can also point to an instance of
+                 ``NX_coordinate_system`` if this transformation depends on it.
+            </doc>
+        </attribute>
+        <attribute name="equipment_component" type="NX_CHAR">
+            <doc>
+                 An arbitrary identifier of a component of the equipment to which
+                 the transformation belongs, such as 'detector_arm' or 'detector_module'.
+                 NXtransformations with the same equipment_component label form a logical
+                 grouping which can be combined together into a single change-of-basis
+                 operation.
+            </doc>
+        </attribute>
+    </field>
+    <field name="AXISNAME_end" type="NX_NUMBER" units="NX_TRANSFORMATION" nameType="any" minOccurs="0">
+        <doc>
+             ``AXISNAME_end`` is a placeholder for a name constructed from the actual
+             name of an axis to which ``_end`` has been appended.
+             
+             The values in this field are the end points of the motions that start
+             at the corresponding positions given in the ``AXISNAME`` field.
+        </doc>
+    </field>
+    <field name="AXISNAME_increment_set" type="NX_NUMBER" units="NX_TRANSFORMATION" nameType="any" minOccurs="0">
+        <doc>
+             ``AXISNAME_increment_set`` is a placeholder for a name constructed from the actual
+             name of an axis to which ``_increment_set`` has been appended.
+             
+             The value of this optional field is the intended average range through which
+             the corresponding axis moves during the exposure of a frame.  Ideally, the
+             value of this field added to each value of ``AXISNAME`` would agree with the
+             corresponding values of ``AXISNAME_end``, but there is a possibility of significant
+             differences. Use of ``AXISNAME_end`` is recommended.
+        </doc>
+    </field>
     <attribute name="default">
         <doc>
-            .. index:: plotting
-            
-            Declares which child group contains a path leading 
-            to a :ref:`NXdata` group.
-            
-            It is recommended (as of NIAC2014) to use this attribute
-            to help define the path to the default dataset to be plotted.
-            See https://www.nexusformat.org/2014_How_to_find_default_data.html
-            for a summary of the discussion.
+             .. index:: plotting
+             
+             Declares which child group contains a path leading
+             to a :ref:`NXdata` group.
+             
+             It is recommended (as of NIAC2014) to use this attribute
+             to help define the path to the default dataset to be plotted.
+             See https://www.nexusformat.org/2014_How_to_find_default_data.html
+             for a summary of the discussion.
         </doc>
     </attribute>
 </definition>

--- a/base_classes/nyaml/NXtransformations.yaml
+++ b/base_classes/nyaml/NXtransformations.yaml
@@ -187,26 +187,26 @@ doc: |
         vertical:NXdetector
           depends_on=position/distance
           position:NXtransformations
-            distance=10            # move downstream from the sample
+            distance=10           # move downstream from the sample
               @depends_on=polar
               @units=cm
               @vector=[1 0 0]
-            polar=5                # title above the horizontal plane
+            polar=5               # title above the horizontal plane
               @depends_on=azimuth
               @units=degrees
               @vector=[0 -1 0]
-            azimuth=0              # stay in the vertical plane
+            azimuth=0           # stay in the vertical plane
               @depends_on=/entry/coordinate_system/beam
               @units=degrees
               @vector=[-1 0 0]
         horizontal:NXdetector
           depends_on=position/distance
           position:NXtransformations
-            distance=11            # move downstream from the sample
+            distance=11           # move downstream from the sample
               @depends_on=polar
               @units=cm
               @vector=[1 0 0]
-            polar=6                # title above the horizontal plane
+            polar=6               # title above the horizontal plane
               @depends_on=azimuth
               @units=degrees
               @vector=[0 -1 0]
@@ -217,16 +217,16 @@ doc: |
         transmission:NXdetector
           depends_on=position/distance
           position:NXtransformations
-            distance=20            # move downstream from the sample
+            distance=20           # move downstream from the sample
               @depends_on=/entry/coordinate_system/beam
               @units=cm
               @vector=[1 0 0]
       coordinate_system:NXtransformations
-        beam=NaN                   # value is never used
+        beam=NaN                 # value is never used
           @depends_on=gravity
-          @vector=[1 0 0]          # X-axis points in the beam direction
-        gravity=NaN                # value is never used
-          @depends_on=.            # end of the chain
+          @vector=[1 0 0]       # X-axis points in the beam direction
+        gravity=NaN               # value is never used
+          @depends_on=.           # end of the chain
           @vector=[0 0 -1]         # Z-axis points up
 type: group
 ignoreExtraGroups: true
@@ -338,14 +338,14 @@ NXtransformations(NXobject):
       for a summary of the discussion.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 5d52fcf7efc8ead93b3d310d183e880eee52434b88d148020efff95b32119d93
-# <?xml version="1.0" encoding="UTF-8"?>
-# <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl" ?>
+# 9fe265099bd7f15a00e1f244948ae17ceb523ee01b164cc947ac5f14e9f68917
+# <?xml version='1.0' encoding='UTF-8'?>
+# <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
 # # NeXus - Neutron and X-ray Common Data Format
-# # 
-# # Copyright (C) 2014-2022 NeXus International Advisory Committee (NIAC)
-# # 
+# #
+# # Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+# #
 # # This library is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU Lesser General Public
 # # License as published by the Free Software Foundation; either
@@ -362,356 +362,344 @@ NXtransformations(NXobject):
 # #
 # # For further information, see http://www.nexusformat.org
 # -->
-# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1"
-# 	category="base"
-# 	name="NXtransformations"
-# 	type="group"
-# 	extends="NXobject"
-# 	ignoreExtraGroups="true"
-# 	ignoreExtraFields="true"
-# 	ignoreExtraAttributes="true"
-# 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-# 	xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
-# 	>
-# 
-# 	<doc>
-# 		Collection of axis-based translations and rotations to describe a geometry.
-# 		May also contain axes that do not move and therefore do not have a transformation
-# 		type specified, but are useful in understanding coordinate frames within which
-# 		transformations are done, or in documenting important directions, such as the
-# 		direction of gravity.
-# 
-# 		A nested sequence of transformations lists the translation and rotation steps
-# 		needed to describe the position and orientation of any movable or fixed device.
-# 
-# 		There will be one or more transformations (axes) defined by one or more fields
-# 		for each transformation. Transformations can also be described by NXlog groups when
-# 		the values change with time. The all-caps name ``AXISNAME`` designates the
-# 		particular axis generating a transformation (e.g. a rotation axis or a translation
-# 		axis or a general axis).   The attribute ``units="NX_TRANSFORMATION"`` designates the
-# 		units will be appropriate to the ``transformation_type`` attribute:
-# 
-# 		* ``NX_LENGTH`` for ``translation``
-# 		* ``NX_ANGLE`` for ``rotation``
-# 		* ``NX_UNITLESS`` for axes for which no transformation type is specified
-# 
-# 		This class will usually contain all axes of a sample stage or goniometer or
-# 		a detector. The NeXus default :ref:`McSTAS coordinate frame&lt;Design-CoordinateSystem&gt;`
-# 		is assumed, but additional useful coordinate axes may be defined by using axes for which
-# 		no transformation type has been specified.
-# 
-# 		**Transformation chain**
-# 
-# 		The entry point of a chain of transformations is a field called ``depends_on``
-# 		will be outside of this class and points to a field in here. Following the chain may
-# 		also require following ``depends_on`` links to transformations outside, for example
-# 		to a common base table.  If a relative path is given, it is relative to the group
-# 		enclosing the ``depends_on`` specification.
-# 
-# 		For a chain of three transformations, where :math:`T_1` depends on :math:`T_2`
-# 		which in turn depends on :math:`T_3`, the final *active* transformation
-# 		matrix :math:`T_f` is
-# 
-# 		.. math:: T_f = T_3 . T_2 . T_1
-# 
-# 		For example when positioning a flat detector, its pixel positions in the laboratory
-# 		reference frame (:ref:`McSTAS coordinate frame&lt;Design-CoordinateSystem&gt;` by default)
-# 		can be calculated by
-# 
-# 		.. math:: X_\text{lab} = T_f . X_\text{pixel} = T_3 . T_2 . T_1 . X_\text{pixel}
-# 
-# 		Note that :math:`T_1` comes first in the *depends-on* chain and is also applied first
-# 		to the pixel coordinates.
-# 
-# 		When we say transformation :math:`A` *depends on* transformation :math:`B` we mean that
-# 		the physical motor that realizes :math:`A` is *stacked on top of* the motor that realizes :math:`B`.
-# 		So the activate coordinate transformation :math:`A` needs to be applied to a coordinate
-# 		before applying :math:`B`. In other words :math:`X' = B . A . X`.
-# 
-# 		**Transformation matrix**
-# 
-# 		In explicit terms, the transformations are a subset of affine transformations expressed as
-# 		4x4 active transformation matrices that act on homogeneous coordinates, :math:`X=[x,y,z,1]^T`.
-# 
-# 		For rotation and translation,
-# 
-# 		.. math:: T_r &amp;= \begin{pmatrix} R &amp; o \\ 0_3 &amp; 1 \end{pmatrix} \\ T_t &amp;= \begin{pmatrix} I_3  &amp; t + o \\ 0_3 &amp; 1 \end{pmatrix}
-# 
-# 		where :math:`R` is the usual 3x3 rotation matrix, :math:`o` is an offset vector,
-# 		:math:`0_3` is a row of 3 zeros, :math:`I_3` is the 3x3 identity matrix and
-# 		:math:`t` is the translation vector.
-# 
-# 		:math:`o` is given by the ``offset`` attribute, :math:`t` is given by the ``vector``
-# 		attribute multiplied by the field value, and :math:`R` is defined as a rotation
-# 		about an axis in the direction of ``vector``, of angle of the field value.
-# 
-# 		**Usage**
-# 
-# 		One possible use of ``NXtransformations`` is to define the motors and
-# 		transformations for a diffractometer (goniometer).  Such use is mentioned
-# 		in the ``NXinstrument`` base class.  Use one ``NXtransformations`` group 
-# 		for each diffractometer and name the group appropriate to the device.
-# 		Collecting the motors of a sample table or xyz-stage in an NXtransformations
-# 		group is equally possible.
-# 
-# 		Following the section on the general description of axis in NXtransformations is a section which
-# 		documents the fields commonly used within NeXus for positioning purposes and their meaning. Whenever
-# 		there is a need for positioning a beam line component please use the existing names. Use as many fields
-# 		as needed in order to position the component. Feel free to add more axis if required. In the description
-# 		given below, only those atttributes which are defined through the name are spcified. Add the other attributes
-# 		of the full set:
-# 
-# 		* vector
-# 		* offset
-# 		* transformation_type
-# 		* depends_on
-# 
-# 		as needed.
-# 
-# 		**Example 1: goniometer**
-# 
-# 		Position a sample mounted on a goniometer in the :ref:`McSTAS coordinate frame&lt;Design-CoordinateSystem&gt;`.
-# 
-# 		The sample is oriented as follows
-# 
-# 		.. math:: X_\text{lab} = R(\vec{v}_\omega, \omega) . 
-# 								 T(\vec{v}_z, \text{sam}_z) . 
-# 								 T(\vec{v}_y, \text{sam}_y) . 
-# 								 T(\vec{v}_x, \text{sam}_x) . 
-# 								 R(\vec{v}_\chi, \chi) . 
-# 								 R(\vec{v}_\varphi, \varphi) . X_s
-# 
-# 		where
-# 
-# 		* :math:`R(\vec{v},a)` is a rotation around vector :math:`\vec{v}` with angle :math:`a`
-# 		* :math:`T(\vec{u},t)` is a translation along vector :math:`\vec{u}` over a distance :math:`t`
-# 		* :math:`X_s` a coordinate in the sample reference frame.
-# 
-# 		.. code-block::
-# 
-# 		  entry:NXentry
-# 		    sample:NXsample
-# 		      depends_on=transformations/phi
-# 		      transformations:NXtransformations
-# 		        phi=0
-# 		          @depends_on=chi
-# 		          @transformation_type=rotation
-# 		          @vector=[-1 -0.0037 -0.002]
-# 		          @units=degrees
-# 		        chi=0
-# 		          @depends_on=sam_x
-# 		          @transformation_type=rotation
-# 		          @vector=[0.0046 0.0372 0.9993]
-# 		          @units=degrees
-# 		        sam_x=0
-# 		          @depends_on=sam_y
-# 		          @transformation_type=translation
-# 		          @vector=[1 0 0]
-# 		          @units=mm
-# 		        sam_y=0
-# 		          @depends_on=sam_z
-# 		          @transformation_type=translation
-# 		          @vector=[0 1 0]
-# 		          @units=mm
-# 		        sam_z=0
-# 		          @depends_on=omega
-# 		          @transformation_type=translation
-# 		          @vector=[0 0 1]
-# 		          @units=mm
-# 		        omega=174
-# 		          @depends_on=.
-# 		          @transformation_type=rotation
-# 		          @vector=[-1 0 0]
-# 		          @units=degrees
-# 
-# 		**Example 2: different coordinate system**
-# 
-# 		Define a laboratory reference frame with the X-axis along the beam and the Z-axis opposite to the direction of gravity.
-# 		Three point detectors are positioned in this reference:
-# 
-# 		* *transmission*:
-# 			* point detector in the beam
-# 			* 20 cm downstream from the sample (the origin of the reference frame)
-# 		* *vertical*:
-# 			* point detector 10 cm downstream from the sample
-# 			* making an angle of 5 degrees with the beam w.r.t. the sample
-# 			* positioned in the XZ-plane above the XY-plane
-# 		* *horizontal*:
-# 			* point detector 11 cm downstream from the sample
-# 			* making an angle of 6 degrees with the beam w.r.t. the sample
-# 			* positioned in the XY-plane above the XZ-plane
-# 
-# 		The coordinates of the point detectors in the laboratory reference frame are
-# 
-# 		* *transmission*: :math:`X_\text{lab} = T_x(20) . X_d`
-# 		* *vertical*: :math:`X_\text{lab} = R_y(-5) . T_x(10) . X_d`
-# 		* *horizontal*: :math:`X_\text{lab} = R_x(-90) . R_y(-6) . T_x(11) . X_d`
-# 
-# 		where
-# 
-# 		* :math:`T_x`, :math:`T_y`, :math:`T_z`: active transformation matrices for translation along the X, Y and Z axes
-# 		* :math:`R_x`, :math:`R_y`, :math:`R_z`: active transformation matrices for rotation around the X, Y and Z axes
-# 		* :math:`X_d` is a coordinate in the detector reference frame.
-# 
-# 		Note that as these are point detectors, we only have one coordinate :math:`X_d=[0,0,0,1]^T`.
-# 
-# 		.. code-block::
-# 
-# 		  entry:NXentry
-# 		    instrument:NXinstrument
-# 		      vertical:NXdetector
-# 		        depends_on=position/distance
-# 		        position:NXtransformations
-# 		          distance=10            # move downstream from the sample
-# 		            @depends_on=polar
-# 		            @units=cm
-# 		            @vector=[1 0 0]
-# 		          polar=5                # title above the horizontal plane
-# 		            @depends_on=azimuth
-# 		            @units=degrees
-# 		            @vector=[0 -1 0]
-# 		          azimuth=0              # stay in the vertical plane
-# 		            @depends_on=/entry/coordinate_system/beam
-# 		            @units=degrees
-# 		            @vector=[-1 0 0]
-# 		      horizontal:NXdetector
-# 		        depends_on=position/distance
-# 		        position:NXtransformations
-# 		          distance=11            # move downstream from the sample
-# 		            @depends_on=polar
-# 		            @units=cm
-# 		            @vector=[1 0 0]
-# 		          polar=6                # title above the horizontal plane
-# 		            @depends_on=azimuth
-# 		            @units=degrees
-# 		            @vector=[0 -1 0]
-# 		          azimuth=90             # rotate to the horizontal plane
-# 		            @depends_on=/entry/coordinate_system/beam
-# 		            @units=degrees
-# 		            @vector=[-1 0 0]
-# 		      transmission:NXdetector
-# 		        depends_on=position/distance
-# 		        position:NXtransformations
-# 		          distance=20            # move downstream from the sample
-# 		            @depends_on=/entry/coordinate_system/beam
-# 		            @units=cm
-# 		            @vector=[1 0 0]
-# 		    coordinate_system:NXtransformations
-# 		      beam=NaN                   # value is never used
-# 		        @depends_on=gravity
-# 		        @vector=[1 0 0]          # X-axis points in the beam direction
-# 		      gravity=NaN                # value is never used
-# 		        @depends_on=.            # end of the chain
-# 		        @vector=[0 0 -1]         # Z-axis points up
-# 
-# 	</doc>
-# 	<field name="AXISNAME" nameType="any" units="NX_TRANSFORMATION" type="NX_NUMBER" maxOccurs="unbounded">
-# 		<doc>
-# 			Units need to be appropriate for translation or rotation
-# 
-# 			The name of this field is not forced.  The user is free to use any name
-# 			that does not cause confusion.  When using more than one ``AXISNAME`` field,
-# 			make sure that each field name is unique in the same group, as required
-# 			by HDF5.
-# 
-# 			The values given should be the start points of exposures for the corresponding
-# 			frames.  The end points should be given in ``AXISNAME_end``.
-# 		</doc>
-# 		<attribute name="transformation_type" optional="true">
-# 			<doc>
-# 				The transformation_type may be ``translation``, in which case the
-# 				values are linear displacements along the axis, ``rotation``,
-# 				in which case the values are angular rotations around the axis.
-# 
-# 				If this attribute is omitted, this is an axis for which there
-# 				is no motion to be specifies, such as the direction of gravity,
-# 				or the direction to the source, or a basis vector of a
-# 				coordinate frame.
-# 			</doc>
-# 			<enumeration>
-# 				<item value="translation" />
-# 				<item value="rotation" />
-# 				<!-- <item value="general" /> -->
-# 			</enumeration>
-# 		</attribute>
-# 		<attribute name="vector" optional="false" type="NX_NUMBER">
-# 			<doc>
-# 				Three values that define the axis for this transformation.
-# 				The axis should be normalized to unit length, making it
-# 				dimensionless.  For ``rotation`` axes, the direction should be
-# 				chosen for a right-handed rotation with increasing angle.
-# 				For ``translation`` axes the direction should be chosen for
-# 				increasing displacement. For general axes, an appropriate direction
-# 				should be chosen.
-# 			</doc>
-# 			<dimensions rank="1">
-# 				<dim index="1" value="3" />
-# 			</dimensions>
-# 		</attribute>
-# 		<attribute name="offset" type="NX_NUMBER">
-# 			<doc>
-# 				A fixed offset applied before the transformation (three vector components).
-# 				This is not intended to be a substitute for a fixed ``translation`` axis but, for example,
-# 				as the mechanical offset from mounting the axis to its dependency.
-# 			</doc>
-# 			<dimensions rank="1">
-# 				<dim index="1" value="3" />
-# 			</dimensions>
-# 		</attribute>
-# 		<attribute name="offset_units" type="NX_CHAR">
-# 			<doc>
-# 				Units of the offset.  Values should be consistent with NX_LENGTH.
-# 			</doc>
-# 		</attribute>
-# 		<attribute name="depends_on" type="NX_CHAR">
-# 			<doc>
-# 				Points to the path of a field defining the axis on which this instance of
-# 				NXtransformations depends or the string ".". It can also point to an instance of
-# 				``NX_coordinate_system`` if this transformation depends on it.
-# 			</doc>
-# 		</attribute>
-# 		<attribute name="equipment_component" type="NX_CHAR">
-# 			<doc>
-# 				An arbitrary identifier of a component of the equipment to which
-# 				the transformation belongs, such as 'detector_arm' or 'detector_module'.
-# 				NXtransformations with the same equipment_component label form a logical
-# 				grouping which can be combined together into a single change-of-basis
-# 				operation.
-# 			</doc>
-# 		</attribute>
-# 	</field>
-# 	<field name="AXISNAME_end" units="NX_TRANSFORMATION" nameType="any" type="NX_NUMBER" minOccurs="0">
-# 		<doc>
-# 			``AXISNAME_end`` is a placeholder for a name constructed from the actual
-# 			name of an axis to which ``_end`` has been appended.
-# 
-# 			The values in this field are the end points of the motions that start
-# 			at the corresponding positions given in the ``AXISNAME`` field.
-# 		</doc>
-# 	</field>
-# 	<field name="AXISNAME_increment_set" units="NX_TRANSFORMATION"  nameType="any" type="NX_NUMBER" minOccurs="0">
-# 		<doc>
-# 			``AXISNAME_increment_set`` is a placeholder for a name constructed from the actual
-# 			name of an axis to which ``_increment_set`` has been appended.
-# 
-# 			The value of this optional field is the intended average range through which
-# 			the corresponding axis moves during the exposure of a frame.  Ideally, the
-# 			value of this field added to each value of ``AXISNAME`` would agree with the
-# 			corresponding values of ``AXISNAME_end``, but there is a possibility of significant
-# 			differences. Use of ``AXISNAME_end`` is recommended.
-# 		</doc>
-# 	</field>
+# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" ignoreExtraGroups="true" ignoreExtraFields="true" ignoreExtraAttributes="true" name="NXtransformations" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+#     <doc>
+#          Collection of axis-based translations and rotations to describe a geometry.
+#          May also contain axes that do not move and therefore do not have a transformation
+#          type specified, but are useful in understanding coordinate frames within which
+#          transformations are done, or in documenting important directions, such as the
+#          direction of gravity.
+#          
+#          A nested sequence of transformations lists the translation and rotation steps
+#          needed to describe the position and orientation of any movable or fixed device.
+#          
+#          There will be one or more transformations (axes) defined by one or more fields
+#          for each transformation. Transformations can also be described by NXlog groups when
+#          the values change with time. The all-caps name ``AXISNAME`` designates the
+#          particular axis generating a transformation (e.g. a rotation axis or a translation
+#          axis or a general axis).   The attribute ``units="NX_TRANSFORMATION"`` designates the
+#          units will be appropriate to the ``transformation_type`` attribute:
+#          
+#          * ``NX_LENGTH`` for ``translation``
+#          * ``NX_ANGLE`` for ``rotation``
+#          * ``NX_UNITLESS`` for axes for which no transformation type is specified
+#          
+#          This class will usually contain all axes of a sample stage or goniometer or
+#          a detector. The NeXus default :ref:`McSTAS coordinate frame&lt;Design-CoordinateSystem&gt;`
+#          is assumed, but additional useful coordinate axes may be defined by using axes for which
+#          no transformation type has been specified.
+#          
+#          **Transformation chain**
+#          
+#          The entry point of a chain of transformations is a field called ``depends_on``
+#          will be outside of this class and points to a field in here. Following the chain may
+#          also require following ``depends_on`` links to transformations outside, for example
+#          to a common base table.  If a relative path is given, it is relative to the group
+#          enclosing the ``depends_on`` specification.
+#          
+#          For a chain of three transformations, where :math:`T_1` depends on :math:`T_2`
+#          which in turn depends on :math:`T_3`, the final *active* transformation
+#          matrix :math:`T_f` is
+#          
+#          .. math:: T_f = T_3 . T_2 . T_1
+#          
+#          For example when positioning a flat detector, its pixel positions in the laboratory
+#          reference frame (:ref:`McSTAS coordinate frame&lt;Design-CoordinateSystem&gt;` by default)
+#          can be calculated by
+#          
+#          .. math:: X_\text{lab} = T_f . X_\text{pixel} = T_3 . T_2 . T_1 . X_\text{pixel}
+#          
+#          Note that :math:`T_1` comes first in the *depends-on* chain and is also applied first
+#          to the pixel coordinates.
+#          
+#          When we say transformation :math:`A` *depends on* transformation :math:`B` we mean that
+#          the physical motor that realizes :math:`A` is *stacked on top of* the motor that realizes :math:`B`.
+#          So the activate coordinate transformation :math:`A` needs to be applied to a coordinate
+#          before applying :math:`B`. In other words :math:`X' = B . A . X`.
+#          
+#          **Transformation matrix**
+#          
+#          In explicit terms, the transformations are a subset of affine transformations expressed as
+#          4x4 active transformation matrices that act on homogeneous coordinates, :math:`X=[x,y,z,1]^T`.
+#          
+#          For rotation and translation,
+#          
+#          .. math:: T_r &amp;= \begin{pmatrix} R &amp; o \\ 0_3 &amp; 1 \end{pmatrix} \\ T_t &amp;= \begin{pmatrix} I_3  &amp; t + o \\ 0_3 &amp; 1 \end{pmatrix}
+#          
+#          where :math:`R` is the usual 3x3 rotation matrix, :math:`o` is an offset vector,
+#          :math:`0_3` is a row of 3 zeros, :math:`I_3` is the 3x3 identity matrix and
+#          :math:`t` is the translation vector.
+#          
+#          :math:`o` is given by the ``offset`` attribute, :math:`t` is given by the ``vector``
+#          attribute multiplied by the field value, and :math:`R` is defined as a rotation
+#          about an axis in the direction of ``vector``, of angle of the field value.
+#          
+#          **Usage**
+#          
+#          One possible use of ``NXtransformations`` is to define the motors and
+#          transformations for a diffractometer (goniometer).  Such use is mentioned
+#          in the ``NXinstrument`` base class.  Use one ``NXtransformations`` group
+#          for each diffractometer and name the group appropriate to the device.
+#          Collecting the motors of a sample table or xyz-stage in an NXtransformations
+#          group is equally possible.
+#          
+#          Following the section on the general description of axis in NXtransformations is a section which
+#          documents the fields commonly used within NeXus for positioning purposes and their meaning. Whenever
+#          there is a need for positioning a beam line component please use the existing names. Use as many fields
+#          as needed in order to position the component. Feel free to add more axis if required. In the description
+#          given below, only those atttributes which are defined through the name are spcified. Add the other attributes
+#          of the full set:
+#          
+#          * vector
+#          * offset
+#          * transformation_type
+#          * depends_on
+#          
+#          as needed.
+#          
+#          **Example 1: goniometer**
+#          
+#          Position a sample mounted on a goniometer in the :ref:`McSTAS coordinate frame&lt;Design-CoordinateSystem&gt;`.
+#          
+#          The sample is oriented as follows
+#          
+#          .. math:: X_\text{lab} = R(\vec{v}_\omega, \omega) .
+#                                   T(\vec{v}_z, \text{sam}_z) .
+#                                   T(\vec{v}_y, \text{sam}_y) .
+#                                   T(\vec{v}_x, \text{sam}_x) .
+#                                   R(\vec{v}_\chi, \chi) .
+#                                   R(\vec{v}_\varphi, \varphi) . X_s
+#          
+#          where
+#          
+#          * :math:`R(\vec{v},a)` is a rotation around vector :math:`\vec{v}` with angle :math:`a`
+#          * :math:`T(\vec{u},t)` is a translation along vector :math:`\vec{u}` over a distance :math:`t`
+#          * :math:`X_s` a coordinate in the sample reference frame.
+#          
+#          .. code-block::
+#          
+#            entry:NXentry
+#              sample:NXsample
+#                depends_on=transformations/phi
+#                transformations:NXtransformations
+#                  phi=0
+#                    @depends_on=chi
+#                    @transformation_type=rotation
+#                    @vector=[-1 -0.0037 -0.002]
+#                    @units=degrees
+#                  chi=0
+#                    @depends_on=sam_x
+#                    @transformation_type=rotation
+#                    @vector=[0.0046 0.0372 0.9993]
+#                    @units=degrees
+#                  sam_x=0
+#                    @depends_on=sam_y
+#                    @transformation_type=translation
+#                    @vector=[1 0 0]
+#                    @units=mm
+#                  sam_y=0
+#                    @depends_on=sam_z
+#                    @transformation_type=translation
+#                    @vector=[0 1 0]
+#                    @units=mm
+#                  sam_z=0
+#                    @depends_on=omega
+#                    @transformation_type=translation
+#                    @vector=[0 0 1]
+#                    @units=mm
+#                  omega=174
+#                    @depends_on=.
+#                    @transformation_type=rotation
+#                    @vector=[-1 0 0]
+#                    @units=degrees
+#          
+#          **Example 2: different coordinate system**
+#          
+#          Define a laboratory reference frame with the X-axis along the beam and the Z-axis opposite to the direction of gravity.
+#          Three point detectors are positioned in this reference:
+#          
+#          * *transmission*:
+#              * point detector in the beam
+#              * 20 cm downstream from the sample (the origin of the reference frame)
+#          * *vertical*:
+#              * point detector 10 cm downstream from the sample
+#              * making an angle of 5 degrees with the beam w.r.t. the sample
+#              * positioned in the XZ-plane above the XY-plane
+#          * *horizontal*:
+#              * point detector 11 cm downstream from the sample
+#              * making an angle of 6 degrees with the beam w.r.t. the sample
+#              * positioned in the XY-plane above the XZ-plane
+#          
+#          The coordinates of the point detectors in the laboratory reference frame are
+#          
+#          * *transmission*: :math:`X_\text{lab} = T_x(20) . X_d`
+#          * *vertical*: :math:`X_\text{lab} = R_y(-5) . T_x(10) . X_d`
+#          * *horizontal*: :math:`X_\text{lab} = R_x(-90) . R_y(-6) . T_x(11) . X_d`
+#          
+#          where
+#          
+#          * :math:`T_x`, :math:`T_y`, :math:`T_z`: active transformation matrices for translation along the X, Y and Z axes
+#          * :math:`R_x`, :math:`R_y`, :math:`R_z`: active transformation matrices for rotation around the X, Y and Z axes
+#          * :math:`X_d` is a coordinate in the detector reference frame.
+#          
+#          Note that as these are point detectors, we only have one coordinate :math:`X_d=[0,0,0,1]^T`.
+#          
+#          .. code-block::
+#          
+#            entry:NXentry
+#              instrument:NXinstrument
+#                vertical:NXdetector
+#                  depends_on=position/distance
+#                  position:NXtransformations
+#                    distance=10           # move downstream from the sample
+#                      @depends_on=polar
+#                      @units=cm
+#                      @vector=[1 0 0]
+#                    polar=5               # title above the horizontal plane
+#                      @depends_on=azimuth
+#                      @units=degrees
+#                      @vector=[0 -1 0]
+#                    azimuth=0           # stay in the vertical plane
+#                      @depends_on=/entry/coordinate_system/beam
+#                      @units=degrees
+#                      @vector=[-1 0 0]
+#                horizontal:NXdetector
+#                  depends_on=position/distance
+#                  position:NXtransformations
+#                    distance=11           # move downstream from the sample
+#                      @depends_on=polar
+#                      @units=cm
+#                      @vector=[1 0 0]
+#                    polar=6               # title above the horizontal plane
+#                      @depends_on=azimuth
+#                      @units=degrees
+#                      @vector=[0 -1 0]
+#                    azimuth=90             # rotate to the horizontal plane
+#                      @depends_on=/entry/coordinate_system/beam
+#                      @units=degrees
+#                      @vector=[-1 0 0]
+#                transmission:NXdetector
+#                  depends_on=position/distance
+#                  position:NXtransformations
+#                    distance=20           # move downstream from the sample
+#                      @depends_on=/entry/coordinate_system/beam
+#                      @units=cm
+#                      @vector=[1 0 0]
+#              coordinate_system:NXtransformations
+#                beam=NaN                 # value is never used
+#                  @depends_on=gravity
+#                  @vector=[1 0 0]       # X-axis points in the beam direction
+#                gravity=NaN               # value is never used
+#                  @depends_on=.           # end of the chain
+#                  @vector=[0 0 -1]         # Z-axis points up
+#     </doc>
+#     <field name="AXISNAME" type="NX_NUMBER" nameType="any" units="NX_TRANSFORMATION" maxOccurs="unbounded">
+#         <doc>
+#              Units need to be appropriate for translation or rotation
+#              
+#              The name of this field is not forced.  The user is free to use any name
+#              that does not cause confusion.  When using more than one ``AXISNAME`` field,
+#              make sure that each field name is unique in the same group, as required
+#              by HDF5.
+#              
+#              The values given should be the start points of exposures for the corresponding
+#              frames.  The end points should be given in ``AXISNAME_end``.
+#         </doc>
+#         <attribute name="transformation_type" optional="true">
+#             <doc>
+#                  The transformation_type may be ``translation``, in which case the
+#                  values are linear displacements along the axis, ``rotation``,
+#                  in which case the values are angular rotations around the axis.
+#                  
+#                  If this attribute is omitted, this is an axis for which there
+#                  is no motion to be specifies, such as the direction of gravity,
+#                  or the direction to the source, or a basis vector of a
+#                  coordinate frame.
+#             </doc>
+#             <!--<item value="general" />-->
+#             <enumeration>
+#                 <item value="translation"/>
+#                 <item value="rotation"/>
+#             </enumeration>
+#         </attribute>
+#         <attribute name="vector" optional="true" type="NX_NUMBER">
+#             <doc>
+#                  Three values that define the axis for this transformation.
+#                  The axis should be normalized to unit length, making it
+#                  dimensionless.  For ``rotation`` axes, the direction should be
+#                  chosen for a right-handed rotation with increasing angle.
+#                  For ``translation`` axes the direction should be chosen for
+#                  increasing displacement. For general axes, an appropriate direction
+#                  should be chosen.
+#             </doc>
+#             <dimensions rank="1">
+#                 <dim index="1" value="3"/>
+#             </dimensions>
+#         </attribute>
+#         <attribute name="offset" type="NX_NUMBER">
+#             <doc>
+#                  A fixed offset applied before the transformation (three vector components).
+#                  This is not intended to be a substitute for a fixed ``translation`` axis but, for example,
+#                  as the mechanical offset from mounting the axis to its dependency.
+#             </doc>
+#             <dimensions rank="1">
+#                 <dim index="1" value="3"/>
+#             </dimensions>
+#         </attribute>
+#         <attribute name="offset_units" type="NX_CHAR">
+#             <doc>
+#                  Units of the offset.  Values should be consistent with NX_LENGTH.
+#             </doc>
+#         </attribute>
+#         <attribute name="depends_on" type="NX_CHAR">
+#             <doc>
+#                  Points to the path of a field defining the axis on which this instance of
+#                  NXtransformations depends or the string ".". It can also point to an instance of
+#                  ``NX_coordinate_system`` if this transformation depends on it.
+#             </doc>
+#         </attribute>
+#         <attribute name="equipment_component" type="NX_CHAR">
+#             <doc>
+#                  An arbitrary identifier of a component of the equipment to which
+#                  the transformation belongs, such as 'detector_arm' or 'detector_module'.
+#                  NXtransformations with the same equipment_component label form a logical
+#                  grouping which can be combined together into a single change-of-basis
+#                  operation.
+#             </doc>
+#         </attribute>
+#     </field>
+#     <field name="AXISNAME_end" type="NX_NUMBER" units="NX_TRANSFORMATION" nameType="any" minOccurs="0">
+#         <doc>
+#              ``AXISNAME_end`` is a placeholder for a name constructed from the actual
+#              name of an axis to which ``_end`` has been appended.
+#              
+#              The values in this field are the end points of the motions that start
+#              at the corresponding positions given in the ``AXISNAME`` field.
+#         </doc>
+#     </field>
+#     <field name="AXISNAME_increment_set" type="NX_NUMBER" units="NX_TRANSFORMATION" nameType="any" minOccurs="0">
+#         <doc>
+#              ``AXISNAME_increment_set`` is a placeholder for a name constructed from the actual
+#              name of an axis to which ``_increment_set`` has been appended.
+#              
+#              The value of this optional field is the intended average range through which
+#              the corresponding axis moves during the exposure of a frame.  Ideally, the
+#              value of this field added to each value of ``AXISNAME`` would agree with the
+#              corresponding values of ``AXISNAME_end``, but there is a possibility of significant
+#              differences. Use of ``AXISNAME_end`` is recommended.
+#         </doc>
+#     </field>
 #     <attribute name="default">
 #         <doc>
-#             .. index:: plotting
-#             
-#             Declares which child group contains a path leading 
-#             to a :ref:`NXdata` group.
-#             
-#             It is recommended (as of NIAC2014) to use this attribute
-#             to help define the path to the default dataset to be plotted.
-#             See https://www.nexusformat.org/2014_How_to_find_default_data.html
-#             for a summary of the discussion.
+#              .. index:: plotting
+#              
+#              Declares which child group contains a path leading
+#              to a :ref:`NXdata` group.
+#              
+#              It is recommended (as of NIAC2014) to use this attribute
+#              to help define the path to the default dataset to be plotted.
+#              See https://www.nexusformat.org/2014_How_to_find_default_data.html
+#              for a summary of the discussion.
 #         </doc>
 #     </attribute>
 # </definition>

--- a/base_classes/nyaml/NXtransformations.yaml
+++ b/base_classes/nyaml/NXtransformations.yaml
@@ -292,7 +292,8 @@ NXtransformations(NXobject):
       type: NX_CHAR
       doc: |
         Points to the path to a field defining the axis on which this
-        depends or the string "." when at the end of the chain.
+        depends or the string ".". It can also point to an instance of
+        ``NX_coordinate_system`` if this transformation depends on it.
     \@equipment_component:
       type: NX_CHAR
       doc: |

--- a/base_classes/nyaml/NXtransformations.yaml
+++ b/base_classes/nyaml/NXtransformations.yaml
@@ -338,7 +338,7 @@ NXtransformations(NXobject):
       for a summary of the discussion.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 6a1dc796e67a81292ff555a4e73fd6d2e67769d83ddb0686e193f8f7b1ccfef0
+# 5d52fcf7efc8ead93b3d310d183e880eee52434b88d148020efff95b32119d93
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl" ?>
 # <!--
@@ -665,8 +665,9 @@ NXtransformations(NXobject):
 # 		</attribute>
 # 		<attribute name="depends_on" type="NX_CHAR">
 # 			<doc>
-# 				Points to the path to a field defining the axis on which this
-# 				depends or the string "." when at the end of the chain.
+# 				Points to the path of a field defining the axis on which this instance of
+# 				NXtransformations depends or the string ".". It can also point to an instance of
+# 				``NX_coordinate_system`` if this transformation depends on it.
 # 			</doc>
 # 		</attribute>
 # 		<attribute name="equipment_component" type="NX_CHAR">
@@ -697,7 +698,7 @@ NXtransformations(NXobject):
 # 			the corresponding axis moves during the exposure of a frame.  Ideally, the
 # 			value of this field added to each value of ``AXISNAME`` would agree with the
 # 			corresponding values of ``AXISNAME_end``, but there is a possibility of significant
-# 			differences.  Use of ``AXISNAME_end`` is recommended.
+# 			differences. Use of ``AXISNAME_end`` is recommended.
 # 		</doc>
 # 	</field>
 #     <attribute name="default">

--- a/base_classes/nyaml/NXtransformations.yaml
+++ b/base_classes/nyaml/NXtransformations.yaml
@@ -187,47 +187,47 @@ doc: |
         vertical:NXdetector
           depends_on=position/distance
           position:NXtransformations
-            distance=10           # move downstream from the sample
+            distance=10          # move downstream from the sample
               @depends_on=polar
               @units=cm
               @vector=[1 0 0]
-            polar=5               # title above the horizontal plane
+            polar=5              # title above the horizontal plane
               @depends_on=azimuth
               @units=degrees
               @vector=[0 -1 0]
-            azimuth=0           # stay in the vertical plane
+            azimuth=0            # stay in the vertical plane
               @depends_on=/entry/coordinate_system/beam
               @units=degrees
               @vector=[-1 0 0]
         horizontal:NXdetector
           depends_on=position/distance
           position:NXtransformations
-            distance=11           # move downstream from the sample
+            distance=11          # move downstream from the sample
               @depends_on=polar
               @units=cm
               @vector=[1 0 0]
-            polar=6               # title above the horizontal plane
+            polar=6              # title above the horizontal plane
               @depends_on=azimuth
               @units=degrees
               @vector=[0 -1 0]
-            azimuth=90             # rotate to the horizontal plane
+            azimuth=90           # rotate to the horizontal plane
               @depends_on=/entry/coordinate_system/beam
               @units=degrees
               @vector=[-1 0 0]
         transmission:NXdetector
           depends_on=position/distance
           position:NXtransformations
-            distance=20           # move downstream from the sample
+            distance=20          # move downstream from the sample
               @depends_on=/entry/coordinate_system/beam
               @units=cm
               @vector=[1 0 0]
       coordinate_system:NXtransformations
         beam=NaN                 # value is never used
           @depends_on=gravity
-          @vector=[1 0 0]       # X-axis points in the beam direction
-        gravity=NaN               # value is never used
-          @depends_on=.           # end of the chain
-          @vector=[0 0 -1]         # Z-axis points up
+          @vector=[1 0 0]        # X-axis points in the beam direction
+        gravity=NaN              # value is never used
+          @depends_on=.          # end of the chain
+          @vector=[0 0 -1]       # Z-axis points up
 type: group
 ignoreExtraGroups: true
 ignoreExtraFields: true

--- a/base_classes/nyaml/NXtransformations.yaml
+++ b/base_classes/nyaml/NXtransformations.yaml
@@ -291,8 +291,8 @@ NXtransformations(NXobject):
     \@depends_on:
       type: NX_CHAR
       doc: |
-        Points to the path to a field defining the axis on which this
-        depends or the string ".". It can also point to an instance of
+        Points to the path of a field defining the axis on which this instance of
+        NXtransformations depends or the string ".". It can also point to an instance of
         ``NX_coordinate_system`` if this transformation depends on it.
     \@equipment_component:
       type: NX_CHAR
@@ -324,7 +324,7 @@ NXtransformations(NXobject):
       the corresponding axis moves during the exposure of a frame.  Ideally, the
       value of this field added to each value of ``AXISNAME`` would agree with the
       corresponding values of ``AXISNAME_end``, but there is a possibility of significant
-      differences.  Use of ``AXISNAME_end`` is recommended.
+      differences. Use of ``AXISNAME_end`` is recommended.
   \@default:
     doc: |
       .. index:: plotting

--- a/contributed_definitions/NXcoordinate_system.nxdl.xml
+++ b/contributed_definitions/NXcoordinate_system.nxdl.xml
@@ -142,7 +142,7 @@ https://www.zenodo.org/record/3526738/files/lyso009a_0087.JF07T32V01_master.h5?d
     </field>
     <field name="depends_on" type="NX_CHAR">
         <doc>
-             This specificies the relation to another coordinate system by pointing to the last 
+             This specificies the relation to another coordinate system by pointing to the last
              transformation in the transformation chain in the NXtransformations group.
         </doc>
     </field>

--- a/contributed_definitions/NXcoordinate_system.nxdl.xml
+++ b/contributed_definitions/NXcoordinate_system.nxdl.xml
@@ -140,17 +140,16 @@ https://www.zenodo.org/record/3526738/files/lyso009a_0087.JF07T32V01_master.h5?d
             <dim index="1" value="3"/>
         </dimensions>
     </field>
-    <field name="offset" type="NX_NUMBER">
+    <field name="depends_on" type="NX_CHAR">
         <doc>
-             Translational shift during a passive transformation from the coordinate system
-             defined in the the `depends_on` attribute.
+             This specificies the relation to another coordinate system by pointing to the last 
+             transformation in the transformation chain in the NXtransformations group.
         </doc>
     </field>
-    <attribute name="depends_on" type="NX_CHAR">
+    <group type="NXtransformations">
         <doc>
-             This defines which coordinate system the base transformation defined by the 
-             `x`, `y`, and `z` fields refers to. 
-             By default, it is (.) and points to the McStas coordinate system.
+             Collection of axis-based translations and rotations to describe this coordinate system
+             with respect to another coordinate system.
         </doc>
-    </attribute>
+    </group>
 </definition>

--- a/contributed_definitions/NXcoordinate_system.nxdl.xml
+++ b/contributed_definitions/NXcoordinate_system.nxdl.xml
@@ -140,4 +140,11 @@ https://www.zenodo.org/record/3526738/files/lyso009a_0087.JF07T32V01_master.h5?d
             <dim index="1" value="3"/>
         </dimensions>
     </field>
+    <field name="depends_on" type="NX_CHAR"/>
+    <group type="NXtransformations">
+        <doc>
+             Collection of axis-based translations and rotations to describe this coordinate system
+             with respect to another coordinate system.
+        </doc>
+    </group>
 </definition>

--- a/contributed_definitions/NXcoordinate_system.nxdl.xml
+++ b/contributed_definitions/NXcoordinate_system.nxdl.xml
@@ -132,7 +132,7 @@ https://www.zenodo.org/record/3526738/files/lyso009a_0087.JF07T32V01_master.h5?d
     </field>
     <field name="z" type="NX_NUMBER" units="NX_LENGTH">
         <doc>
-             Base unit vector along the second axis which spans the coordinate system.
+             Base unit vector along the third axis which spans the coordinate system.
              This axis is frequently referred to as the z-axis in real space and
              the k-axis in reciprocal space.
         </doc>
@@ -140,11 +140,17 @@ https://www.zenodo.org/record/3526738/files/lyso009a_0087.JF07T32V01_master.h5?d
             <dim index="1" value="3"/>
         </dimensions>
     </field>
-    <field name="depends_on" type="NX_CHAR"/>
-    <group type="NXtransformations">
+    <field name="offset" type="NX_NUMBER">
         <doc>
-             Collection of axis-based translations and rotations to describe this coordinate system
-             with respect to another coordinate system.
+             Translational shift during a passive transformation from the coordinate system
+             defined in the the `depends_on` attribute.
         </doc>
-    </group>
+    </field>
+    <attribute name="depends_on" type="NX_CHAR">
+        <doc>
+             This defines which coordinate system the base transformation defined by the 
+             `x`, `y`, and `z` fields refers to. 
+             By default, it is (.) and points to the McStas coordinate system.
+        </doc>
+    </attribute>
 </definition>

--- a/contributed_definitions/NXcoordinate_system_set.nxdl.xml
+++ b/contributed_definitions/NXcoordinate_system_set.nxdl.xml
@@ -25,10 +25,10 @@
     <doc>
          Base class to hold different coordinate systems and representation conversions.
          
-         How many nodes of type :ref:`NXcoordinate_system_set` should be used in an appdef?
+         How many nodes of type :ref:`NXcoordinate_system_set` should be used in an application definition?
          
-         * 0; if no instance of :ref:`NXcoordinate_system_set` and therein or elsewhere across
-           the appdef an instance of NXcoordinate_system is defined,
+         * 0; if there is no instance of :ref:`NXcoordinate_system_set` and therein or elsewhere across
+           the application definition, an instance of NXcoordinate_system is defined,
            the default NeXus `McStas &lt;https://mailman2.mcstas.org/pipermail/mcstas-users/2021q2/001431.html&gt;`_
            coordinate system is assumed. This makes :ref:`NXcoordinate_system_set` and
            NXcoordinate_system base classes backwards compatible to older
@@ -36,13 +36,12 @@
          * 1; if only one :ref:`NXcoordinate_system_set` is defined, it should be placed
            as high up in the node hierarchy (ideally right below an instance of NXentry)
            of the application definition tree as possible.
-           This :ref:`NXcoordinate_system_set` should at least define one NXcoordinate_system
-           instance which should be called mcstas for the sake of improved clarity.
-           Alternatively, at least one NXcoordinate_system member of the set should be
-           defined and named such that it is clear how this coordinate system is
-           typically referred to in a community. Additional NXcoordinate_system instances
-           should be specified if possible in that same :ref:`NXcoordinate_system_set` instead
-           of cluttering them across the tree.
+           This :ref:`NXcoordinate_system_set` should define at least one NXcoordinate_system
+           instance. This shall be named such that it is clear how this coordinate system is
+           typically referred to in a community. For the NeXus `McStas coordinate system, it is
+           adviused to call it mcstas for the sake of improved clarity.
+           Additional NXcoordinate_system instances should be specified if possible in that same
+           :ref:`NXcoordinate_system_set` instead of cluttering them across the tree.
            
            If this is the case, it is assumed that the NXcoordinate_system_members
            overwrite the NeXus default McStas coordinate system, i.e. users can thereby
@@ -102,7 +101,10 @@
            specifying of the coordinate system used in every case is that especially
            in combination with having coordinate systems inside deeper branches
            makes up for a very versatile, backwards compatible, but powerful system
-           to express different types of coordinate systems using NeXus.
+           to express different types of coordinate systems using NeXus. In the case
+           of two or more instances of NXcoordinate_system in one :ref:`NXcoordinate_system_set`,
+           it is also advised to specify the relationship between the two coordinate systems by
+           using the (NXtransformations) group within NXcoordinate_system.
          
          In effect, 1 should be the preferred choice. However, if more than one coordinate
          system is defined for practical purposes, explicit depends_on fields should

--- a/contributed_definitions/NXcoordinate_system_set.nxdl.xml
+++ b/contributed_definitions/NXcoordinate_system_set.nxdl.xml
@@ -39,7 +39,7 @@
            This :ref:`NXcoordinate_system_set` should define at least one NXcoordinate_system
            instance. This shall be named such that it is clear how this coordinate system is
            typically referred to in a community. For the NeXus `McStas coordinate system, it is
-           adviused to call it mcstas for the sake of improved clarity.
+           advised to call it mcstas for the sake of improved clarity.
            Additional NXcoordinate_system instances should be specified if possible in that same
            :ref:`NXcoordinate_system_set` instead of cluttering them across the tree.
            
@@ -118,5 +118,5 @@ Depends on cardinality of NXcoordinate_system_set, i.e. how many NXcoordinate_sy
 - 0, the root of an NXtransformation chain i.e. "." means McStas
 - 1, the root of an NXtransformation chain i.e. "." means "that specific CS" i.e. the one defined by the single instance of NXcoordinate_system in the set
 - > 1, "." becomes ambiguous. My suggestion, spell out the name of the specific NXcoordinate_system instance to be used, using "."
-  despite all these, a warning should be raised, like a logic warning (and McStas kick in) or an error (i.e. be forbidden) be raised-->
+despite all these, a warning should be raised, like a logic warning (and McStas kick in) or an error (i.e. be forbidden) be raised-->
 </definition>

--- a/contributed_definitions/NXem_conventions.nxdl.xml
+++ b/contributed_definitions/NXem_conventions.nxdl.xml
@@ -398,7 +398,7 @@ assumed reference frame and rotation conventions-->
         <doc>
              Details about the detector reference frame for a specific detector.
         </doc>
-        <attribute name="depends_on" type="NX_CHAR">
+        <attribute name="detector" type="NX_CHAR">
             <doc>
                  Reference to the specifically named :ref:`NXdetector` instance
                  for which these conventions in this :ref:`NXprocess` group apply

--- a/contributed_definitions/nyaml/NXcoordinate_system.yaml
+++ b/contributed_definitions/nyaml/NXcoordinate_system.yaml
@@ -91,19 +91,17 @@ NXcoordinate_system(NXobject):
     dimensions:
       rank: 1
       dim: [[1, 3]]
-  offset(NX_NUMBER):
+  depends_on(NX_CHAR):
     doc: |
-      Translational shift during a passive transformation from the coordinate system
-      defined in the the `depends_on` attribute.
-  \@depends_on:
-    type: NX_CHAR
+      This specificies the relation to another coordinate system by pointing to the last
+      transformation in the transformation chain in the NXtransformations group.
+  (NXtransformations):
     doc: |
-      This defines which coordinate system the base transformation defined by the
-      `x`, `y`, and `z` fields refers to.
-      By default, it is (.) and points to the McStas coordinate system.
+      Collection of axis-based translations and rotations to describe this coordinate system
+      with respect to another coordinate system.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 8f206af983210d7f46437cc8940974e32cc2966d997126c290089ef355f6fb59
+# 76304029bbb3a1882d9855d8b170be0cfb2a18eebd5f0b60c752ae35c441f906
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -246,17 +244,16 @@ NXcoordinate_system(NXobject):
 #             <dim index="1" value="3"/>
 #         </dimensions>
 #     </field>
-#     <field name="offset" type="NX_NUMBER">
+#     <field name="depends_on" type="NX_CHAR">
 #         <doc>
-#              Translational shift during a passive transformation from the coordinate system
-#              defined in the the `depends_on` attribute.
+#              This specificies the relation to another coordinate system by pointing to the last 
+#              transformation in the transformation chain in the NXtransformations group.
 #         </doc>
 #     </field>
-#     <attribute name="depends_on" type="NX_CHAR">
+#     <group type="NXtransformations">
 #         <doc>
-#              This defines which coordinate system the base transformation defined by the 
-#              `x`, `y`, and `z` fields refers to. 
-#              By default, it is (.) and points to the McStas coordinate system.
+#              Collection of axis-based translations and rotations to describe this coordinate system
+#              with respect to another coordinate system.
 #         </doc>
-#     </attribute>
+#     </group>
 # </definition>

--- a/contributed_definitions/nyaml/NXcoordinate_system.yaml
+++ b/contributed_definitions/nyaml/NXcoordinate_system.yaml
@@ -18,6 +18,7 @@ NXcoordinate_system(NXobject):
       Exemplar values could be *left corner of the lab bench*, *door-handle*
       *pinhole through which the electron beam exists the pole piece*.
       *barycenter of the triangle*, *center of mass of the stone*.
+  
   # implementing a proposal for "a common base table" along thoughts like:
   # https://manual.nexusformat.org/classes/base_classes/NXtransformations.html#nxtransformations
   # similar to a place where all transformations are stored
@@ -44,12 +45,14 @@ NXcoordinate_system(NXobject):
       
       Exemplar values could be direction of gravity.
   x(NX_NUMBER):
+    unit: NX_LENGTH
     doc: |
       Base unit vector along the first axis which spans the coordinate system.
       This axis is frequently referred to as the x-axis in real space and
       the i-axis in reciprocal space.
-    unit: NX_LENGTH
-    dim: (3,)
+    dimensions:
+      rank: 1
+      dim: [[1, 3]]
   y_alias(NX_CHAR):
     doc: |
       Possibility to define an alias for the name of the y-axis.
@@ -61,12 +64,14 @@ NXcoordinate_system(NXobject):
       
       See docstring of x_alias for further details.
   y(NX_NUMBER):
+    unit: NX_LENGTH
     doc: |
       Base unit vector along the second axis which spans the coordinate system.
       This axis is frequently referred to as the y-axis in real space and
       the j-axis in reciprocal space.
-    unit: NX_LENGTH
-    dim: (3,)
+    dimensions:
+      rank: 1
+      dim: [[1, 3]]
   z_alias(NX_CHAR):
     doc: |
       Possibility to define an alias for the name of the z-axis.
@@ -78,14 +83,180 @@ NXcoordinate_system(NXobject):
       
       See docstring of x_alias for further details.
   z(NX_NUMBER):
+    unit: NX_LENGTH
     doc: |
-      Base unit vector along the second axis which spans the coordinate system.
+      Base unit vector along the third axis which spans the coordinate system.
       This axis is frequently referred to as the z-axis in real space and
       the k-axis in reciprocal space.
-    unit: NX_LENGTH
-    dim: (3,)
-  depends_on(NX_CHAR):
-  (NXtransformations):
+    dimensions:
+      rank: 1
+      dim: [[1, 3]]
+  offset(NX_NUMBER):
     doc: |
-      Collection of axis-based translations and rotations to describe this coordinate system
-      with respect to another coordinate system.
+      Translational shift during a passive transformation from the coordinate system
+      defined in the the `depends_on` attribute.
+  \@depends_on:
+    type: NX_CHAR
+    doc: |
+      This defines which coordinate system the base transformation defined by the
+      `x`, `y`, and `z` fields refers to.
+      By default, it is (.) and points to the McStas coordinate system.
+
+# ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
+# 8f206af983210d7f46437cc8940974e32cc2966d997126c290089ef355f6fb59
+# <?xml version='1.0' encoding='UTF-8'?>
+# <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+# <!--
+# # NeXus - Neutron and X-ray Common Data Format
+# #
+# # Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+# #
+# # This library is free software; you can redistribute it and/or
+# # modify it under the terms of the GNU Lesser General Public
+# # License as published by the Free Software Foundation; either
+# # version 3 of the License, or (at your option) any later version.
+# #
+# # This library is distributed in the hope that it will be useful,
+# # but WITHOUT ANY WARRANTY; without even the implied warranty of
+# # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# # Lesser General Public License for more details.
+# #
+# # You should have received a copy of the GNU Lesser General Public
+# # License along with this library; if not, write to the Free Software
+# # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# #
+# # For further information, see http://www.nexusformat.org
+# -->
+# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXcoordinate_system" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+#     <doc>
+#          Base class to detail a coordinate system (CS).
+#          
+#          Whenever possible, an instance of :ref:`NXcoordinate_system` should be used as
+#          a member in an :ref:`NXcoordinate_system_set` and the name of the instance
+#          should be this alias. This may support a process whereby jargon when talking
+#          about coordinate systems and conventions may become cleaner for users
+#          because it is not evident for people outside a lab that terms like e.g.
+#          tip space or specimen space refer to the same coordinate system.
+#          This is an example of jargon used in e.g. the field of atom
+#          probe tomography.
+#     </doc>
+#     <field name="origin" type="NX_CHAR">
+#         <doc>
+#              Human-readable field telling where the origin of this CS is.
+#              Exemplar values could be *left corner of the lab bench*, *door-handle*
+#              *pinhole through which the electron beam exists the pole piece*.
+#              *barycenter of the triangle*, *center of mass of the stone*.
+#         </doc>
+#     </field>
+#     <!--implementing a proposal for "a common base table" along thoughts like:
+# https://manual.nexusformat.org/classes/base_classes/NXtransformations.html#nxtransformations
+# similar to a place where all transformations are stored
+# https://www.zenodo.org/record/3526738/files/lyso009a_0087.JF07T32V01_master.h5?download=1-->
+#     <field name="alias" type="NX_CHAR">
+#         <doc>
+#              An alternative name given to that coordinate system.
+#         </doc>
+#     </field>
+#     <field name="type" type="NX_CHAR">
+#         <doc>
+#              Coordinate system type.
+#         </doc>
+#         <enumeration>
+#             <item value="cartesian"/>
+#         </enumeration>
+#     </field>
+#     <field name="handedness" type="NX_CHAR">
+#         <doc>
+#              Handedness of the coordinate system if it is a Cartesian.
+#         </doc>
+#         <enumeration>
+#             <item value="right_handed"/>
+#             <item value="left_handed"/>
+#         </enumeration>
+#     </field>
+#     <field name="x_alias" type="NX_CHAR">
+#         <doc>
+#              Possibility to define an alias for the name of the x-axis.
+#         </doc>
+#     </field>
+#     <field name="x_direction" type="NX_CHAR">
+#         <doc>
+#              Human-readable field telling in which direction the x-axis points if that
+#              instance of :ref:`NXcoordinate_system` has no reference to any parent and as such
+#              is the mighty world reference frame.
+#              
+#              Exemplar values could be direction of gravity.
+#         </doc>
+#     </field>
+#     <field name="x" type="NX_NUMBER" units="NX_LENGTH">
+#         <doc>
+#              Base unit vector along the first axis which spans the coordinate system.
+#              This axis is frequently referred to as the x-axis in real space and
+#              the i-axis in reciprocal space.
+#         </doc>
+#         <dimensions rank="1">
+#             <dim index="1" value="3"/>
+#         </dimensions>
+#     </field>
+#     <field name="y_alias" type="NX_CHAR">
+#         <doc>
+#              Possibility to define an alias for the name of the y-axis.
+#         </doc>
+#     </field>
+#     <field name="y_direction" type="NX_CHAR">
+#         <doc>
+#              Human-readable field telling in which direction the y-axis points if that
+#              instance of :ref:`NXcoordinate_system` has no reference to any parent and as such
+#              is the mighty world reference frame.
+#              
+#              See docstring of x_alias for further details.
+#         </doc>
+#     </field>
+#     <field name="y" type="NX_NUMBER" units="NX_LENGTH">
+#         <doc>
+#              Base unit vector along the second axis which spans the coordinate system.
+#              This axis is frequently referred to as the y-axis in real space and
+#              the j-axis in reciprocal space.
+#         </doc>
+#         <dimensions rank="1">
+#             <dim index="1" value="3"/>
+#         </dimensions>
+#     </field>
+#     <field name="z_alias" type="NX_CHAR">
+#         <doc>
+#              Possibility to define an alias for the name of the z-axis.
+#         </doc>
+#     </field>
+#     <field name="z_direction" type="NX_CHAR">
+#         <doc>
+#              Human-readable field telling in which direction the z-axis points if that
+#              instance of :ref:`NXcoordinate_system` has no reference to any parent and as such
+#              is the mighty world reference frame.
+#              
+#              See docstring of x_alias for further details.
+#         </doc>
+#     </field>
+#     <field name="z" type="NX_NUMBER" units="NX_LENGTH">
+#         <doc>
+#              Base unit vector along the third axis which spans the coordinate system.
+#              This axis is frequently referred to as the z-axis in real space and
+#              the k-axis in reciprocal space.
+#         </doc>
+#         <dimensions rank="1">
+#             <dim index="1" value="3"/>
+#         </dimensions>
+#     </field>
+#     <field name="offset" type="NX_NUMBER">
+#         <doc>
+#              Translational shift during a passive transformation from the coordinate system
+#              defined in the the `depends_on` attribute.
+#         </doc>
+#     </field>
+#     <attribute name="depends_on" type="NX_CHAR">
+#         <doc>
+#              This defines which coordinate system the base transformation defined by the 
+#              `x`, `y`, and `z` fields refers to. 
+#              By default, it is (.) and points to the McStas coordinate system.
+#         </doc>
+#     </attribute>
+# </definition>

--- a/contributed_definitions/nyaml/NXcoordinate_system.yaml
+++ b/contributed_definitions/nyaml/NXcoordinate_system.yaml
@@ -84,3 +84,8 @@ NXcoordinate_system(NXobject):
       the k-axis in reciprocal space.
     unit: NX_LENGTH
     dim: (3,)
+  depends_on(NX_CHAR):
+  (NXtransformations):
+    doc: |
+      Collection of axis-based translations and rotations to describe this coordinate system
+      with respect to another coordinate system.

--- a/contributed_definitions/nyaml/NXcoordinate_system.yaml
+++ b/contributed_definitions/nyaml/NXcoordinate_system.yaml
@@ -246,7 +246,7 @@ NXcoordinate_system(NXobject):
 #     </field>
 #     <field name="depends_on" type="NX_CHAR">
 #         <doc>
-#              This specificies the relation to another coordinate system by pointing to the last 
+#              This specificies the relation to another coordinate system by pointing to the last
 #              transformation in the transformation chain in the NXtransformations group.
 #         </doc>
 #     </field>

--- a/contributed_definitions/nyaml/NXcoordinate_system_set.yaml
+++ b/contributed_definitions/nyaml/NXcoordinate_system_set.yaml
@@ -16,7 +16,7 @@ doc: |
     This :ref:`NXcoordinate_system_set` should define at least one NXcoordinate_system
     instance. This shall be named such that it is clear how this coordinate system is
     typically referred to in a community. For the NeXus `McStas coordinate system, it is
-    adviused to call it mcstas for the sake of improved clarity.
+    advised to call it mcstas for the sake of improved clarity.
     Additional NXcoordinate_system instances should be specified if possible in that same
     :ref:`NXcoordinate_system_set` instead of cluttering them across the tree.
     
@@ -100,7 +100,7 @@ NXcoordinate_system_set(NXobject):
   # despite all these, a warning should be raised, like a logic warning (and McStas kick in) or an error (i.e. be forbidden) be raised
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 19dcdaa81b00c7163aed10d5e3a9fd6393f681c1df3bf0b79af8db1e9f8e746e
+# 2c012af7dc8e09a7f7df9408a0d04886f58bc74feff6fc207658954ad8682422
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -142,7 +142,7 @@ NXcoordinate_system_set(NXobject):
 #            This :ref:`NXcoordinate_system_set` should define at least one NXcoordinate_system
 #            instance. This shall be named such that it is clear how this coordinate system is
 #            typically referred to in a community. For the NeXus `McStas coordinate system, it is
-#            adviused to call it mcstas for the sake of improved clarity.
+#            advised to call it mcstas for the sake of improved clarity.
 #            Additional NXcoordinate_system instances should be specified if possible in that same
 #            :ref:`NXcoordinate_system_set` instead of cluttering them across the tree.
 #            
@@ -221,5 +221,5 @@ NXcoordinate_system_set(NXobject):
 # - 0, the root of an NXtransformation chain i.e. "." means McStas
 # - 1, the root of an NXtransformation chain i.e. "." means "that specific CS" i.e. the one defined by the single instance of NXcoordinate_system in the set
 # - > 1, "." becomes ambiguous. My suggestion, spell out the name of the specific NXcoordinate_system instance to be used, using "."
-#   despite all these, a warning should be raised, like a logic warning (and McStas kick in) or an error (i.e. be forbidden) be raised-->
+# despite all these, a warning should be raised, like a logic warning (and McStas kick in) or an error (i.e. be forbidden) be raised-->
 # </definition>

--- a/contributed_definitions/nyaml/NXcoordinate_system_set.yaml
+++ b/contributed_definitions/nyaml/NXcoordinate_system_set.yaml
@@ -2,10 +2,10 @@ category: base
 doc: |
   Base class to hold different coordinate systems and representation conversions.
   
-  How many nodes of type :ref:`NXcoordinate_system_set` should be used in an appdef?
+  How many nodes of type :ref:`NXcoordinate_system_set` should be used in an application definition?
   
-  * 0; if no instance of :ref:`NXcoordinate_system_set` and therein or elsewhere across
-    the appdef an instance of NXcoordinate_system is defined,
+  * 0; if there is no instance of :ref:`NXcoordinate_system_set` and therein or elsewhere across
+    the application definition, an instance of NXcoordinate_system is defined,
     the default NeXus `McStas <https://mailman2.mcstas.org/pipermail/mcstas-users/2021q2/001431.html>`_
     coordinate system is assumed. This makes :ref:`NXcoordinate_system_set` and
     NXcoordinate_system base classes backwards compatible to older
@@ -13,13 +13,12 @@ doc: |
   * 1; if only one :ref:`NXcoordinate_system_set` is defined, it should be placed
     as high up in the node hierarchy (ideally right below an instance of NXentry)
     of the application definition tree as possible.
-    This :ref:`NXcoordinate_system_set` should at least define one NXcoordinate_system
-    instance which should be called mcstas for the sake of improved clarity.
-    Alternatively, at least one NXcoordinate_system member of the set should be
-    defined and named such that it is clear how this coordinate system is
-    typically referred to in a community. Additional NXcoordinate_system instances
-    should be specified if possible in that same :ref:`NXcoordinate_system_set` instead
-    of cluttering them across the tree.
+    This :ref:`NXcoordinate_system_set` should define at least one NXcoordinate_system
+    instance. This shall be named such that it is clear how this coordinate system is
+    typically referred to in a community. For the NeXus `McStas coordinate system, it is
+    adviused to call it mcstas for the sake of improved clarity.
+    Additional NXcoordinate_system instances should be specified if possible in that same
+    :ref:`NXcoordinate_system_set` instead of cluttering them across the tree.
     
     If this is the case, it is assumed that the NXcoordinate_system_members
     overwrite the NeXus default McStas coordinate system, i.e. users can thereby
@@ -79,7 +78,10 @@ doc: |
     specifying of the coordinate system used in every case is that especially
     in combination with having coordinate systems inside deeper branches
     makes up for a very versatile, backwards compatible, but powerful system
-    to express different types of coordinate systems using NeXus.
+    to express different types of coordinate systems using NeXus. In the case
+    of two or more instances of NXcoordinate_system in one :ref:`NXcoordinate_system_set`,
+    it is also advised to specify the relationship between the two coordinate systems by
+    using the (NXtransformations) group within NXcoordinate_system.
   
   In effect, 1 should be the preferred choice. However, if more than one coordinate
   system is defined for practical purposes, explicit depends_on fields should
@@ -88,11 +90,136 @@ doc: |
 type: group
 NXcoordinate_system_set(NXobject):
   (NXcoordinate_system):
-# How to interpret "depends_on" calls for NXtransformations instances which live
+  
+  # How to interpret "depends_on" calls for NXtransformations instances which live
+  # within an instance of NXcoordinate_system(_set)?
+  # Depends on cardinality of NXcoordinate_system_set, i.e. how many NXcoordinate_system are defined?
+  # - 0, the root of an NXtransformation chain i.e. "." means McStas
+  # - 1, the root of an NXtransformation chain i.e. "." means "that specific CS" i.e. the one defined by the single instance of NXcoordinate_system in the set
+  # - > 1, "." becomes ambiguous. My suggestion, spell out the name of the specific NXcoordinate_system instance to be used, using "."
+  # despite all these, a warning should be raised, like a logic warning (and McStas kick in) or an error (i.e. be forbidden) be raised
+
+# ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
+# 19dcdaa81b00c7163aed10d5e3a9fd6393f681c1df3bf0b79af8db1e9f8e746e
+# <?xml version='1.0' encoding='UTF-8'?>
+# <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+# <!--
+# # NeXus - Neutron and X-ray Common Data Format
+# #
+# # Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+# #
+# # This library is free software; you can redistribute it and/or
+# # modify it under the terms of the GNU Lesser General Public
+# # License as published by the Free Software Foundation; either
+# # version 3 of the License, or (at your option) any later version.
+# #
+# # This library is distributed in the hope that it will be useful,
+# # but WITHOUT ANY WARRANTY; without even the implied warranty of
+# # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# # Lesser General Public License for more details.
+# #
+# # You should have received a copy of the GNU Lesser General Public
+# # License along with this library; if not, write to the Free Software
+# # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# #
+# # For further information, see http://www.nexusformat.org
+# -->
+# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXcoordinate_system_set" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+#     <doc>
+#          Base class to hold different coordinate systems and representation conversions.
+#          
+#          How many nodes of type :ref:`NXcoordinate_system_set` should be used in an application definition?
+#          
+#          * 0; if there is no instance of :ref:`NXcoordinate_system_set` and therein or elsewhere across
+#            the application definition, an instance of NXcoordinate_system is defined,
+#            the default NeXus `McStas &lt;https://mailman2.mcstas.org/pipermail/mcstas-users/2021q2/001431.html&gt;`_
+#            coordinate system is assumed. This makes :ref:`NXcoordinate_system_set` and
+#            NXcoordinate_system base classes backwards compatible to older
+#            NeXus conventions and classes.
+#          * 1; if only one :ref:`NXcoordinate_system_set` is defined, it should be placed
+#            as high up in the node hierarchy (ideally right below an instance of NXentry)
+#            of the application definition tree as possible.
+#            This :ref:`NXcoordinate_system_set` should define at least one NXcoordinate_system
+#            instance. This shall be named such that it is clear how this coordinate system is
+#            typically referred to in a community. For the NeXus `McStas coordinate system, it is
+#            adviused to call it mcstas for the sake of improved clarity.
+#            Additional NXcoordinate_system instances should be specified if possible in that same
+#            :ref:`NXcoordinate_system_set` instead of cluttering them across the tree.
+#            
+#            If this is the case, it is assumed that the NXcoordinate_system_members
+#            overwrite the NeXus default McStas coordinate system, i.e. users can thereby
+#            conveniently and explicitly specify the coordinate system(s) that
+#            they wish to use.
+#            
+#            Users are encouraged to write also explicit and clean depends_on fields in
+#            all groups that encode information about where the interpretation of coordinate
+#            systems is relevant. If these depends_on hints are not provided, it is
+#            automatically assumed that all children (to arbitrary depth)
+#            of that branch and sub-branches below the one in which that
+#            :ref:`NXcoordinate_system_set` is defined use either the only NXcoordinate_system_set
+#            instance in that set or the application definition is considered
+#            underconstrained which should at all costs be avoided and in which case
+#            again McStas is assumed.
+#          * 2 and more; as soon as more than one :ref:`NXcoordinate_system_set` is specified
+#            somewhere in the tree, different interpretations are possible as to which
+#            of these coordinate system sets and instances apply or take preference.
+#            We realize that such ambiguities should at all costs be avoided.
+#            However, the opportunity for multiple sets and their instances enables to
+#            have branch-specific coordinate system conventions which could especially
+#            be useful for deep classes where multiple scientific methods are combined or
+#            cases where having a definition of global translation and conversion tables
+#            how to convert between representations in different coordinate systems
+#            is not desired or available for now.
+#            We argue that having 2 or more :ref:`NXcoordinate_system_set` instances and respective
+#            NXcoordinate_system instances makes the interpretation eventually unnecessary
+#            complicated. Instead, developers of application definitions should always try
+#            to work for clarity and thus use only one top-level coordinate system set.
+#          
+#          For these reasons we conclude that the option with one top-level
+#          :ref:`NXcoordinate_system_set` instance is the preferred choice.
+#          
+#          McStas is used if neither an instance of :ref:`NXcoordinate_system_set` nor an instance
+#          of NXcoordinate_system is specified. However, even in this case it is better
+#          to be explicit like for every other coordinate system definition to support
+#          users with interpreting the content and logic behind every instance of the tree.
+#          
+#          How to store coordinate systems inside :ref:`NXcoordinate_system_set`?
+#          Individual coordinate systems should be specified as members of the
+#          :ref:`NXcoordinate_system_set` instance using instances of NXcoordinate_system.
+#          
+#          How many individual instances of NXcoordinate_system to allow within one
+#          instance of :ref:`NXcoordinate_system_set`?
+#          
+#          * 0; This case should be avoided for the sake of clarity but this case could
+#            mean the authors of the definition meant that McStas is used. We conclude,
+#            McStas is used in this case.
+#          * 1; Like above-mentioned this case has the advantage that it is explicit
+#            and faces no ambiguities. However, in reality typically multiple
+#            coordinate systems have to be mastered especially for complex
+#            multi-signal modality experiments.
+#          * 2 or more; If this case is realized, the best practice is that in every
+#            case where a coordinate system should be referred to the respective class
+#            has a depends_on field which resolves the possible ambiguities which specific
+#            coordinate systems is referred to. The benefit of this explicit and clear
+#            specifying of the coordinate system used in every case is that especially
+#            in combination with having coordinate systems inside deeper branches
+#            makes up for a very versatile, backwards compatible, but powerful system
+#            to express different types of coordinate systems using NeXus. In the case
+#            of two or more instances of NXcoordinate_system in one :ref:`NXcoordinate_system_set`,
+#            it is also advised to specify the relationship between the two coordinate systems by
+#            using the (NXtransformations) group within NXcoordinate_system.
+#          
+#          In effect, 1 should be the preferred choice. However, if more than one coordinate
+#          system is defined for practical purposes, explicit depends_on fields should
+#          always guide the user for each group and field which of the coordinate system
+#          one refers to.
+#     </doc>
+#     <group type="NXcoordinate_system"/>
+#     <!--How to interpret "depends_on" calls for NXtransformations instances which live
 # within an instance of NXcoordinate_system(_set)?
 # Depends on cardinality of NXcoordinate_system_set, i.e. how many NXcoordinate_system are defined?
 # - 0, the root of an NXtransformation chain i.e. "." means McStas
 # - 1, the root of an NXtransformation chain i.e. "." means "that specific CS" i.e. the one defined by the single instance of NXcoordinate_system in the set
 # - > 1, "." becomes ambiguous. My suggestion, spell out the name of the specific NXcoordinate_system instance to be used, using "."
-#   despite all these, a warning should be raised, like a logic warning (and McStas kick in) or an error (i.e. be forbidden) be raised
-
+#   despite all these, a warning should be raised, like a logic warning (and McStas kick in) or an error (i.e. be forbidden) be raised-->
+# </definition>

--- a/contributed_definitions/nyaml/NXem_conventions.yaml
+++ b/contributed_definitions/nyaml/NXem_conventions.yaml
@@ -1,4 +1,5 @@
 category: base
+
 # symbols:
 doc: |
   Conventions for rotations and coordinate systems to interpret crystal orientation
@@ -42,6 +43,7 @@ doc: |
 # definition.
 type: group
 NXem_conventions(NXobject):
+  
   # mandatory information about used or
   # assumed reference frame and rotation conventions
   rotation_conventions(NXobject):
@@ -223,7 +225,8 @@ NXem_conventions(NXobject):
   detector_reference_frameID(NXcoordinate_system):
     doc: |
       Details about the detector reference frame for a specific detector.
-    \@depends_on(NX_CHAR):
+    \@detector:
+      type: NX_CHAR
       doc: |
         Reference to the specifically named :ref:`NXdetector` instance
         for which these conventions in this :ref:`NXprocess` group apply
@@ -292,5 +295,545 @@ NXem_conventions(NXobject):
         For further information consult also the help info for the
         xaxis_direction field.
       enumeration: [undefined, north, east, south, west, in, out]
+  
   # conventions specific for EBSD
   (NXem_conventions_ebsd):
+  
+  # conventions specific for EBSD
+
+# ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
+# b4e33f4b52cd8aad5fa72fb4796c5ca1cd43482b7394ca7af917b8d321024659
+# <?xml version='1.0' encoding='UTF-8'?>
+# <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+# <!--
+# # NeXus - Neutron and X-ray Common Data Format
+# #
+# # Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+# #
+# # This library is free software; you can redistribute it and/or
+# # modify it under the terms of the GNU Lesser General Public
+# # License as published by the Free Software Foundation; either
+# # version 3 of the License, or (at your option) any later version.
+# #
+# # This library is distributed in the hope that it will be useful,
+# # but WITHOUT ANY WARRANTY; without even the implied warranty of
+# # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# # Lesser General Public License for more details.
+# #
+# # You should have received a copy of the GNU Lesser General Public
+# # License along with this library; if not, write to the Free Software
+# # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# #
+# # For further information, see http://www.nexusformat.org
+# -->
+# <!--
+# This base class provides several sets of such assumptions and conventions.
+# Further base classes should be defined when specific techniques and methods
+# demand further specifications or have specialized demands. NXem_conventions_ebsd
+# is an example for such method-specific base class to summarize key conventions
+# for Electron Backscatter Diffraction (EBSD).-->
+# <!--
+# What is could be a best practice for application definition developers
+# who would like to describe an electron microscopy case where multiple
+# methods and/or detectors are used. In this case one should define a
+# method-specific base class like the template NXem_conventions_ebsd.
+# Even though this may come at a cost of some duplicated information where
+# the same physical detector is used in different ways, i.e. the signal collect
+# from the detector is interpreted in a different way.
+# As in most cases established types of signal and thus detectors are used
+# (secondary electron, backscattered electron, etc.) one could equally use
+# just one NXem_conventions base class instance in an application definition
+# and use detector_reference_frame as a template. For each method and detector
+# one then creates one NXprocess group named detector_reference_frame1,
+# detector_reference_frame2, detector_reference_frame3, and so on and so forth
+# and adds inside that NXprocess and use the depends_on field.-->
+# <!--
+# What is considered best practice in an application definition with multiple
+# NXentry instances? In this case each NXentry instance should have an own
+# NXspecimen instance and thus the NXem_conventions instance should be place
+# inside that NXentry. This enables to group multiple experiments on multiple
+# samples together without setting a constraint that in all these instances
+# the conventions have to be the same.-->
+# <!--
+# However, best practice is the conventions should be expressed explicitly
+# and they should whenever possible be as simple as possible and as few
+# as possible to support users with understanding the content of the application
+# definition.-->
+# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXem_conventions" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+#     <!--
+# symbols:
+# -->
+#     <doc>
+#          Conventions for rotations and coordinate systems to interpret crystal orientation
+#          and other data and results collected with electron microscopy research.
+#          
+#          Documenting explicitly all used conventions and coordinate systems is
+#          the decisive context whereby many results from electron microscopy are
+#          at all interpretable.
+#     </doc>
+#     <!--mandatory information about used or
+# assumed reference frame and rotation conventions-->
+#     <group name="rotation_conventions" type="NXobject">
+#         <doc>
+#              Mathematical conventions and materials-science-specific conventions
+#              required for interpreting every collection of orientation data.
+#         </doc>
+#         <field name="rotation_handedness" type="NX_CHAR">
+#             <doc>
+#                  Convention how a positive rotation angle is defined when viewing
+#                  from the end of the rotation unit vector towards its origin,
+#                  i.e. in accordance with convention 2 of
+#                  DOI: 10.1088/0965-0393/23/8/083501.
+#                  Counter_clockwise is equivalent to a right-handed choice.
+#                  Clockwise is equivalent to a left-handed choice.
+#             </doc>
+#             <enumeration>
+#                 <item value="undefined"/>
+#                 <item value="counter_clockwise"/>
+#                 <item value="clockwise"/>
+#             </enumeration>
+#         </field>
+#         <field name="rotation_convention" type="NX_CHAR">
+#             <doc>
+#                  How are rotations interpreted into an orientation
+#                  according to convention 3 of
+#                  DOI: 10.1088/0965-0393/23/8/083501.
+#             </doc>
+#             <enumeration>
+#                 <item value="undefined"/>
+#                 <item value="passive"/>
+#                 <item value="active"/>
+#             </enumeration>
+#         </field>
+#         <field name="euler_angle_convention" type="NX_CHAR">
+#             <doc>
+#                  How are Euler angles interpreted given that there are several
+#                  choices (e.g. ZXZ, XYZ, etc.) according to convention 4 of
+#                  DOI: 10.1088/0965-0393/23/8/083501.
+#                  The most frequently used convention is ZXZ which is based on
+#                  the work of H.-J. Bunge but other conventions are possible.
+#             </doc>
+#             <enumeration>
+#                 <item value="undefined"/>
+#                 <item value="zxz"/>
+#             </enumeration>
+#         </field>
+#         <field name="axis_angle_convention" type="NX_CHAR">
+#             <doc>
+#                  To which angular range is the rotation angle argument of an
+#                  axis-angle pair parameterization constrained according to
+#                  convention 5 of DOI: 10.1088/0965-0393/23/8/083501.
+#             </doc>
+#             <enumeration>
+#                 <item value="undefined"/>
+#                 <item value="rotation_angle_on_interval_zero_to_pi"/>
+#             </enumeration>
+#         </field>
+#         <field name="sign_convention" type="NX_CHAR">
+#             <doc>
+#                  Which sign convention is followed when converting orientations
+#                  between different parameterizations/representations according
+#                  to convention 6 of DOI: 10.1088/0965-0393/23/8/083501.
+#             </doc>
+#             <enumeration>
+#                 <item value="undefined"/>
+#                 <item value="p_plus_one"/>
+#                 <item value="p_minus_one"/>
+#             </enumeration>
+#         </field>
+#     </group>
+#     <group name="processing_reference_frame" type="NXcoordinate_system">
+#         <doc>
+#              Details about eventually relevant named directions that may
+#              give reasons for anisotropies. The classical example is cold-rolling
+#              where one has to specify which directions (rolling, transverse, and normal)
+#              align how with the direction of the base vectors of the sample_reference_frame.
+#         </doc>
+#         <field name="type" type="NX_CHAR">
+#             <doc>
+#                  Type of coordinate system and reference frame according to
+#                  convention 1 of DOI: 10.1088/0965-0393/23/8/083501.
+#             </doc>
+#             <enumeration>
+#                 <item value="undefined"/>
+#                 <item value="cartesian"/>
+#             </enumeration>
+#         </field>
+#         <field name="handedness" type="NX_CHAR">
+#             <doc>
+#                  Handedness of coordinate system.
+#             </doc>
+#             <enumeration>
+#                 <item value="right_handed"/>
+#                 <item value="left_handed"/>
+#             </enumeration>
+#         </field>
+#         <field name="origin" type="NX_CHAR">
+#             <doc>
+#                  Location of the origin of the processing_reference_frame.
+#                  This specifies the location Xp = 0, Yp = 0, Zp = 0.
+#                  Assume regions-of-interest in this reference frame form a
+#                  rectangle or cuboid.
+#                  Edges are interpreted by inspecting the direction of their
+#                  outer unit normals (which point either parallel or antiparallel)
+#                  along respective base vector direction of the reference frame.
+#             </doc>
+#             <enumeration>
+#                 <item value="undefined"/>
+#                 <item value="front_top_left"/>
+#                 <item value="front_top_right"/>
+#                 <item value="front_bottom_right"/>
+#                 <item value="front_bottom_left"/>
+#                 <item value="back_top_left"/>
+#                 <item value="back_top_right"/>
+#                 <item value="back_bottom_right"/>
+#                 <item value="back_bottom_left"/>
+#             </enumeration>
+#         </field>
+#         <field name="x_alias" type="NX_CHAR">
+#             <doc>
+#                  Name or alias assigned to the x-axis base vector,
+#                  e.g. rolling direction.
+#             </doc>
+#         </field>
+#         <field name="x_direction" type="NX_CHAR">
+#             <doc>
+#                  Direction of the positively pointing x-axis base vector of
+#                  the processing_reference_frame. We assume the configuration
+#                  is inspected by looking towards the sample surface from a position
+#                  that is located behind the detector.
+#             </doc>
+#             <enumeration>
+#                 <item value="undefined"/>
+#                 <item value="north"/>
+#                 <item value="east"/>
+#                 <item value="south"/>
+#                 <item value="west"/>
+#                 <item value="in"/>
+#                 <item value="out"/>
+#             </enumeration>
+#         </field>
+#         <field name="y_alias" type="NX_CHAR">
+#             <doc>
+#                  Name or alias assigned to the y-axis base vector,
+#                  e.g. transverse direction.
+#             </doc>
+#         </field>
+#         <field name="y_direction" type="NX_CHAR">
+#             <doc>
+#                  Direction of the positively pointing y-axis base vector of
+#                  the processing_reference_frame. We assume the configuration
+#                  is inspected by looking towards the sample surface from a position
+#                  that is located behind the detector. For further information consult
+#                  also the help info for the xaxis_direction field.
+#             </doc>
+#             <enumeration>
+#                 <item value="undefined"/>
+#                 <item value="north"/>
+#                 <item value="east"/>
+#                 <item value="south"/>
+#                 <item value="west"/>
+#                 <item value="in"/>
+#                 <item value="out"/>
+#             </enumeration>
+#         </field>
+#         <field name="z_alias" type="NX_CHAR">
+#             <doc>
+#                  Name or alias assigned to the z-axis base vector,
+#                  e.g. normal direction.
+#             </doc>
+#         </field>
+#         <field name="z_direction" type="NX_CHAR">
+#             <doc>
+#                  Direction of the positively pointing z-axis base vector of
+#                  the processing_reference frame. We assume the configuration
+#                  is inspected by looking towards the sample surface from a position
+#                  that is located behind the detector. For further information consult
+#                  also the help info for the xaxis_direction field.
+#             </doc>
+#             <enumeration>
+#                 <item value="undefined"/>
+#                 <item value="north"/>
+#                 <item value="east"/>
+#                 <item value="south"/>
+#                 <item value="west"/>
+#                 <item value="in"/>
+#                 <item value="out"/>
+#             </enumeration>
+#         </field>
+#     </group>
+#     <group name="sample_reference_frame" type="NXcoordinate_system">
+#         <doc>
+#              Details about the sample/specimen reference frame.
+#         </doc>
+#         <field name="type" type="NX_CHAR">
+#             <doc>
+#                  Type of coordinate system and reference frame according to
+#                  convention 1 of DOI: 10.1088/0965-0393/23/8/083501.
+#                  The reference frame for the sample surface reference is used for
+#                  identifying positions on a (virtual) image which is formed by
+#                  information collected from an electron beam scanning the
+#                  sample surface. We assume the configuration is inspected by
+#                  looking towards the sample surface from a position that is
+#                  located behind the detector.
+#                  Reference DOI: 10.1016/j.matchar.2016.04.008
+#                  The sample surface reference frame has coordinates Xs, Ys, Zs.
+#                  In three dimensions these coordinates are not necessarily
+#                  located on the surface of the sample as there are multiple
+#                  faces/sides of the sample. Most frequently though the coordinate
+#                  system here is used to define the surface which the electron
+#                  beam scans.
+#             </doc>
+#             <enumeration>
+#                 <item value="undefined"/>
+#                 <item value="cartesian"/>
+#             </enumeration>
+#         </field>
+#         <field name="handedness" type="NX_CHAR">
+#             <doc>
+#                  Handedness of the coordinate system if it is a Cartesian.
+#             </doc>
+#             <enumeration>
+#                 <item value="right_handed"/>
+#                 <item value="left_handed"/>
+#             </enumeration>
+#         </field>
+#         <field name="origin" type="NX_CHAR">
+#             <doc>
+#                  Location of the origin of the sample surface reference frame.
+#                  This specifies the location Xs = 0, Ys = 0, Zs = 0.
+#                  Assume regions-of-interest in this reference frame form a
+#                  rectangle or cuboid.
+#                  Edges are interpreted by inspecting the direction of their
+#                  outer unit normals (which point either parallel or antiparallel)
+#                  along respective base vector direction of the reference frame.
+#             </doc>
+#             <enumeration>
+#                 <item value="undefined"/>
+#                 <item value="front_top_left"/>
+#                 <item value="front_top_right"/>
+#                 <item value="front_bottom_right"/>
+#                 <item value="front_bottom_left"/>
+#                 <item value="back_top_left"/>
+#                 <item value="back_top_right"/>
+#                 <item value="back_bottom_right"/>
+#                 <item value="back_bottom_left"/>
+#             </enumeration>
+#         </field>
+#         <field name="x_alias" type="NX_CHAR">
+#             <doc>
+#                  Name or alias assigned to the x-axis base vector,
+#                  e.g. longest edge.
+#             </doc>
+#         </field>
+#         <field name="x_direction" type="NX_CHAR">
+#             <doc>
+#                  Direction of the positively pointing x-axis base vector of
+#                  the sample surface reference frame. We assume the configuration
+#                  is inspected by looking towards the sample surface from a position
+#                  that is located behind the detector.
+#                  Different tools assume that different strategies can be used
+#                  and are perceived as differently convenient to enter
+#                  details about coordinate system definitions. In this ELN users
+#                  have to possibility to fill in what they assume is sufficient to
+#                  define the coordinate system directions unambiguously.
+#                  Software which works with this user input needs to offer parsing
+#                  capabilities which detect conflicting input and warn accordingly.
+#             </doc>
+#             <enumeration>
+#                 <item value="undefined"/>
+#                 <item value="north"/>
+#                 <item value="east"/>
+#                 <item value="south"/>
+#                 <item value="west"/>
+#                 <item value="in"/>
+#                 <item value="out"/>
+#             </enumeration>
+#         </field>
+#         <field name="y_alias" type="NX_CHAR">
+#             <doc>
+#                  Name or alias assigned to the y-axis base vector,
+#                  e.g. long edge.
+#             </doc>
+#         </field>
+#         <field name="y_direction" type="NX_CHAR">
+#             <doc>
+#                  Direction of the positively pointing y-axis base vector of
+#                  the sample surface reference frame. We assume the configuration
+#                  is inspected by looking towards the sample surface from a position
+#                  that is located behind the detector. For further information consult
+#                  also the help info for the xaxis_direction field.
+#             </doc>
+#             <enumeration>
+#                 <item value="undefined"/>
+#                 <item value="north"/>
+#                 <item value="east"/>
+#                 <item value="south"/>
+#                 <item value="west"/>
+#                 <item value="in"/>
+#                 <item value="out"/>
+#             </enumeration>
+#         </field>
+#         <field name="z_alias" type="NX_CHAR">
+#             <doc>
+#                  Name or alias assigned to the z-axis base vector,
+#                  e.g. shortest edge.
+#             </doc>
+#         </field>
+#         <field name="z_direction" type="NX_CHAR">
+#             <doc>
+#                  Direction of the positively pointing z-axis base vector of
+#                  the sample surface reference frame. We assume the configuration
+#                  is inspected by looking towards the sample surface from a position
+#                  that is located behind the detector. For further information consult
+#                  also the help info for the xaxis_direction field.
+#             </doc>
+#             <enumeration>
+#                 <item value="undefined"/>
+#                 <item value="north"/>
+#                 <item value="east"/>
+#                 <item value="south"/>
+#                 <item value="west"/>
+#                 <item value="in"/>
+#                 <item value="out"/>
+#             </enumeration>
+#         </field>
+#     </group>
+#     <group name="detector_reference_frameID" type="NXcoordinate_system">
+#         <doc>
+#              Details about the detector reference frame for a specific detector.
+#         </doc>
+#         <attribute name="detector" type="NX_CHAR">
+#             <doc>
+#                  Reference to the specifically named :ref:`NXdetector` instance
+#                  for which these conventions in this :ref:`NXprocess` group apply
+#                  (e.g. /entry1/instrument/detector1).
+#             </doc>
+#         </attribute>
+#         <field name="type" type="NX_CHAR">
+#             <doc>
+#                  Type of coordinate system/reference frame used for
+#                  identifying positions in detector space Xd, Yd, Zd,
+#                  according to DOI: 10.1016/j.matchar.2016.04.008.
+#             </doc>
+#             <enumeration>
+#                 <item value="undefined"/>
+#                 <item value="cartesian"/>
+#             </enumeration>
+#         </field>
+#         <field name="handedness" type="NX_CHAR">
+#             <doc>
+#                  Handedness of the coordinate system if it is a Cartesian.
+#             </doc>
+#             <enumeration>
+#                 <item value="right_handed"/>
+#                 <item value="left_handed"/>
+#             </enumeration>
+#         </field>
+#         <field name="origin" type="NX_CHAR">
+#             <doc>
+#                  Where is the origin of the detector space reference
+#                  frame located. This is the location of Xd = 0, Yd = 0, Zd = 0.
+#                  Assume regions-of-interest in this reference frame form a
+#                  rectangle or cuboid.
+#                  Edges are interpreted by inspecting the direction of their
+#                  outer unit normals (which point either parallel or antiparallel)
+#                  along respective base vector direction of the reference frame.
+#             </doc>
+#             <enumeration>
+#                 <item value="undefined"/>
+#                 <item value="front_top_left"/>
+#                 <item value="front_top_right"/>
+#                 <item value="front_bottom_right"/>
+#                 <item value="front_bottom_left"/>
+#                 <item value="back_top_left"/>
+#                 <item value="back_top_right"/>
+#                 <item value="back_bottom_right"/>
+#                 <item value="back_bottom_left"/>
+#             </enumeration>
+#         </field>
+#         <field name="x_alias" type="NX_CHAR">
+#             <doc>
+#                  Name or alias assigned to the x-axis base vector,
+#                  e.g. longest edge as some landmark on the detector.
+#             </doc>
+#         </field>
+#         <field name="x_direction" type="NX_CHAR">
+#             <doc>
+#                  Direction of the positively pointing x-axis base vector of
+#                  the detector space reference frame. We assume the configuration
+#                  is inspected by looking towards the sample surface from a
+#                  position that is located behind the detector.
+#                  Different tools assume that different strategies can be used
+#                  and are perceived as differently convenient to enter
+#                  details about coordinate system definitions. In this ELN users
+#                  have to possibility to fill in what they assume is sufficient to
+#                  define the coordinate system directions unambiguously.
+#                  Software which works with this user input needs to offer parsing
+#                  capabilities which detect conflicting input and warn accordingly.
+#             </doc>
+#             <enumeration>
+#                 <item value="undefined"/>
+#                 <item value="north"/>
+#                 <item value="east"/>
+#                 <item value="south"/>
+#                 <item value="west"/>
+#                 <item value="in"/>
+#                 <item value="out"/>
+#             </enumeration>
+#         </field>
+#         <field name="y_alias" type="NX_CHAR">
+#             <doc>
+#                  Name or alias assigned to the x-axis base vector,
+#                  e.g. long edge as some landmark on the detector.
+#             </doc>
+#         </field>
+#         <field name="y_direction" type="NX_CHAR">
+#             <doc>
+#                  Direction of the positively pointing y-axis base vector of
+#                  the detector space reference frame. We assume the configuration
+#                  is inspected by looking towards the sample surface from a
+#                  position that is located behind the detector.
+#                  For further information consult also the help info for the
+#                  xaxis_direction field.
+#             </doc>
+#             <enumeration>
+#                 <item value="undefined"/>
+#                 <item value="north"/>
+#                 <item value="east"/>
+#                 <item value="south"/>
+#                 <item value="west"/>
+#                 <item value="in"/>
+#                 <item value="out"/>
+#             </enumeration>
+#         </field>
+#         <field name="z_alias" type="NX_CHAR">
+#             <doc>
+#                  Name or alias assigned to the x-axis base vector,
+#                  e.g. short edge as some landmark on the detector.
+#             </doc>
+#         </field>
+#         <field name="z_direction" type="NX_CHAR">
+#             <doc>
+#                  Direction of the positively pointing z-axis base vector of
+#                  the detector space reference frame. We assume the configuration
+#                  is inspected by looking towards the sample surface from a
+#                  position that is located behind the detector.
+#                  For further information consult also the help info for the
+#                  xaxis_direction field.
+#             </doc>
+#             <enumeration>
+#                 <item value="undefined"/>
+#                 <item value="north"/>
+#                 <item value="east"/>
+#                 <item value="south"/>
+#                 <item value="west"/>
+#                 <item value="in"/>
+#                 <item value="out"/>
+#             </enumeration>
+#         </field>
+#     </group>
+#     <!--conventions specific for EBSD-->
+#     <group type="NXem_conventions_ebsd"/>
+#     <!--conventions specific for EBSD-->
+# </definition>


### PR DESCRIPTION
Fixes #143.

- [x] in TRANSFORMATIONS depends_on, one can place either ".", or the path to an NX_coordinate_system
- [x] in NXcoordinate_system, there is a depends_on, and TRANSFORMATION field
- [x] if a depends_on attribute or field links to a NXcoordinate_system, it should pick the respective depends_on field in that class, and apply the specified TRANSFORMATIONS
- [x] NX_coordinate_system_set contains NXcoordinate_systems
- [ ] add example to doc of NXcoordinate_system_set with multiple NX_coordinate_system(s) and their transformations -> shall be handled in #235 

EDIT: an example for converting from one CS to another by using `NXcoordinate_system/(NXtransformations)` can be found [here](https://github.com/FAIRmat-NFDI/pynxtools-xps/blob/4e4107b7505ca0513d99d99b4159e36cd64b947c/examples/coordinate_system/vms-cs-fixed.nxs).