### PR TITLE
MPES: rename lens_mode according to base class

### DIFF
--- a/contributed_definitions/NXmpes.nxdl.xml
+++ b/contributed_definitions/NXmpes.nxdl.xml
@@ -248,7 +248,7 @@
                             <item value="non-dispersive"/>
                         </enumeration>
                     </field>
-                    <field name="mode" recommended="true"/>
+                    <field name="lens_mode" recommended="true"/>
                     <field name="projection" recommended="true"/>
                     <field name="angular_acceptance" type="NX_FLOAT" optional="true"/>
                     <field name="spatial_acceptance" type="NX_FLOAT" optional="true"/>

--- a/contributed_definitions/nyaml/NXmpes.yaml
+++ b/contributed_definitions/nyaml/NXmpes.yaml
@@ -203,7 +203,7 @@ NXmpes(NXobject):
             doc: |
               Scheme of the electron collection column.
             enumeration: [angular dispersive, spatial dispersive, momentum dispersive, non-dispersive]
-          mode:
+          lens_mode:
             exists: recommended
           projection:
             exists: recommended
@@ -753,7 +753,7 @@ NXmpes(NXobject):
             @energy_depends: 'entry/process/energy_calibration'
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 0858e4c498e1d031bbe35e761fdbb30b8db75d6725f7b39b320d53a90ec23587
+# a126a001ba56386d0e4cb7731e73e48921961202950cf53ecc142cc30fa79728
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -1004,7 +1004,7 @@ NXmpes(NXobject):
 #                             <item value="non-dispersive"/>
 #                         </enumeration>
 #                     </field>
-#                     <field name="mode" recommended="true"/>
+#                     <field name="lens_mode" recommended="true"/>
 #                     <field name="projection" recommended="true"/>
 #                     <field name="angular_acceptance" type="NX_FLOAT" optional="true"/>
 #                     <field name="spatial_acceptance" type="NX_FLOAT" optional="true"/>


### PR DESCRIPTION
In the NXcollection_column base class, we have the field `lens_mode`, but in NXmpes it is just called `mode`. 