### PR TITLE
Makes sensor scan an appdef again

### DIFF
--- a/contributed_definitions/NXsensor_scan.nxdl.xml
+++ b/contributed_definitions/NXsensor_scan.nxdl.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format
-# 
-# Copyright (C) 2014-2022 NeXus International Advisory Committee (NIAC)
-# 
+#
+# Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+#
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -21,7 +21,7 @@
 #
 # For further information, see http://www.nexusformat.org
 -->
-<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" name="NXsensor_scan" extends="NXobject" type="group" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXsensor_scan" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
     <symbols>
         <doc>
              Variables used to set a common size for collected sensor data.
@@ -123,7 +123,7 @@
                      NXsensor groups. Similarly, seperate NXsensor groups are used to store the readings from each
                      measurement sensor.
                      
-                     For example, in a temperature-dependent IV measurement, the temperature and voltage must be 
+                     For example, in a temperature-dependent IV measurement, the temperature and voltage must be
                      present as independently scanned controllers and the current sensor must also be present with
                      its readings.
                 </doc>

--- a/contributed_definitions/nyaml/NXsensor_scan.yaml
+++ b/contributed_definitions/nyaml/NXsensor_scan.yaml
@@ -1,4 +1,4 @@
-category: base
+category: application
 doc: |
   Application definition for a generic scan using sensors.
   


### PR DESCRIPTION
`NXsensor_scan` was accidentally converted to a base class in https://github.com/FAIRmat-NFDI/nexus_definitions/commit/db6632204654dcc1f7052a130a85b1fd18b6f137.

This breaks `NXiv_temp` and `NXsts`.
This PR reverts the change.