### PR TITLE
Add a reference to NXmpes from NXarpes

### DIFF
--- a/applications/NXarpes.nxdl.xml
+++ b/applications/NXarpes.nxdl.xml
@@ -29,7 +29,7 @@
          
          This definition is a legacy support for older NXarpes experiments.
          There is, however, a newer definition to collect data &amp; metadata
-         for general photoemission experiments, called :ref:`NXmpes`.
+         for general photoemission experiments, called :ref:`NXmpes_arpes`.
     </doc>
     <group type="NXentry">
         <attribute name="entry">

--- a/applications/NXarpes.nxdl.xml
+++ b/applications/NXarpes.nxdl.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl" ?>
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format
-# 
-# Copyright (C) 2012-2022 NeXus International Advisory Committee (NIAC)
-# 
+#
+# Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+#
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -21,114 +21,133 @@
 #
 # For further information, see http://www.nexusformat.org
 -->
-<definition name="NXarpes" extends="NXobject" type="group"
-	    category="application"
-	    xmlns="http://definition.nexusformat.org/nxdl/3.1"
-	    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	    xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
-	    >
-  <doc>
-    This is an application definition for angular resolved photo electron spectroscopy.
-    
-    It has been drawn up with hemispherical electron analysers in mind. 
-  </doc>
-  <group type="NXentry">
-    <attribute name="entry">
-      <doc>
-        NeXus convention is to use "entry1", "entry2", ... 
-        for analysis software to locate each entry.
-      </doc>
-    </attribute>
-    <field name="title" type="NX_CHAR"/>
-    <field name="start_time" type="NX_DATE_TIME"/>
-    <field name="definition">
-      <doc>Official NeXus NXDL schema to which this file conforms.</doc>
-      <enumeration>
-        <item value="NXarpes"></item>
-      </enumeration>
-    </field>
-    <group type="NXinstrument">
-      <group type="NXsource">
-        <field name="type" type="NX_CHAR"/>
-        <field name="name" type="NX_CHAR"/>
-        <field name="probe">
-          <enumeration>
-            <item value="x-ray"/>
-          </enumeration>
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXarpes" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+    <doc>
+         This is an application definition for angular resolved photo electron spectroscopy.
+         
+         It has been drawn up with hemispherical electron analysers in mind.
+         
+         This definition is a legacy support for older NXarpes experiments.
+         There is, however, a newer definition to collect data &amp; metadata
+         for general photoemission experiments, called NXmpes.
+    </doc>
+    <group type="NXentry">
+        <attribute name="entry">
+            <doc>
+                 NeXus convention is to use "entry1", "entry2", ...
+                 for analysis software to locate each entry.
+            </doc>
+        </attribute>
+        <field name="title" type="NX_CHAR"/>
+        <field name="start_time" type="NX_DATE_TIME"/>
+        <field name="definition">
+            <doc>
+                 Official NeXus NXDL schema to which this file conforms.
+            </doc>
+            <enumeration>
+                <item value="NXarpes"/>
+            </enumeration>
         </field>
-      </group>
-      <group type="NXmonochromator" name="monochromator">
-        <field name="energy" type="NX_NUMBER" units="NX_ENERGY"/>
-      </group>
-      <group type="NXdetector" name="analyser">
-        <field name="data" type="NX_NUMBER" />
-        <field name="lens_mode" type="NX_CHAR">
-          <doc>setting for the electron analyser lens</doc>
-        </field>
-        <field name="acquisition_mode">
-          <enumeration>
-            <item value="swept"/>
-            <item value="fixed"/>
-          </enumeration>
-        </field>
-        <field name="entrance_slit_shape">
-          <enumeration>
-            <item value="curved"/>
-            <item value="straight"/>
-          </enumeration>
-        </field>
-        <field name="entrance_slit_setting" type="NX_NUMBER" units="NX_ANY">
-          <doc>dial setting of the entrance slit</doc>
-        </field>
-        <field name="entrance_slit_size" type="NX_NUMBER" units="NX_LENGTH">
-          <doc>size of the entrance slit</doc>
-        </field>
-        <field name="pass_energy" type="NX_NUMBER" units="NX_ENERGY">
-          <doc>energy of the electrons on the mean path of the analyser</doc>
-        </field>
-        <field name="time_per_channel" type="NX_NUMBER" units="NX_TIME">
-          <doc>todo: define more clearly</doc>
-        </field>
-        <field name="angles" type="NX_NUMBER" units="NX_ANGLE">
-          <doc>
-            Angular axis of the analyser data
-            which dimension the axis applies to is defined
-            using the normal NXdata methods.
-          </doc>
-        </field>
-        <field name="energies" type="NX_NUMBER" units="NX_ENERGY">
-          <doc>
-            Energy axis of the analyser data
-            which dimension the axis applies to is defined
-            using the normal NXdata methods.
-          </doc>
-        </field>
-        <field name="sensor_size" type="NX_INT">
-          <doc>number of raw active elements in each dimension</doc>
-          <dimensions rank="1">
-          	<dim index="1" value="2" />
-          </dimensions>
-        </field>
-        <field name="region_origin" type="NX_INT">
-          <doc>origin of rectangular region selected for readout</doc>
-          <dimensions rank="1">
-          	<dim index="1" value="2" />
-          </dimensions>
-        </field>
-        <field name="region_size" type="NX_INT">
-          <doc>size of rectangular region selected for readout</doc>
-          <dimensions rank="1" >
-          	<dim index="1" value="2" />
-          </dimensions>
-        </field>
-      </group>
+        <group type="NXinstrument">
+            <group type="NXsource">
+                <field name="type" type="NX_CHAR"/>
+                <field name="name" type="NX_CHAR"/>
+                <field name="probe">
+                    <enumeration>
+                        <item value="x-ray"/>
+                    </enumeration>
+                </field>
+            </group>
+            <group type="NXmonochromator" name="monochromator">
+                <field name="energy" type="NX_NUMBER" units="NX_ENERGY"/>
+            </group>
+            <group type="NXdetector" name="analyser">
+                <field name="data" type="NX_NUMBER"/>
+                <field name="lens_mode" type="NX_CHAR">
+                    <doc>
+                         setting for the electron analyser lens
+                    </doc>
+                </field>
+                <field name="acquisition_mode">
+                    <enumeration>
+                        <item value="swept"/>
+                        <item value="fixed"/>
+                    </enumeration>
+                </field>
+                <field name="entrance_slit_shape">
+                    <enumeration>
+                        <item value="curved"/>
+                        <item value="straight"/>
+                    </enumeration>
+                </field>
+                <field name="entrance_slit_setting" type="NX_NUMBER" units="NX_ANY">
+                    <doc>
+                         dial setting of the entrance slit
+                    </doc>
+                </field>
+                <field name="entrance_slit_size" type="NX_NUMBER" units="NX_LENGTH">
+                    <doc>
+                         size of the entrance slit
+                    </doc>
+                </field>
+                <field name="pass_energy" type="NX_NUMBER" units="NX_ENERGY">
+                    <doc>
+                         energy of the electrons on the mean path of the analyser
+                    </doc>
+                </field>
+                <field name="time_per_channel" type="NX_NUMBER" units="NX_TIME">
+                    <doc>
+                         todo: define more clearly
+                    </doc>
+                </field>
+                <field name="angles" type="NX_NUMBER" units="NX_ANGLE">
+                    <doc>
+                         Angular axis of the analyser data
+                         which dimension the axis applies to is defined
+                         using the normal NXdata methods.
+                    </doc>
+                </field>
+                <field name="energies" type="NX_NUMBER" units="NX_ENERGY">
+                    <doc>
+                         Energy axis of the analyser data
+                         which dimension the axis applies to is defined
+                         using the normal NXdata methods.
+                    </doc>
+                </field>
+                <field name="sensor_size" type="NX_INT">
+                    <doc>
+                         number of raw active elements in each dimension
+                    </doc>
+                    <dimensions rank="1">
+                        <dim index="1" value="2"/>
+                    </dimensions>
+                </field>
+                <field name="region_origin" type="NX_INT">
+                    <doc>
+                         origin of rectangular region selected for readout
+                    </doc>
+                    <dimensions rank="1">
+                        <dim index="1" value="2"/>
+                    </dimensions>
+                </field>
+                <field name="region_size" type="NX_INT">
+                    <doc>
+                         size of rectangular region selected for readout
+                    </doc>
+                    <dimensions rank="1">
+                        <dim index="1" value="2"/>
+                    </dimensions>
+                </field>
+            </group>
+        </group>
+        <group type="NXsample">
+            <field name="name" type="NX_CHAR">
+                <doc>
+                     Descriptive name of sample
+                </doc>
+            </field>
+            <field name="temperature" type="NX_NUMBER" units="NX_TEMPERATURE"/>
+        </group>
+        <group type="NXdata"/>
     </group>
-    <group type="NXsample">
-      <field name="name" type="NX_CHAR">
-        <doc>Descriptive name of sample</doc>
-      </field>
-      <field name="temperature" type="NX_NUMBER" units="NX_TEMPERATURE"/>
-    </group>
-    <group type="NXdata"/>
-  </group>
 </definition>

--- a/applications/NXarpes.nxdl.xml
+++ b/applications/NXarpes.nxdl.xml
@@ -29,7 +29,8 @@
          
          This definition is a legacy support for older NXarpes experiments.
          There is, however, a newer definition to collect data &amp; metadata
-         for general photoemission experiments, called :ref:`NXmpes_arpes`.
+         for general photoemission experiments, called :ref:NXmpes,
+         as well as a specialization for ARPES experiments, called :ref:NXmpes_arpes."
     </doc>
     <group type="NXentry">
         <attribute name="entry">

--- a/applications/NXarpes.nxdl.xml
+++ b/applications/NXarpes.nxdl.xml
@@ -29,7 +29,7 @@
          
          This definition is a legacy support for older NXarpes experiments.
          There is, however, a newer definition to collect data &amp; metadata
-         for general photoemission experiments, called NXmpes.
+         for general photoemission experiments, called :ref:`NXmpes`.
     </doc>
     <group type="NXentry">
         <attribute name="entry">

--- a/applications/nyaml/NXarpes.yaml
+++ b/applications/nyaml/NXarpes.yaml
@@ -6,7 +6,7 @@ doc: |
 
   This definition is a legacy support for older NXarpes experiments.
   There is, however, a newer definition to collect data & metadata
-  for general photoemission experiments, called NXmpes.
+  for general photoemission experiments, called :ref:`NXmpes`.
 type: group
 NXarpes(NXobject):
   (NXentry):

--- a/applications/nyaml/NXarpes.yaml
+++ b/applications/nyaml/NXarpes.yaml
@@ -3,6 +3,10 @@ doc: |
   This is an application definition for angular resolved photo electron spectroscopy.
   
   It has been drawn up with hemispherical electron analysers in mind.
+
+  This definition is a legacy support for older NXarpes experiments.
+  There is, however, a newer definition to collect data & metadata
+  for general photoemission experiments, called NXmpes.
 type: group
 NXarpes(NXobject):
   (NXentry):

--- a/applications/nyaml/NXarpes.yaml
+++ b/applications/nyaml/NXarpes.yaml
@@ -3,10 +3,11 @@ doc: |
   This is an application definition for angular resolved photo electron spectroscopy.
   
   It has been drawn up with hemispherical electron analysers in mind.
-
+  
   This definition is a legacy support for older NXarpes experiments.
   There is, however, a newer definition to collect data & metadata
-  for general photoemission experiments, called :ref:`NXmpes_arpes`.
+  for general photoemission experiments, called :ref:NXmpes,
+  as well as a specialization for ARPES experiments, called :ref:NXmpes_arpes."
 type: group
 NXarpes(NXobject):
   (NXentry):
@@ -93,14 +94,14 @@ NXarpes(NXobject):
     (NXdata):
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 31232b8eac61f1e491926e74795efc8930591197ca40ea19d78788a866e7c6bf
-# <?xml version="1.0" encoding="UTF-8"?>
-# <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl" ?>
+# e784cdaecf56854c79a01b60711ee9c499ac4c8d12e5d7f72651309e8663baa3
+# <?xml version='1.0' encoding='UTF-8'?>
+# <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
 # # NeXus - Neutron and X-ray Common Data Format
-# # 
-# # Copyright (C) 2012-2022 NeXus International Advisory Committee (NIAC)
-# # 
+# #
+# # Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+# #
 # # This library is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU Lesser General Public
 # # License as published by the Free Software Foundation; either
@@ -117,114 +118,134 @@ NXarpes(NXobject):
 # #
 # # For further information, see http://www.nexusformat.org
 # -->
-# <definition name="NXarpes" extends="NXobject" type="group"
-# 	    category="application"
-# 	    xmlns="http://definition.nexusformat.org/nxdl/3.1"
-# 	    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-# 	    xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
-# 	    >
-#   <doc>
-#     This is an application definition for angular resolved photo electron spectroscopy.
-#     
-#     It has been drawn up with hemispherical electron analysers in mind. 
-#   </doc>
-#   <group type="NXentry">
-#     <attribute name="entry">
-#       <doc>
-#         NeXus convention is to use "entry1", "entry2", ... 
-#         for analysis software to locate each entry.
-#       </doc>
-#     </attribute>
-#     <field name="title" type="NX_CHAR"/>
-#     <field name="start_time" type="NX_DATE_TIME"/>
-#     <field name="definition">
-#       <doc>Official NeXus NXDL schema to which this file conforms.</doc>
-#       <enumeration>
-#         <item value="NXarpes"></item>
-#       </enumeration>
-#     </field>
-#     <group type="NXinstrument">
-#       <group type="NXsource">
-#         <field name="type" type="NX_CHAR"/>
-#         <field name="name" type="NX_CHAR"/>
-#         <field name="probe">
-#           <enumeration>
-#             <item value="x-ray"/>
-#           </enumeration>
+# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXarpes" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+#     <doc>
+#          This is an application definition for angular resolved photo electron spectroscopy.
+#          
+#          It has been drawn up with hemispherical electron analysers in mind.
+#          
+#          This definition is a legacy support for older NXarpes experiments.
+#          There is, however, a newer definition to collect data &amp; metadata
+#          for general photoemission experiments, called :ref:NXmpes,
+#          as well as a specialization for ARPES experiments, called :ref:NXmpes_arpes."
+#     </doc>
+#     <group type="NXentry">
+#         <attribute name="entry">
+#             <doc>
+#                  NeXus convention is to use "entry1", "entry2", ...
+#                  for analysis software to locate each entry.
+#             </doc>
+#         </attribute>
+#         <field name="title" type="NX_CHAR"/>
+#         <field name="start_time" type="NX_DATE_TIME"/>
+#         <field name="definition">
+#             <doc>
+#                  Official NeXus NXDL schema to which this file conforms.
+#             </doc>
+#             <enumeration>
+#                 <item value="NXarpes"/>
+#             </enumeration>
 #         </field>
-#       </group>
-#       <group type="NXmonochromator" name="monochromator">
-#         <field name="energy" type="NX_NUMBER" units="NX_ENERGY"/>
-#       </group>
-#       <group type="NXdetector" name="analyser">
-#         <field name="data" type="NX_NUMBER" />
-#         <field name="lens_mode" type="NX_CHAR">
-#           <doc>setting for the electron analyser lens</doc>
-#         </field>
-#         <field name="acquisition_mode">
-#           <enumeration>
-#             <item value="swept"/>
-#             <item value="fixed"/>
-#           </enumeration>
-#         </field>
-#         <field name="entrance_slit_shape">
-#           <enumeration>
-#             <item value="curved"/>
-#             <item value="straight"/>
-#           </enumeration>
-#         </field>
-#         <field name="entrance_slit_setting" type="NX_NUMBER" units="NX_ANY">
-#           <doc>dial setting of the entrance slit</doc>
-#         </field>
-#         <field name="entrance_slit_size" type="NX_NUMBER" units="NX_LENGTH">
-#           <doc>size of the entrance slit</doc>
-#         </field>
-#         <field name="pass_energy" type="NX_NUMBER" units="NX_ENERGY">
-#           <doc>energy of the electrons on the mean path of the analyser</doc>
-#         </field>
-#         <field name="time_per_channel" type="NX_NUMBER" units="NX_TIME">
-#           <doc>todo: define more clearly</doc>
-#         </field>
-#         <field name="angles" type="NX_NUMBER" units="NX_ANGLE">
-#           <doc>
-#             Angular axis of the analyser data
-#             which dimension the axis applies to is defined
-#             using the normal NXdata methods.
-#           </doc>
-#         </field>
-#         <field name="energies" type="NX_NUMBER" units="NX_ENERGY">
-#           <doc>
-#             Energy axis of the analyser data
-#             which dimension the axis applies to is defined
-#             using the normal NXdata methods.
-#           </doc>
-#         </field>
-#         <field name="sensor_size" type="NX_INT">
-#           <doc>number of raw active elements in each dimension</doc>
-#           <dimensions rank="1">
-#           	<dim index="1" value="2" />
-#           </dimensions>
-#         </field>
-#         <field name="region_origin" type="NX_INT">
-#           <doc>origin of rectangular region selected for readout</doc>
-#           <dimensions rank="1">
-#           	<dim index="1" value="2" />
-#           </dimensions>
-#         </field>
-#         <field name="region_size" type="NX_INT">
-#           <doc>size of rectangular region selected for readout</doc>
-#           <dimensions rank="1" >
-#           	<dim index="1" value="2" />
-#           </dimensions>
-#         </field>
-#       </group>
+#         <group type="NXinstrument">
+#             <group type="NXsource">
+#                 <field name="type" type="NX_CHAR"/>
+#                 <field name="name" type="NX_CHAR"/>
+#                 <field name="probe">
+#                     <enumeration>
+#                         <item value="x-ray"/>
+#                     </enumeration>
+#                 </field>
+#             </group>
+#             <group type="NXmonochromator" name="monochromator">
+#                 <field name="energy" type="NX_NUMBER" units="NX_ENERGY"/>
+#             </group>
+#             <group type="NXdetector" name="analyser">
+#                 <field name="data" type="NX_NUMBER"/>
+#                 <field name="lens_mode" type="NX_CHAR">
+#                     <doc>
+#                          setting for the electron analyser lens
+#                     </doc>
+#                 </field>
+#                 <field name="acquisition_mode">
+#                     <enumeration>
+#                         <item value="swept"/>
+#                         <item value="fixed"/>
+#                     </enumeration>
+#                 </field>
+#                 <field name="entrance_slit_shape">
+#                     <enumeration>
+#                         <item value="curved"/>
+#                         <item value="straight"/>
+#                     </enumeration>
+#                 </field>
+#                 <field name="entrance_slit_setting" type="NX_NUMBER" units="NX_ANY">
+#                     <doc>
+#                          dial setting of the entrance slit
+#                     </doc>
+#                 </field>
+#                 <field name="entrance_slit_size" type="NX_NUMBER" units="NX_LENGTH">
+#                     <doc>
+#                          size of the entrance slit
+#                     </doc>
+#                 </field>
+#                 <field name="pass_energy" type="NX_NUMBER" units="NX_ENERGY">
+#                     <doc>
+#                          energy of the electrons on the mean path of the analyser
+#                     </doc>
+#                 </field>
+#                 <field name="time_per_channel" type="NX_NUMBER" units="NX_TIME">
+#                     <doc>
+#                          todo: define more clearly
+#                     </doc>
+#                 </field>
+#                 <field name="angles" type="NX_NUMBER" units="NX_ANGLE">
+#                     <doc>
+#                          Angular axis of the analyser data
+#                          which dimension the axis applies to is defined
+#                          using the normal NXdata methods.
+#                     </doc>
+#                 </field>
+#                 <field name="energies" type="NX_NUMBER" units="NX_ENERGY">
+#                     <doc>
+#                          Energy axis of the analyser data
+#                          which dimension the axis applies to is defined
+#                          using the normal NXdata methods.
+#                     </doc>
+#                 </field>
+#                 <field name="sensor_size" type="NX_INT">
+#                     <doc>
+#                          number of raw active elements in each dimension
+#                     </doc>
+#                     <dimensions rank="1">
+#                         <dim index="1" value="2"/>
+#                     </dimensions>
+#                 </field>
+#                 <field name="region_origin" type="NX_INT">
+#                     <doc>
+#                          origin of rectangular region selected for readout
+#                     </doc>
+#                     <dimensions rank="1">
+#                         <dim index="1" value="2"/>
+#                     </dimensions>
+#                 </field>
+#                 <field name="region_size" type="NX_INT">
+#                     <doc>
+#                          size of rectangular region selected for readout
+#                     </doc>
+#                     <dimensions rank="1">
+#                         <dim index="1" value="2"/>
+#                     </dimensions>
+#                 </field>
+#             </group>
+#         </group>
+#         <group type="NXsample">
+#             <field name="name" type="NX_CHAR">
+#                 <doc>
+#                      Descriptive name of sample
+#                 </doc>
+#             </field>
+#             <field name="temperature" type="NX_NUMBER" units="NX_TEMPERATURE"/>
+#         </group>
+#         <group type="NXdata"/>
 #     </group>
-#     <group type="NXsample">
-#       <field name="name" type="NX_CHAR">
-#         <doc>Descriptive name of sample</doc>
-#       </field>
-#       <field name="temperature" type="NX_NUMBER" units="NX_TEMPERATURE"/>
-#     </group>
-#     <group type="NXdata"/>
-#   </group>
 # </definition>

--- a/applications/nyaml/NXarpes.yaml
+++ b/applications/nyaml/NXarpes.yaml
@@ -6,7 +6,7 @@ doc: |
 
   This definition is a legacy support for older NXarpes experiments.
   There is, however, a newer definition to collect data & metadata
-  for general photoemission experiments, called :ref:`NXmpes`.
+  for general photoemission experiments, called :ref:`NXmpes_arpes`.
 type: group
 NXarpes(NXobject):
   (NXentry):


### PR DESCRIPTION
This is a proposal to refer NXmpes from NXarpes to avoid confusion for users of the definition.
This relates to #74 (i.e., whether it should refer to NXphotoemission _or_ NXmpes).

It might also be a point for discussion whether NXarpes is a legacy version and newer experiments should be collected in NXmpes. Do we also support converting NXarpes to NXmpes/NXmpes_arpes?