### PR TITLE
Add first NXraman Version

### DIFF
--- a/contributed_definitions/NXbeam_device.nxdl.xml
+++ b/contributed_definitions/NXbeam_device.nxdl.xml
@@ -21,6 +21,9 @@
 #
 # For further information, see http://www.nexusformat.org
 -->
+<!--
+This beam device properites shall later be integrated into NXsource, NXdetector, etc
+i.e. each different beam device.-->
 <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" name="NXbeam_device" extends="NXobject" type="group" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
     <doc>
          Properties of generic beam device in an experimental setup.
@@ -53,6 +56,12 @@
              For example, if a group of devices is used for second harmonic generation,
              all these devices have the group name "second harmonic generation".
              Is used for simplified setup vizualization (or description?).
+        </doc>
+    </field>
+    <field name="device">
+        <doc>
+             This is the name of the NeXus device like a NXdetector, a NXmonochromator or
+             NXsource.
         </doc>
     </field>
     <group type="NXtransformations">

--- a/contributed_definitions/NXbeam_device.nxdl.xml
+++ b/contributed_definitions/NXbeam_device.nxdl.xml
@@ -58,12 +58,14 @@ i.e. each different beam device.-->
              Is used for simplified setup vizualization (or description?).
         </doc>
     </field>
-    <field name="device">
+    <attribute name="device" type="NX_CHAR" recommended="true">
         <doc>
-             This is the name of the NeXus device like a NXdetector, a NXmonochromator or
-             NXsource.
+             Link to the NeXus device like a NXdetector, a NXmonochromator or NXsource.
+             
+             For example:
+               @device: 'entry/instrument/laser_source'
         </doc>
-    </field>
+    </attribute>
     <group type="NXtransformations">
         <doc>
              Location and orientation of the device. Note that even a

--- a/contributed_definitions/NXopt.nxdl.xml
+++ b/contributed_definitions/NXopt.nxdl.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format
-# 
-# Copyright (C) 2014-2022 NeXus International Advisory Committee (NIAC)
-# 
+#
+# Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+#
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -21,14 +21,16 @@
 #
 # For further information, see http://www.nexusformat.org
 -->
-<!--05/2023
+<!--
+05/2023
 Draft of a NeXus application definition which serves as a template for various
 optical spectroscopy experiments-->
-<!--To do:
+<!--
+To do:
 [ ] Check base classes (NXbeam_path + base classes used by it)
 [ ] Harmonize NXopt and NXellipsometry
 [ ] Fix dimensions and ranks-->
-<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" name="NXopt" extends="NXobject" type="group" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXopt" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
     <symbols>
         <doc>
              Variables used throughout the document, e.g. dimensions or parameters.
@@ -277,18 +279,12 @@ optical spectroscopy experiments-->
                     </doc>
                 </field>
             </group>
-            <group type="NXbeam_path">
+            <group type="NXbeam_device" recommended="true">
+                <field name="previous_devices"/>
+            </group>
+            <group type="NXbeam" optional="true">
                 <doc>
-                     Describes an arrangement of optical or other elements, e.g. the beam
-                     path between the light source and the sample, or between the sample
-                     and the detector unit (including the sources and detectors
-                     themselves).
-                     
-                     If a beam splitter (i.e. a device that splits the incoming beam into
-                     two or more beams) is part of the beam path, two or more NXbeam_path
-                     fields may be needed to fully describe the beam paths and the correct
-                     sequence of the beam path elements.
-                     Use as many beam paths as needed to describe the setup.
+                     Beam characteristics between two beam_devices.
                 </doc>
             </group>
             <field name="angle_of_incidence" type="NX_NUMBER" units="NX_ANGLE">

--- a/contributed_definitions/NXraman.nxdl.xml
+++ b/contributed_definitions/NXraman.nxdl.xml
@@ -1,0 +1,378 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+<!--
+# NeXus - Neutron and X-ray Common Data Format
+#
+# Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# For further information, see http://www.nexusformat.org
+-->
+<!--
+03/2024
+A draft version of a NeXus application definition for Raman spectroscopy.-->
+<!--
+The document has the following main elements:
+- Instrument used and is characteristics
+- Sample: Properties of the sample
+- Data: measured data, data errors
+- Derived parameters: e.g. extra parameters derived in the measurement software-->
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXraman" extends="NXopt" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+    <symbols>
+        <doc>
+             Variables used throughout the document, e.g. dimensions or parameters.
+        </doc>
+    </symbols>
+    <doc>
+         An application definition for Raman spectrocopy experiments.
+         
+         Information on Raman spectroscopy are provided in:
+         
+         General
+         * Lewis, Ian R.; Edwards, Howell G. M.
+           Handbook of Raman Spectroscopy
+           ISBN 0-8247-0557-2
+         
+         Raman scattering selection rules
+         * Dresselhaus, M. S.; Dresselhaus, G.; Jorio, A.
+           Group Theory - Application to the Physics ofCondensed Matter
+           ISBN 3540328971
+         
+         Semiconductors
+         * Manuel Cardona
+           Light Scattering in Solids I
+           eBook ISBN: 978-3-540-37568-5
+           DOI: https://doi.org/10.1007/978-3-540-37568-5
+         
+         * Manuel Cardona, Gernot Güntherodt
+           Light Scattering in Solids II
+           eBook ISBN:  978-3-540-39075-6
+           DOI: https://doi.org/10.1007/3-540-11380-0
+         
+         * See as well other Books from the "Light Scattering in Solids" series:
+           III: Recent Results
+           IV: Electronic Scattering, Spin Effects, SERS, and Morphic Effects
+           V: Superlattices and Other Microstructures
+           VI: Recent Results, Including High-Tc Superconductivity
+           VII: Crystal-Field and Magnetic Excitations
+           VIII: Fullerenes, Semiconductor Surfaces, Coherent Phonons
+           IX: Novel Materials and Techniques
+         
+         Glasses, Liquids, Gasses, ...
+         
+         Review articles:
+         Stimulated Raman scattering, Coherent anti-Stokes Raman scattering,
+         Surface-enhanced Raman scattering, Tip-enhanced Raman scattering
+         * https://doi.org/10.1186/s11671-019-3039-2
+    </doc>
+    <group type="NXentry">
+        <doc>
+             This is the application definition describing Raman spectroscopy experiments.
+             
+             Such experiments may be as simple a single Raman spectrum from spontanous
+             Raman scattering and range to Raman imaging Raman spectrometer,
+             surface- and tip-enhanced Raman techniques, x-Ray Raman scattering, as well
+             as resonant Raman scattering phenomena or multidimenional Raman spectra (i.e.
+             varying temperature, pressure, electric field, ....)
+             
+             The application definition defines:
+             
+             * elements of the experimental instrument
+             * calibration information if available
+             * parameters used to tune the state of the sample
+             * sample description
+        </doc>
+        <field name="definition">
+            <doc>
+                 An application definition for ellipsometry.
+            </doc>
+            <attribute name="version">
+                <doc>
+                     Version number to identify which definition of this application
+                     definition was used for this entry/data.
+                </doc>
+            </attribute>
+            <attribute name="url">
+                <doc>
+                     URL where to find further material (documentation, examples) relevant
+                     to the application definition.
+                </doc>
+            </attribute>
+            <enumeration>
+                <item value="NXraman"/>
+            </enumeration>
+        </field>
+        <field name="experiment_description">
+            <doc>
+                 An optional free-text description of the experiment.
+                 
+                 However, details of the experiment should be defined in the specific
+                 fields of this application definition rather than in this experiment
+                 description.
+            </doc>
+        </field>
+        <field name="experiment_type">
+            <doc>
+                 Specify the type of Raman measurement.
+            </doc>
+            <enumeration>
+                <item value="in situ Raman spectroscopy"/>
+                <item value="resonant Raman spectroscopy"/>
+                <item value="non-resonant Raman spectroscopy"/>
+                <item value="Raman imaging"/>
+                <item value="Tip-enhanced Raman spectroscopy (TERS)"/>
+                <item value="Surface-enhanced Raman spectroscopy (SERS)"/>
+                <item value="Surface plasmon polariton enhanced Raman scattering (SPPERS)"/>
+                <item value="Hyper Raman spectroscopy (HRS)"/>
+                <item value="Stimulated Raman spectroscopy (SRS)"/>
+                <item value="Inverse Raman spectroscopy (IRS)"/>
+                <item value="Coherent anti-Stokes Raman spectroscopy (CARS)"/>
+            </enumeration>
+        </field>
+        <group type="NXinstrument">
+            <doc>
+                 Properties of the Instruments used for Raman instrumeasurements.
+            </doc>
+            <field name="company" optional="true">
+                <doc>
+                     Name of the company which build the instrument.
+                </doc>
+            </field>
+            <field name="construction_year" type="NX_DATE_TIME" optional="true">
+                <doc>
+                     ISO8601 date when the instrument was constructed.
+                     UTC offset should be specified.
+                </doc>
+            </field>
+            <group name="software" type="NXprocess">
+                <field name="program">
+                    <doc>
+                         Commercial or otherwise defined given name of the program that was
+                         used to generate the result file(s) with measured data and metadata.
+                         This program converts the measured signals to Raman data. If
+                         home written, one can provide the actual steps in the NOTE subfield
+                         here.
+                    </doc>
+                </field>
+            </group>
+            <field name="incident_source_wavelength" type="NX_NUMBER" units="NX_LENGTH">
+                <doc>
+                     Which indicent wavelength was used for e.g. a laser source.
+                     For multiple excitation wavelengths, please state the specific discret
+                     wavelengths (i.e. for dye laser) or the specific contnious range
+                     (i.e for white light laser source)
+                </doc>
+            </field>
+            <field name="scattering_configuration" type="NX_CHAR">
+                <!--
+unit: NX_LENGTH
+-->
+                <doc>
+                     Scattering configuration as defined by the porto notation by three
+                     states, which are othogonal to each other. Example: z(xx)z for
+                     parallel polarized backscattering configuration.
+                     
+                     See:
+                     https://www.cryst.ehu.es/cgi-bin/cryst/programs/nph-doc-raman
+                     
+                     A(BC)D
+                     
+                     A = The propagation direction of the incident light (k_i)
+                     B = The polarization direction of the incident light (E_i)
+                     C = The polarization direction of the scattered light (E_s)
+                     D = The propagation direction of the scattered light (k_s)
+                     
+                     An orthogonal base is assumed.
+                     Linear polarized light is displayed by e.g. "x","y" or "z"
+                     Unpolarized light is displayed by "."
+                </doc>
+                <attribute name="non_orthogonal_base_vectors" type="NX_NUMBER">
+                    <!--
+unit: NX_LENGTH
+-->
+                    <doc>
+                         Scattering configuration as defined by the porto notation given by
+                         respective vectors.
+                         
+                         Vectors in the porto notation are defined as for A, B, C, D above.
+                         Linear light polarization is assumed.
+                    </doc>
+                    <dimensions rank="2">
+                        <doc>
+                             3 x 4 Matrix, which lists the porto notation vectors A, B, C, D.
+                             A has to be perpendicular to B and C perpendicular to D.
+                        </doc>
+                        <dim index="1" value="4"/>
+                        <dim index="2" value="3"/>
+                    </dimensions>
+                </attribute>
+            </field>
+            <group type="NXbeam_path">
+                <group name="light_source" type="NXsource">
+                    <doc>
+                         Specify the used light source. Multiple selection possible.
+                    </doc>
+                    <field name="source_type">
+                        <enumeration>
+                            <item value="laser"/>
+                            <item value="dye-laser"/>
+                            <item value="broadband tunable light source"/>
+                            <item value="other"/>
+                        </enumeration>
+                    </field>
+                </group>
+                <group name="incident_light_optics" type="NXlens_opt" recommended="true">
+                    <doc>
+                         This is the optical element used for the incident light in the Raman
+                         scattering process.
+                         
+                         This can be for example a simple lens or microscope
+                         objective.
+                    </doc>
+                    <field name="type">
+                        <enumeration>
+                            <item value="objective"/>
+                            <item value="lens"/>
+                            <item value="glass fiber"/>
+                            <item value="none"/>
+                            <item value="other"/>
+                        </enumeration>
+                    </field>
+                    <field name="numerical_aperture" type="NX_NUMBER">
+                        <doc>
+                             The numerical aperture of the used incident light optics.
+                        </doc>
+                    </field>
+                </group>
+                <group name="scattered_light_optics" type="NXlens_opt" optional="true">
+                    <doc>
+                         This is the optical element used for the incident light in the Raman
+                         scattering process.
+                         
+                         This can be for example a simple lens or microscope
+                         objective.
+                    </doc>
+                    <attribute name="is_same_as_for_incident_light"/>
+                    <field name="type">
+                        <enumeration>
+                            <item value="objective"/>
+                            <item value="lens"/>
+                            <item value="glass fiber"/>
+                            <item value="none"/>
+                            <item value="other"/>
+                        </enumeration>
+                    </field>
+                    <field name="numerical_aperture" type="NX_NUMBER">
+                        <doc>
+                             The numerical aperture of the used incident light optics.
+                        </doc>
+                    </field>
+                </group>
+                <group type="NXdetector">
+                    <doc>
+                         Properties of the detector used. Integration time is the count time
+                         field, or the real time field. See their definition.
+                    </doc>
+                </group>
+                <group name="polarization_manipulator_N" type="NXwaveplate" optional="true">
+                    <doc>
+                         Device for the manipulation of the state of light which is a half wave
+                         plate.
+                    </doc>
+                    <field name="type">
+                        <enumeration>
+                            <item value="objective"/>
+                            <item value="lens"/>
+                            <item value="glass fiber"/>
+                            <item value="none"/>
+                            <item value="other"/>
+                        </enumeration>
+                    </field>
+                </group>
+                <field name="polarization_filter" type="NX_CHAR" optional="true">
+                    <doc>
+                         Physical principle of the polarization filter used to create a
+                         defined incident or scattered light state.
+                    </doc>
+                    <enumeration>
+                        <item value="Polarization by Fresnel reflection"/>
+                        <item value="Birefringent polarizers"/>
+                        <item value="Thin film polarizers"/>
+                        <item value="Wire-grid polarizers"/>
+                        <item value="other"/>
+                    </enumeration>
+                </field>
+                <field name="specific_polarization_filter_type" type="NX_CHAR">
+                    <doc>
+                         Specific name or type of the polarizer used.
+                         
+                         For example: Glan-Thompson, Glan-Taylor, Rochon Prism, Wollaston
+                         Polarizer...
+                    </doc>
+                </field>
+                <field name="laser_line_filter_type" optional="true">
+                    <doc>
+                         Type of laserline filter used to supress the laser, if measurements
+                         close to the laserline are performed.
+                    </doc>
+                    <enumeration>
+                        <item value="Long-pass filter"/>
+                        <item value="Short-pass filter"/>
+                        <item value="Notch Filter"/>
+                    </enumeration>
+                </field>
+                <field name="laser_line_filter_steepness" type="NX_float">
+                    <doc>
+                         Steepness of the filter by normal incidence of the light as defined
+                         by 10% - 90% transmittance of the respective filter, given in cm^-1.
+                    </doc>
+                </field>
+                <!--for a notch filter in principle two steepness have to be defined..-->
+                <field name="laser_line_filter_strength" type="NX_float">
+                    <doc>
+                         Designed supression strength of the laserline at optimal condition
+                         given in orders of magnitude.
+                    </doc>
+                </field>
+                <group name="spectrometer" type="NXmonochromator" optional="true">
+                    <doc>
+                         The spectroscope element of the ellipsometer before the detector,
+                         but often integrated to form one closed unit. Information on the
+                         dispersive element can be specified in the subfield GRATING. Note
+                         that different gratings might be used for different wavelength
+                         ranges. The dispersion of the grating for each wavelength range can
+                         be stored in grating_dispersion.
+                    </doc>
+                </group>
+            </group>
+        </group>
+        <group type="NXsample"/>
+        <group name="data_collection" type="NXprocess">
+            <field name="data_type">
+                <doc>
+                     Select which type of data was recorded, for example a simple spectrum
+                     with intensity vs. Raman shift, CCD image or a set of spectra with
+                     probe, reference and background signals for pump beam on and off.
+                </doc>
+                <enumeration>
+                    <item value="Integrated single spectrum"/>
+                    <item value="CCD image"/>
+                    <item value="Probe + Background + Reference for Pump-on and Pump-off (i.e. for FSRS)"/>
+                </enumeration>
+            </field>
+        </group>
+    </group>
+</definition>

--- a/contributed_definitions/NXraman.nxdl.xml
+++ b/contributed_definitions/NXraman.nxdl.xml
@@ -189,23 +189,33 @@ The document has the following main elements:
                 <item value="Stimulated Raman spectroscopy (SRS)"/>
                 <item value="Inverse Raman spectroscopy (IRS)"/>
                 <item value="Coherent anti-Stokes Raman spectroscopy (CARS)"/>
+                <item value="other"/>
             </enumeration>
+        </field>
+        <field name="experiment_type_other" optional="true">
+            <doc>
+                 If the experiment_type is `other`, a name should be specified here.
+            </doc>
         </field>
         <group type="NXinstrument">
             <doc>
-                 Properties of the Instruments used for Raman instrumeasurements.
+                 Metadata of the setup, its optical elements and physical properites which
+                 defines the Raman measurement.
             </doc>
-            <field name="company" optional="true">
+            <group name="device_information" type="NXfabrication" recommended="true">
                 <doc>
                      Name of the company which build the instrument.
                 </doc>
-            </field>
-            <field name="construction_year" type="NX_DATE_TIME" optional="true">
-                <doc>
-                     ISO8601 date when the instrument was constructed.
-                     UTC offset should be specified.
-                </doc>
-            </field>
+                <field name="vendor" recommended="true"/>
+                <field name="model" recommended="true"/>
+                <field name="identifier" recommended="true"/>
+                <field name="construction_year" type="NX_DATE_TIME" optional="true">
+                    <doc>
+                         ISO8601 date when the instrument was constructed.
+                         UTC offset should be specified.
+                    </doc>
+                </field>
+            </group>
             <group name="software" type="NXprocess">
                 <field name="program">
                     <doc>
@@ -269,16 +279,96 @@ unit: NX_LENGTH
                     </dimensions>
                 </attribute>
             </field>
+            <!--In the following - Auxillary NXbeam_devices are defined, to enable a
+beam path description of the setup, while using the up now available
+Nexus definitions for source, detector, monochromator, ...-->
             <group name="opt_source" type="NXbeam_device">
                 <doc>
-                     beam device instance of the optical source.
+                     This is the beam device instance of the optical source.
+                     
+                     It enables a description of the optical setup via NXbeam_devices to 
+                     be able to connect the components. This connection is then a "beam path".
+                     
+                     The properties of the source are located in a NXsource group.
+                     [Note: the idea is to incorporate later NXbeam_device into NXsource]
+                     
+                     This is done similarily with NXlens_opt, NXdetector, NXwaveplate and NXmonochromator.
                 </doc>
-                <field name="device">
+                <attribute name="device">
                     <doc>
                          It should contain the name of the Nexus source group.
                     </doc>
-                </field>
+                </attribute>
             </group>
+            <group name="incident_light_optics" type="NXbeam_device">
+                <doc>
+                     Beam device instance of the incident light optics.
+                </doc>
+                <attribute name="device">
+                    <doc>
+                         It should contain the name of the "incident_light_lens(NXlens_opt)" group
+                    </doc>
+                </attribute>
+            </group>
+            <group name="scattered_light_optics" type="NXbeam_device">
+                <doc>
+                     Beam device instance of the scattered light optics.
+                </doc>
+                <attribute name="device">
+                    <doc>
+                         It should contain the name of the "scattered_light_lens(NXlens_opt)" group
+                    </doc>
+                </attribute>
+            </group>
+            <group name="opt_detector" type="NXbeam_device">
+                <doc>
+                     Properties of the detector to link it via NXbeam_device to other beam
+                     elements
+                </doc>
+                <attribute name="device">
+                    <doc>
+                         It should contain the name of the Nexus detector group
+                    </doc>
+                </attribute>
+            </group>
+            <group name="polarization_manipulator_NAME" type="NXbeam_device" optional="true">
+                <doc>
+                     Link to the device, that it can be used to generate a beam path via
+                     NXbeam_device. The string &gt;NAME&lt; in the name of this NXbeam_device
+                     has to identical to &gt;NAME&lt; in waveplate_NAME(NXwaveplate).
+                </doc>
+                <attribute name="device">
+                    <doc>
+                         This should contain the name for each halfwave plate used in the
+                         NXwaveplate group.
+                    </doc>
+                </attribute>
+            </group>
+            <group name="opt_monochromator" type="NXbeam_device" optional="true">
+                <doc>
+                     Dispersive element to create e.g. an energetic resolution used in the 
+                     measurement.
+                </doc>
+                <attribute name="device">
+                    <doc>
+                         It should contain the name of the Nexus Monochromator group
+                    </doc>
+                </attribute>
+            </group>
+            <group name="sample_as_beam_element" type="NXbeam_device">
+                <doc>
+                     Enables beam path description of the sample in the setup.
+                     it in a beam path.
+                </doc>
+                <attribute name="device">
+                    <doc>
+                         Contains the link to the sample.
+                    </doc>
+                </attribute>
+            </group>
+            <!--End of Auxillary NXbeam_devices-->
+            <!--Below:
+generic NeXus definition for optical elements of the setup-->
             <group type="NXsource">
                 <doc>
                      Light source with arbitrary choice of name. This shall be referenced
@@ -293,26 +383,20 @@ unit: NX_LENGTH
                     </enumeration>
                 </field>
             </group>
-            <group name="incident_light_optics" type="NXbeam_device">
+            <group type="NXdetector">
                 <doc>
-                     Beam device instance of the incident light optics.
+                     Detector with arbitrary choice of the name, which shall be referenced
+                     by the detector(NXbeam_device).
                 </doc>
-                <field name="device">
-                    <doc>
-                         It should contain the name of the "incident_light_lens(NXlens_opt)" group
-                    </doc>
-                </field>
             </group>
-            <group name="scattered_light_optics" type="NXbeam_device">
+            <group type="NXmonochromator">
                 <doc>
-                     Beam device instance of the scattered light optics.
+                     Monochromator with arbitrary choice of the name, which shall be referenced
+                     by the spectrometer(NXbeam_device).
                 </doc>
-                <field name="device">
-                    <doc>
-                         It should contain the name of the "scattered_light_lens(NXlens_opt)" group
-                    </doc>
-                </field>
             </group>
+            <!--Below:
+NeXus definition derived optical elements of the setup-->
             <group name="incident_light_lens" type="NXlens_opt" recommended="true">
                 <doc>
                      This is the optical element used for the incident light in the Raman
@@ -359,36 +443,6 @@ unit: NX_LENGTH
                     </doc>
                 </field>
             </group>
-            <group name="opt_detector" type="NXbeam_device">
-                <doc>
-                     Properties of the detector to link it via NXbeam_device to other beam
-                     elements
-                </doc>
-                <field name="device">
-                    <doc>
-                         It should contain the name of the Nexus detector group
-                    </doc>
-                </field>
-            </group>
-            <group type="NXdetector">
-                <doc>
-                     Detector with arbitrary choice of the name, which shall be referenced
-                     by the detector(NXbeam_device).
-                </doc>
-            </group>
-            <group name="polarization_manipulator_NAME" type="NXbeam_device" optional="true">
-                <doc>
-                     Link to the device, that it can be used to generate a beam path via
-                     NXbeam_device. The string &gt;NAME&lt; in the name of this NXbeam_device
-                     has to identical to &gt;NAME&lt; in waveplate_NAME(NXwaveplate).
-                </doc>
-                <field name="device">
-                    <doc>
-                         This should contain the name for each halfwave plate used in the
-                         NXwaveplate group.
-                    </doc>
-                </field>
-            </group>
             <group name="waveplate_NAME" type="NXwaveplate">
                 <doc>
                      Properties of the device for the manipulation of the state of light which is a half wave
@@ -404,6 +458,8 @@ unit: NX_LENGTH
                     </enumeration>
                 </field>
             </group>
+            <!--Below:
+NXraman specific optical elements-->
             <group name="polarization_filter" type="NXbeam_device">
                 <field name="filter_mechanism" type="NX_CHAR" optional="true">
                     <doc>
@@ -478,36 +534,12 @@ N_spectrum_filter -\-> Number of wavelengths-->
                     </attribute>
                 </field>
             </group>
-            <group name="opt_monochromator" type="NXbeam_device" optional="true">
-                <doc>
-                     Dispersive element to create e.g. an energetic resolution used in the 
-                     measurement.
-                </doc>
-                <field name="device">
-                    <doc>
-                         It should contain the name of the Nexus Monochromator group
-                    </doc>
-                </field>
-            </group>
-            <group type="NXmonochromator">
-                <doc>
-                     Monochromator with arbitrary choice of the name, which shall be referenced
-                     by the spectrometer(NXbeam_device).
-                </doc>
-            </group>
-            <group name="Sample_as_beam_element" type="NXbeam_device">
-                <doc>
-                     Enables beam path description of the sample in the setup.
-                     it in a beam path.
-                </doc>
-                <field name="device">
-                    <doc>
-                         Contains the link to the sample.
-                    </doc>
-                </field>
-            </group>
         </group>
-        <group type="NXsample"/>
+        <group type="NXsample">
+            <field name="name" optional="false"/>
+            <field name="sample_id" recommended="true"/>
+            <field name="chemical_formula" recommended="true"/>
+        </group>
         <group name="data_collection" type="NXprocess">
             <field name="data_type">
                 <doc>

--- a/contributed_definitions/NXraman.nxdl.xml
+++ b/contributed_definitions/NXraman.nxdl.xml
@@ -35,6 +35,52 @@ The document has the following main elements:
         <doc>
              Variables used throughout the document, e.g. dimensions or parameters.
         </doc>
+        <symbol name="N_spectrum">
+            <doc>
+                 Length of the spectrum array (e.g. wavelength or energy) of the measured
+                 data.
+            </doc>
+        </symbol>
+        <symbol name="N_sensors">
+            <doc>
+                 Number of sensors used to measure parameters that influence the sample,
+                 such as temperature or pressure.
+            </doc>
+        </symbol>
+        <symbol name="N_measurements">
+            <doc>
+                 Number of measurements (1st dimension of measured_data array). This is
+                 equal to the number of parameters scanned. For example, if the experiment
+                 was performed at three different temperatures and two different pressures
+                 N_measurements = 2*3 = 6.
+            </doc>
+        </symbol>
+        <symbol name="N_scattering_configurations">
+            <doc>
+                 Number of scattering configurations used in the measurement.
+                 It is 1 for only parallel polarization meausement, 2 for parallel and cross 
+                 polarization measurement or larger, if i.e. the incident and scattered photon
+                 direction is varied.
+            </doc>
+        </symbol>
+        <symbol name="N_observables">
+            <doc>
+                 Number of observables that are saved in a measurement. e.g. one for
+                 intensity, reflectivity or transmittance, two for Psi and Delta etc. This
+                 is equal to the second dimension of the data array 'measured_data' and the
+                 number of column names.
+            </doc>
+        </symbol>
+        <symbol name="N_time">
+            <doc>
+                 Number of time points measured, the length of NXsample/time_points
+            </doc>
+        </symbol>
+        <symbol name="N_spectrum_filter">
+            <doc>
+                 Number of points for a spectral filter used in the setup
+            </doc>
+        </symbol>
     </symbols>
     <doc>
          An application definition for Raman spectrocopy experiments.
@@ -223,89 +269,143 @@ unit: NX_LENGTH
                     </dimensions>
                 </attribute>
             </field>
-            <group type="NXbeam_path">
-                <group name="light_source" type="NXsource">
+            <group name="opt_source" type="NXbeam_device">
+                <doc>
+                     beam device instance of the optical source.
+                </doc>
+                <field name="device">
                     <doc>
-                         Specify the used light source. Multiple selection possible.
+                         It should contain the name of the Nexus source group.
                     </doc>
-                    <field name="source_type">
-                        <enumeration>
-                            <item value="laser"/>
-                            <item value="dye-laser"/>
-                            <item value="broadband tunable light source"/>
-                            <item value="other"/>
-                        </enumeration>
-                    </field>
-                </group>
-                <group name="incident_light_optics" type="NXlens_opt" recommended="true">
+                </field>
+            </group>
+            <group type="NXsource">
+                <doc>
+                     Light source with arbitrary choice of name. This shall be referenced
+                     by source(NXbeam_device)
+                </doc>
+                <field name="source_type">
+                    <enumeration>
+                        <item value="laser"/>
+                        <item value="dye-laser"/>
+                        <item value="broadband tunable light source"/>
+                        <item value="other"/>
+                    </enumeration>
+                </field>
+            </group>
+            <group name="incident_light_optics" type="NXbeam_device">
+                <doc>
+                     Beam device instance of the incident light optics.
+                </doc>
+                <field name="device">
                     <doc>
-                         This is the optical element used for the incident light in the Raman
-                         scattering process.
-                         
-                         This can be for example a simple lens or microscope
-                         objective.
+                         It should contain the name of the "incident_light_lens(NXlens_opt)" group
                     </doc>
-                    <field name="type">
-                        <enumeration>
-                            <item value="objective"/>
-                            <item value="lens"/>
-                            <item value="glass fiber"/>
-                            <item value="none"/>
-                            <item value="other"/>
-                        </enumeration>
-                    </field>
-                    <field name="numerical_aperture" type="NX_NUMBER">
-                        <doc>
-                             The numerical aperture of the used incident light optics.
-                        </doc>
-                    </field>
-                </group>
-                <group name="scattered_light_optics" type="NXlens_opt" optional="true">
+                </field>
+            </group>
+            <group name="scattered_light_optics" type="NXbeam_device">
+                <doc>
+                     Beam device instance of the scattered light optics.
+                </doc>
+                <field name="device">
                     <doc>
-                         This is the optical element used for the incident light in the Raman
-                         scattering process.
-                         
-                         This can be for example a simple lens or microscope
-                         objective.
+                         It should contain the name of the "scattered_light_lens(NXlens_opt)" group
                     </doc>
-                    <attribute name="is_same_as_for_incident_light"/>
-                    <field name="type">
-                        <enumeration>
-                            <item value="objective"/>
-                            <item value="lens"/>
-                            <item value="glass fiber"/>
-                            <item value="none"/>
-                            <item value="other"/>
-                        </enumeration>
-                    </field>
-                    <field name="numerical_aperture" type="NX_NUMBER">
-                        <doc>
-                             The numerical aperture of the used incident light optics.
-                        </doc>
-                    </field>
-                </group>
-                <group type="NXdetector">
+                </field>
+            </group>
+            <group name="incident_light_lens" type="NXlens_opt" recommended="true">
+                <doc>
+                     This is the optical element used for the incident light in the Raman
+                     scattering process.
+                     
+                     This can be for example a simple lens or microscope
+                     objective.
+                </doc>
+                <field name="type">
+                    <enumeration>
+                        <item value="objective"/>
+                        <item value="lens"/>
+                        <item value="glass fiber"/>
+                        <item value="none"/>
+                        <item value="other"/>
+                    </enumeration>
+                </field>
+                <field name="numerical_aperture" type="NX_NUMBER">
                     <doc>
-                         Properties of the detector used. Integration time is the count time
-                         field, or the real time field. See their definition.
+                         The numerical aperture of the used incident light optics.
                     </doc>
-                </group>
-                <group name="polarization_manipulator_N" type="NXwaveplate" optional="true">
+                </field>
+            </group>
+            <group name="scattered_light_lens" type="NXlens_opt" recommended="true">
+                <doc>
+                     This is the optical element used for the incident light in the Raman
+                     scattering process.
+                     
+                     This can be for example a simple lens or microscope
+                     objective.
+                </doc>
+                <field name="type">
+                    <enumeration>
+                        <item value="objective"/>
+                        <item value="lens"/>
+                        <item value="glass fiber"/>
+                        <item value="none"/>
+                        <item value="other"/>
+                    </enumeration>
+                </field>
+                <field name="numerical_aperture" type="NX_NUMBER">
                     <doc>
-                         Device for the manipulation of the state of light which is a half wave
-                         plate.
+                         The numerical aperture of the used incident light optics.
                     </doc>
-                    <field name="type">
-                        <enumeration>
-                            <item value="objective"/>
-                            <item value="lens"/>
-                            <item value="glass fiber"/>
-                            <item value="none"/>
-                            <item value="other"/>
-                        </enumeration>
-                    </field>
-                </group>
-                <field name="polarization_filter" type="NX_CHAR" optional="true">
+                </field>
+            </group>
+            <group name="opt_detector" type="NXbeam_device">
+                <doc>
+                     Properties of the detector to link it via NXbeam_device to other beam
+                     elements
+                </doc>
+                <field name="device">
+                    <doc>
+                         It should contain the name of the Nexus detector group
+                    </doc>
+                </field>
+            </group>
+            <group type="NXdetector">
+                <doc>
+                     Detector with arbitrary choice of the name, which shall be referenced
+                     by the detector(NXbeam_device).
+                </doc>
+            </group>
+            <group name="polarization_manipulator_NAME" type="NXbeam_device" optional="true">
+                <doc>
+                     Link to the device, that it can be used to generate a beam path via
+                     NXbeam_device. The string &gt;NAME&lt; in the name of this NXbeam_device
+                     has to identical to &gt;NAME&lt; in waveplate_NAME(NXwaveplate).
+                </doc>
+                <field name="device">
+                    <doc>
+                         This should contain the name for each halfwave plate used in the
+                         NXwaveplate group.
+                    </doc>
+                </field>
+            </group>
+            <group name="waveplate_NAME" type="NXwaveplate">
+                <doc>
+                     Properties of the device for the manipulation of the state of light which is a half wave
+                     plate.
+                </doc>
+                <field name="type">
+                    <enumeration>
+                        <item value="objective"/>
+                        <item value="lens"/>
+                        <item value="glass fiber"/>
+                        <item value="none"/>
+                        <item value="other"/>
+                    </enumeration>
+                </field>
+            </group>
+            <group name="polarization_filter" type="NXbeam_device">
+                <field name="filter_mechanism" type="NX_CHAR" optional="true">
                     <doc>
                          Physical principle of the polarization filter used to create a
                          defined incident or scattered light state.
@@ -322,44 +422,89 @@ unit: NX_LENGTH
                     <doc>
                          Specific name or type of the polarizer used.
                          
-                         For example: Glan-Thompson, Glan-Taylor, Rochon Prism, Wollaston
+                         Free text, for example: Glan-Thompson, Glan-Taylor, Rochon Prism, Wollaston
                          Polarizer...
                     </doc>
                 </field>
-                <field name="laser_line_filter_type" optional="true">
+            </group>
+            <group name="spectral_filter_N" type="NXbeam_device">
+                <field name="filter_type" optional="true">
                     <doc>
                          Type of laserline filter used to supress the laser, if measurements
                          close to the laserline are performed.
                     </doc>
                     <enumeration>
-                        <item value="Long-pass filter"/>
-                        <item value="Short-pass filter"/>
-                        <item value="Notch Filter"/>
+                        <item value="long-pass filter"/>
+                        <item value="short-pass filter"/>
+                        <item value="Notch filter"/>
+                        <item value="reflection filter"/>
+                        <item value="neutral density filter"/>
+                        <item value="other"/>
                     </enumeration>
                 </field>
-                <field name="laser_line_filter_steepness" type="NX_float">
+                <field name="intended_use" optional="true">
                     <doc>
-                         Steepness of the filter by normal incidence of the light as defined
-                         by 10% - 90% transmittance of the respective filter, given in cm^-1.
+                         Type of laserline filter used to supress the laser, if measurements
+                         close to the laserline are performed.
+                    </doc>
+                    <enumeration>
+                        <item value="laser line cleanup"/>
+                        <item value="raylight line removal"/>
+                        <item value="spectral filtering"/>
+                        <item value="intensity manipulation"/>
+                        <item value="other"/>
+                    </enumeration>
+                </field>
+                <field name="filter_characteristics" type="NX_NUMBER" optional="true">
+                    <doc>
+                         Properties of the spectral filter such as wavelength dependent Transmission
+                         or reflectivity.
+                    </doc>
+                    <dimensions rank="2">
+                        <dim index="1" value="2"/>
+                        <dim index="2" value="N_spectrum_filter"/>
+                    </dimensions>
+                    <!--2 -> [Wavelength, Transmission]
+N_spectrum_filter -\-> Number of wavelengths-->
+                    <attribute name="characteristics_type" optional="true">
+                        <doc>
+                             Which property is used to form the spectral properties of light,
+                             i.e. transmission or reflection properties.
+                        </doc>
+                        <enumeration>
+                            <item value="transmission"/>
+                            <item value="reflection"/>
+                        </enumeration>
+                    </attribute>
+                </field>
+            </group>
+            <group name="opt_monochromator" type="NXbeam_device" optional="true">
+                <doc>
+                     Dispersive element to create e.g. an energetic resolution used in the 
+                     measurement.
+                </doc>
+                <field name="device">
+                    <doc>
+                         It should contain the name of the Nexus Monochromator group
                     </doc>
                 </field>
-                <!--for a notch filter in principle two steepness have to be defined..-->
-                <field name="laser_line_filter_strength" type="NX_float">
+            </group>
+            <group type="NXmonochromator">
+                <doc>
+                     Monochromator with arbitrary choice of the name, which shall be referenced
+                     by the spectrometer(NXbeam_device).
+                </doc>
+            </group>
+            <group name="Sample_as_beam_element" type="NXbeam_device">
+                <doc>
+                     Enables beam path description of the sample in the setup.
+                     it in a beam path.
+                </doc>
+                <field name="device">
                     <doc>
-                         Designed supression strength of the laserline at optimal condition
-                         given in orders of magnitude.
+                         Contains the link to the sample.
                     </doc>
                 </field>
-                <group name="spectrometer" type="NXmonochromator" optional="true">
-                    <doc>
-                         The spectroscope element of the ellipsometer before the detector,
-                         but often integrated to form one closed unit. Information on the
-                         dispersive element can be specified in the subfield GRATING. Note
-                         that different gratings might be used for different wavelength
-                         ranges. The dispersion of the grating for each wavelength range can
-                         be stored in grating_dispersion.
-                    </doc>
-                </group>
             </group>
         </group>
         <group type="NXsample"/>

--- a/contributed_definitions/NXraman.nxdl.xml
+++ b/contributed_definitions/NXraman.nxdl.xml
@@ -22,7 +22,12 @@
 # For further information, see http://www.nexusformat.org
 -->
 <!--
-03/2024
+N_incident_wavelengths: |
+ Number of the incident wavelen
+N_incident_beams: |
+ to be done....-->
+<!--
+04/2024
 A draft version of a NeXus application definition for Raman spectroscopy.-->
 <!--
 The document has the following main elements:
@@ -146,7 +151,7 @@ The document has the following main elements:
         </doc>
         <field name="definition">
             <doc>
-                 An application definition for ellipsometry.
+                 An application definition for Raman spectrsocopy.
             </doc>
             <attribute name="version">
                 <doc>
@@ -164,7 +169,7 @@ The document has the following main elements:
                 <item value="NXraman"/>
             </enumeration>
         </field>
-        <field name="experiment_description">
+        <field name="experiment_description" optional="true">
             <doc>
                  An optional free-text description of the experiment.
                  
@@ -209,15 +214,15 @@ The document has the following main elements:
                 <field name="vendor" recommended="true"/>
                 <field name="model" recommended="true"/>
                 <field name="identifier" recommended="true"/>
-                <field name="construction_year" type="NX_DATE_TIME" optional="true">
-                    <doc>
-                         ISO8601 date when the instrument was constructed.
-                         UTC offset should be specified.
-                    </doc>
-                </field>
             </group>
-            <group name="software" type="NXprocess">
-                <field name="program">
+            <field name="construction_year" type="NX_DATE_TIME" optional="true">
+                <doc>
+                     ISO8601 date when the instrument was constructed.
+                     UTC offset should be specified.
+                </doc>
+            </field>
+            <group name="software" type="NXfabrication" recommended="true">
+                <field name="program_name">
                     <doc>
                          Commercial or otherwise defined given name of the program that was
                          used to generate the result file(s) with measured data and metadata.
@@ -227,18 +232,15 @@ The document has the following main elements:
                     </doc>
                 </field>
             </group>
-            <field name="incident_source_wavelength" type="NX_NUMBER" units="NX_LENGTH">
+            <field name="incident_beam_wavelength" type="NX_NUMBER" units="NX_WAVELENGTH">
                 <doc>
-                     Which indicent wavelength was used for e.g. a laser source.
+                     Which wavelength the incident beam has, e.g. a single wavelength for a laser source.
                      For multiple excitation wavelengths, please state the specific discret
                      wavelengths (i.e. for dye laser) or the specific contnious range
-                     (i.e for white light laser source)
+                     (i.e for white light laser source).
                 </doc>
             </field>
             <field name="scattering_configuration" type="NX_CHAR">
-                <!--
-unit: NX_LENGTH
--->
                 <doc>
                      Scattering configuration as defined by the porto notation by three
                      states, which are othogonal to each other. Example: z(xx)z for
@@ -257,8 +259,9 @@ unit: NX_LENGTH
                      An orthogonal base is assumed.
                      Linear polarized light is displayed by e.g. "x","y" or "z"
                      Unpolarized light is displayed by "."
+                     For non-orthogonal vectors, use the attribute porto_notation_vectors.
                 </doc>
-                <attribute name="non_orthogonal_base_vectors" type="NX_NUMBER">
+                <attribute name="porto_notation_vectors" type="NX_NUMBER">
                     <!--
 unit: NX_LENGTH
 -->
@@ -282,7 +285,7 @@ unit: NX_LENGTH
             <!--In the following - Auxillary NXbeam_devices are defined, to enable a
 beam path description of the setup, while using the up now available
 Nexus definitions for source, detector, monochromator, ...-->
-            <group name="opt_source" type="NXbeam_device">
+            <group name="opt_source" type="NXbeam_device" optional="true">
                 <doc>
                      This is the beam device instance of the optical source.
                      
@@ -300,7 +303,7 @@ Nexus definitions for source, detector, monochromator, ...-->
                     </doc>
                 </attribute>
             </group>
-            <group name="incident_light_optics" type="NXbeam_device">
+            <group name="incident_light_optics" type="NXbeam_device" optional="true">
                 <doc>
                      Beam device instance of the incident light optics.
                 </doc>
@@ -310,7 +313,7 @@ Nexus definitions for source, detector, monochromator, ...-->
                     </doc>
                 </attribute>
             </group>
-            <group name="scattered_light_optics" type="NXbeam_device">
+            <group name="scattered_light_optics" type="NXbeam_device" optional="true">
                 <doc>
                      Beam device instance of the scattered light optics.
                 </doc>
@@ -320,7 +323,7 @@ Nexus definitions for source, detector, monochromator, ...-->
                     </doc>
                 </attribute>
             </group>
-            <group name="opt_detector" type="NXbeam_device">
+            <group name="opt_detector" type="NXbeam_device" optional="true">
                 <doc>
                      Properties of the detector to link it via NXbeam_device to other beam
                      elements
@@ -355,7 +358,7 @@ Nexus definitions for source, detector, monochromator, ...-->
                     </doc>
                 </attribute>
             </group>
-            <group name="sample_as_beam_element" type="NXbeam_device">
+            <group name="sample_as_beam_element" type="NXbeam_device" optional="true">
                 <doc>
                      Enables beam path description of the sample in the setup.
                      it in a beam path.
@@ -366,9 +369,7 @@ Nexus definitions for source, detector, monochromator, ...-->
                     </doc>
                 </attribute>
             </group>
-            <!--End of Auxillary NXbeam_devices-->
-            <!--Below:
-generic NeXus definition for optical elements of the setup-->
+            <!--Below: generic NeXus definition for optical elements of the setup-->
             <group type="NXsource">
                 <doc>
                      Light source with arbitrary choice of name. This shall be referenced
@@ -382,28 +383,66 @@ generic NeXus definition for optical elements of the setup-->
                         <item value="other"/>
                     </enumeration>
                 </field>
+                <field name="source_polarization">
+                    <doc>
+                         The type of light polarization procuded by the source.
+                    </doc>
+                    <enumeration>
+                        <item value="linear"/>
+                        <item value="unpolarized"/>
+                        <item value="circular"/>
+                        <item value="elliptically"/>
+                        <item value="other"/>
+                    </enumeration>
+                </field>
+                <group name="device_information" type="NXfabrication">
+                    <doc>
+                         Details about the specific device information if available.
+                    </doc>
+                </group>
             </group>
             <group type="NXdetector">
                 <doc>
                      Detector with arbitrary choice of the name, which shall be referenced
                      by the detector(NXbeam_device).
                 </doc>
+                <group name="device_information" type="NXfabrication">
+                    <doc>
+                         Details about the specific device information if available.
+                    </doc>
+                </group>
+                <field name="data_type" optional="true">
+                    <doc>
+                         Select which type of data was recorded, for example a simple spectrum
+                         with intensity vs. Raman shift, CCD image or a set of spectra with
+                         probe, reference and background signals for pump beam on and off.
+                    </doc>
+                    <enumeration>
+                        <item value="Integrated single spectrum"/>
+                        <item value="CCD image"/>
+                        <item value="Probe + Background + Reference for Pump-on and Pump-off (i.e. for FSRS)"/>
+                    </enumeration>
+                </field>
             </group>
-            <group type="NXmonochromator">
+            <group type="NXmonochromator" optional="true">
                 <doc>
                      Monochromator with arbitrary choice of the name, which shall be referenced
                      by the spectrometer(NXbeam_device).
                 </doc>
+                <group name="device_information" type="NXfabrication">
+                    <doc>
+                         Details about the specific device information if available.
+                    </doc>
+                </group>
             </group>
             <!--Below:
 NeXus definition derived optical elements of the setup-->
-            <group name="incident_light_lens" type="NXlens_opt" recommended="true">
+            <group name="incident_light_lens" type="NXlens_opt" optional="true">
                 <doc>
-                     This is the optical element used for the incident light in the Raman
-                     scattering process.
+                     This is the optical element used to focus the incident light in the
+                     Raman scattering process.
                      
-                     This can be for example a simple lens or microscope
-                     objective.
+                     This can be for example a simple lens or microscope objective.
                 </doc>
                 <field name="type">
                     <enumeration>
@@ -419,14 +458,23 @@ NeXus definition derived optical elements of the setup-->
                          The numerical aperture of the used incident light optics.
                     </doc>
                 </field>
+                <field name="magnification">
+                    <doc>
+                         Magnification of the lens.
+                    </doc>
+                </field>
+                <group name="device_information" type="NXfabrication">
+                    <doc>
+                         Details about the optical component, if available.
+                    </doc>
+                </group>
             </group>
-            <group name="scattered_light_lens" type="NXlens_opt" recommended="true">
+            <group name="scattered_light_lens" type="NXlens_opt" optional="true">
                 <doc>
-                     This is the optical element used for the incident light in the Raman
-                     scattering process.
+                     This is the optical element used to collect the scattered light in the
+                     Raman scattering process.
                      
-                     This can be for example a simple lens or microscope
-                     objective.
+                     This can be for example a simple lens or microscope objective.
                 </doc>
                 <field name="type">
                     <enumeration>
@@ -442,25 +490,29 @@ NeXus definition derived optical elements of the setup-->
                          The numerical aperture of the used incident light optics.
                     </doc>
                 </field>
-            </group>
-            <group name="waveplate_NAME" type="NXwaveplate">
-                <doc>
-                     Properties of the device for the manipulation of the state of light which is a half wave
-                     plate.
-                </doc>
-                <field name="type">
-                    <enumeration>
-                        <item value="objective"/>
-                        <item value="lens"/>
-                        <item value="glass fiber"/>
-                        <item value="none"/>
-                        <item value="other"/>
-                    </enumeration>
+                <field name="magnification">
+                    <doc>
+                         Magnification of the lens.
+                    </doc>
                 </field>
+                <group name="device_information" type="NXfabrication">
+                    <doc>
+                         Details about the optical component, if available.
+                    </doc>
+                </group>
             </group>
-            <!--Below:
-NXraman specific optical elements-->
-            <group name="polarization_filter" type="NXbeam_device">
+            <group name="waveplate_N" type="NXwaveplate" optional="true">
+                <doc>
+                     Properties of a wave plate to manipulate the polarization state of light.
+                </doc>
+                <group name="device_information" type="NXfabrication">
+                    <doc>
+                         Details about the optical component, if available.
+                    </doc>
+                </group>
+            </group>
+            <!--Below: NXraman specific optical elements-->
+            <group name="polarization_filter" type="NXbeam_device" optional="true">
                 <field name="filter_mechanism" type="NX_CHAR" optional="true">
                     <doc>
                          Physical principle of the polarization filter used to create a
@@ -474,7 +526,7 @@ NXraman specific optical elements-->
                         <item value="other"/>
                     </enumeration>
                 </field>
-                <field name="specific_polarization_filter_type" type="NX_CHAR">
+                <field name="specific_polarization_filter_type" type="NX_CHAR" optional="true">
                     <doc>
                          Specific name or type of the polarizer used.
                          
@@ -482,8 +534,16 @@ NXraman specific optical elements-->
                          Polarizer...
                     </doc>
                 </field>
+                <group name="device_information" type="NXfabrication">
+                    <doc>
+                         Details about the optical component, if available.
+                    </doc>
+                </group>
             </group>
-            <group name="spectral_filter_N" type="NXbeam_device">
+            <group name="spectral_filter_N" type="NXbeam_device" optional="true">
+                <doc>
+                     Spectral filter used to modify properties of the scattered or incident light.
+                </doc>
                 <field name="filter_type" optional="true">
                     <doc>
                          Type of laserline filter used to supress the laser, if measurements
@@ -533,26 +593,17 @@ N_spectrum_filter -\-> Number of wavelengths-->
                         </enumeration>
                     </attribute>
                 </field>
+                <group name="device_information" type="NXfabrication">
+                    <doc>
+                         Details about the optical component, if available.
+                    </doc>
+                </group>
             </group>
         </group>
         <group type="NXsample">
             <field name="name" optional="false"/>
             <field name="sample_id" recommended="true"/>
             <field name="chemical_formula" recommended="true"/>
-        </group>
-        <group name="data_collection" type="NXprocess">
-            <field name="data_type">
-                <doc>
-                     Select which type of data was recorded, for example a simple spectrum
-                     with intensity vs. Raman shift, CCD image or a set of spectra with
-                     probe, reference and background signals for pump beam on and off.
-                </doc>
-                <enumeration>
-                    <item value="Integrated single spectrum"/>
-                    <item value="CCD image"/>
-                    <item value="Probe + Background + Reference for Pump-on and Pump-off (i.e. for FSRS)"/>
-                </enumeration>
-            </field>
         </group>
     </group>
 </definition>

--- a/contributed_definitions/NXraman.nxdl.xml
+++ b/contributed_definitions/NXraman.nxdl.xml
@@ -42,16 +42,19 @@ The document has the following main elements:
          Information on Raman spectroscopy are provided in:
          
          General
+         
          * Lewis, Ian R.; Edwards, Howell G. M.
            Handbook of Raman Spectroscopy
            ISBN 0-8247-0557-2
          
          Raman scattering selection rules
+         
          * Dresselhaus, M. S.; Dresselhaus, G.; Jorio, A.
            Group Theory - Application to the Physics ofCondensed Matter
            ISBN 3540328971
          
          Semiconductors
+         
          * Manuel Cardona
            Light Scattering in Solids I
            eBook ISBN: 978-3-540-37568-5

--- a/contributed_definitions/nyaml/NXbeam_device.yaml
+++ b/contributed_definitions/nyaml/NXbeam_device.yaml
@@ -34,9 +34,14 @@ NXbeam_device(NXobject):
       all these devices have the group name "second harmonic generation".
       Is used for simplified setup vizualization (or description?).
 
-  device:
+  \@device:
+    type: NX_CHAR
+    exists: recommended
     doc: |
-      This is the name of the NeXus device like a NXdetector, a NXmonochromator or NXsource.
+      Link to the NeXus device like a NXdetector, a NXmonochromator or NXsource.
+
+      For example:
+        @device: 'entry/instrument/laser_source'
 
 
   (NXtransformations):

--- a/contributed_definitions/nyaml/NXbeam_device.yaml
+++ b/contributed_definitions/nyaml/NXbeam_device.yaml
@@ -7,6 +7,9 @@ doc: |
   can be described here with its experimental position and relationship
   to the other beam devices in the setup.
 
+# This beam device properites shall later be integrated into NXsource, NXdetector, etc
+# i.e. each different beam device.
+
   
 NXbeam_device(NXobject):
 
@@ -30,6 +33,10 @@ NXbeam_device(NXobject):
       For example, if a group of devices is used for second harmonic generation,
       all these devices have the group name "second harmonic generation".
       Is used for simplified setup vizualization (or description?).
+
+  device:
+    doc: |
+      This is the name of the NeXus device like a NXdetector, a NXmonochromator or NXsource.
 
 
   (NXtransformations):

--- a/contributed_definitions/nyaml/NXopt.yaml
+++ b/contributed_definitions/nyaml/NXopt.yaml
@@ -182,18 +182,13 @@ NXopt(NXobject):
         calibration_data_link:
           doc: |
             Link to the NeXus file containing the calibration data and metadata.
-      (NXbeam_path):
+      (NXbeam_device):
+        exists: recommended
+        previous_devices:
+      (NXbeam):
+        exists: optional
         doc: |
-          Describes an arrangement of optical or other elements, e.g. the beam
-          path between the light source and the sample, or between the sample
-          and the detector unit (including the sources and detectors
-          themselves).
-          
-          If a beam splitter (i.e. a device that splits the incoming beam into
-          two or more beams) is part of the beam path, two or more NXbeam_path
-          fields may be needed to fully describe the beam paths and the correct
-          sequence of the beam path elements.
-          Use as many beam paths as needed to describe the setup.
+          Beam characteristics between two beam_devices.
       angle_of_incidence(NX_NUMBER):
         unit: NX_ANGLE
         doc: |

--- a/contributed_definitions/nyaml/NXraman.yaml
+++ b/contributed_definitions/nyaml/NXraman.yaml
@@ -1,0 +1,669 @@
+category: application
+doc: |
+  An application definition for Raman spectrocopy experiments.
+  
+  Information on Raman spectroscopy are provided in:
+  
+  General
+  * Lewis, Ian R.; Edwards, Howell G. M.
+    Handbook of Raman Spectroscopy
+    ISBN 0-8247-0557-2
+  
+  Raman scattering selection rules
+  * Dresselhaus, M. S.; Dresselhaus, G.; Jorio, A.
+    Group Theory - Application to the Physics ofCondensed Matter
+    ISBN 3540328971
+  
+  Semiconductors
+  * Manuel Cardona
+    Light Scattering in Solids I
+    eBook ISBN: 978-3-540-37568-5
+    DOI: https://doi.org/10.1007/978-3-540-37568-5
+  
+  * Manuel Cardona, Gernot Güntherodt
+    Light Scattering in Solids II
+    eBook ISBN:  978-3-540-39075-6
+    DOI: https://doi.org/10.1007/3-540-11380-0
+  
+  * See as well other Books from the "Light Scattering in Solids" series:
+    III: Recent Results
+    IV: Electronic Scattering, Spin Effects, SERS, and Morphic Effects
+    V: Superlattices and Other Microstructures
+    VI: Recent Results, Including High-Tc Superconductivity
+    VII: Crystal-Field and Magnetic Excitations
+    VIII: Fullerenes, Semiconductor Surfaces, Coherent Phonons
+    IX: Novel Materials and Techniques
+  
+  Glasses, Liquids, Gasses, ...
+  
+  Review articles:
+  Stimulated Raman scattering, Coherent anti-Stokes Raman scattering,
+  Surface-enhanced Raman scattering, Tip-enhanced Raman scattering
+  * https://doi.org/10.1186/s11671-019-3039-2
+symbols:
+  doc: |
+    Variables used throughout the document, e.g. dimensions or parameters.
+
+# 03/2024
+# A draft version of a NeXus application definition for Raman spectroscopy.
+
+# The document has the following main elements:
+# - Instrument used and is characteristics
+# - Sample: Properties of the sample
+# - Data: measured data, data errors
+# - Derived parameters: e.g. extra parameters derived in the measurement software
+type: group
+NXraman(NXopt):
+  (NXentry):
+    doc: |
+      This is the application definition describing Raman spectroscopy experiments.
+      
+      Such experiments may be as simple a single Raman spectrum from spontanous
+      Raman scattering and range to Raman imaging Raman spectrometer,
+      surface- and tip-enhanced Raman techniques, x-Ray Raman scattering, as well
+      as resonant Raman scattering phenomena or multidimenional Raman spectra (i.e.
+      varying temperature, pressure, electric field, ....)
+      
+      The application definition defines:
+      
+      * elements of the experimental instrument
+      * calibration information if available
+      * parameters used to tune the state of the sample
+      * sample description
+    definition:
+      doc: |
+        An application definition for ellipsometry.
+      \@version:
+        doc: |
+          Version number to identify which definition of this application
+          definition was used for this entry/data.
+      \@url:
+        doc: |
+          URL where to find further material (documentation, examples) relevant
+          to the application definition.
+      enumeration: [NXraman]
+    experiment_description:
+      doc: |
+        An optional free-text description of the experiment.
+        
+        However, details of the experiment should be defined in the specific
+        fields of this application definition rather than in this experiment
+        description.
+    experiment_type:
+      doc: |
+        Specify the type of Raman measurement.
+      enumeration: [in situ Raman spectroscopy, resonant Raman spectroscopy, non-resonant Raman spectroscopy, Raman imaging, Tip-enhanced Raman spectroscopy (TERS), Surface-enhanced Raman spectroscopy (SERS), Surface plasmon polariton enhanced Raman scattering (SPPERS), Hyper Raman spectroscopy (HRS), Stimulated Raman spectroscopy (SRS), Inverse Raman spectroscopy (IRS), Coherent anti-Stokes Raman spectroscopy (CARS)]
+    (NXinstrument):
+      doc: |
+        Properties of the Instruments used for Raman instrumeasurements.
+      company:
+        exists: optional
+        doc: |
+          Name of the company which build the instrument.
+      construction_year(NX_DATE_TIME):
+        exists: optional
+        doc: |
+          ISO8601 date when the instrument was constructed.
+          UTC offset should be specified.
+      software(NXprocess):
+        program:
+          doc: |
+            Commercial or otherwise defined given name of the program that was
+            used to generate the result file(s) with measured data and metadata.
+            This program converts the measured signals to Raman data. If
+            home written, one can provide the actual steps in the NOTE subfield
+            here.
+      incident_source_wavelength(NX_NUMBER):
+        unit: NX_LENGTH
+        doc: |
+          Which indicent wavelength was used for e.g. a laser source.
+          For multiple excitation wavelengths, please state the specific discret
+          wavelengths (i.e. for dye laser) or the specific contnious range
+          (i.e for white light laser source)
+      scattering_configuration(NX_CHAR):
+        # unit: NX_LENGTH
+        doc: |
+          Scattering configuration as defined by the porto notation by three
+          states, which are othogonal to each other. Example: z(xx)z for
+          parallel polarized backscattering configuration.
+          
+          See:
+          https://www.cryst.ehu.es/cgi-bin/cryst/programs/nph-doc-raman
+          
+          A(BC)D
+          
+          A = The propagation direction of the incident light (k_i)
+          B = The polarization direction of the incident light (E_i)
+          C = The polarization direction of the scattered light (E_s)
+          D = The propagation direction of the scattered light (k_s)
+          
+          An orthogonal base is assumed.
+          Linear polarized light is displayed by e.g. "x","y" or "z"
+          Unpolarized light is displayed by "."
+        \@non_orthogonal_base_vectors(NX_NUMBER):
+          # unit: NX_LENGTH
+          doc: |
+            Scattering configuration as defined by the porto notation given by
+            respective vectors.
+            
+            Vectors in the porto notation are defined as for A, B, C, D above.
+            Linear light polarization is assumed.
+          dimensions:
+            rank: 2
+            doc: |
+              3 x 4 Matrix, which lists the porto notation vectors A, B, C, D.
+              A has to be perpendicular to B and C perpendicular to D.
+            dim: [[1, 4], [2, 3]]
+      (NXbeam_path):
+        light_source(NXsource):
+          doc: |
+            Specify the used light source. Multiple selection possible.
+          source_type:
+            enumeration: [laser, dye-laser, broadband tunable light source, other]
+        incident_light_optics(NXlens_opt):
+          exists: recommended
+          doc: |
+            This is the optical element used for the incident light in the Raman
+            scattering process.
+            
+            This can be for example a simple lens or microscope
+            objective.
+          type:
+            enumeration: [objective, lens, glass fiber, none, other]
+          numerical_aperture(NX_NUMBER):
+            doc: |
+              The numerical aperture of the used incident light optics.
+        scattered_light_optics(NXlens_opt):
+          exists: optional
+          doc: |
+            This is the optical element used for the incident light in the Raman
+            scattering process.
+            
+            This can be for example a simple lens or microscope
+            objective.
+          \@is_same_as_for_incident_light:
+          type:
+            enumeration: [objective, lens, glass fiber, none, other]
+          numerical_aperture(NX_NUMBER):
+            doc: |
+              The numerical aperture of the used incident light optics.
+        (NXdetector):
+          doc: |
+            Properties of the detector used. Integration time is the count time
+            field, or the real time field. See their definition.
+        polarization_manipulator_N(NXwaveplate):
+          exists: optional
+          doc: |
+            Device for the manipulation of the state of light which is a half wave
+            plate.
+          type:
+            enumeration: [objective, lens, glass fiber, none, other]
+        polarization_filter(NX_CHAR):
+          exists: optional
+          doc: |
+            Physical principle of the polarization filter used to create a
+            defined incident or scattered light state.
+          enumeration: [Polarization by Fresnel reflection, Birefringent polarizers, Thin film polarizers, Wire-grid polarizers, other]
+        specific_polarization_filter_type(NX_CHAR):
+          doc: |
+            Specific name or type of the polarizer used.
+            
+            For example: Glan-Thompson, Glan-Taylor, Rochon Prism, Wollaston
+            Polarizer...
+        laser_line_filter_type:
+          exists: optional
+          doc: |
+            Type of laserline filter used to supress the laser, if measurements
+            close to the laserline are performed.
+          enumeration: [Long-pass filter, Short-pass filter, Notch Filter]
+        laser_line_filter_steepness(NX_float):
+          doc: |
+            Steepness of the filter by normal incidence of the light as defined
+            by 10% - 90% transmittance of the respective filter, given in cm^-1.
+          # for a notch filter in principle two steepness have to be defined..
+        laser_line_filter_strength(NX_float):
+          doc: |
+            Designed supression strength of the laserline at optimal condition
+            given in orders of magnitude.
+        spectrometer(NXmonochromator):
+          exists: optional
+          doc: |
+            The spectroscope element of the ellipsometer before the detector,
+            but often integrated to form one closed unit. Information on the
+            dispersive element can be specified in the subfield GRATING. Note
+            that different gratings might be used for different wavelength
+            ranges. The dispersion of the grating for each wavelength range can
+            be stored in grating_dispersion.
+    (NXsample):
+    data_collection(NXprocess):
+      data_type:
+        doc: |
+          Select which type of data was recorded, for example a simple spectrum
+          with intensity vs. Raman shift, CCD image or a set of spectra with
+          probe, reference and background signals for pump beam on and off.
+        enumeration: [Integrated single spectrum, CCD image, Probe + Background + Reference for Pump-on and Pump-off (i.e. for FSRS)]
+
+# ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
+# 80b03b96b60b3c124d11d834654b3e57e09716088e8dca121f7903148c7b06e3
+# <?xml version='1.0' encoding='UTF-8'?>
+# <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+# <!--
+# # NeXus - Neutron and X-ray Common Data Format
+# #
+# # Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+# #
+# # This library is free software; you can redistribute it and/or
+# # modify it under the terms of the GNU Lesser General Public
+# # License as published by the Free Software Foundation; either
+# # version 3 of the License, or (at your option) any later version.
+# #
+# # This library is distributed in the hope that it will be useful,
+# # but WITHOUT ANY WARRANTY; without even the implied warranty of
+# # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# # Lesser General Public License for more details.
+# #
+# # You should have received a copy of the GNU Lesser General Public
+# # License along with this library; if not, write to the Free Software
+# # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# #
+# # For further information, see http://www.nexusformat.org
+# -->
+# <!--
+# 03/2024
+# A draft version of a NeXus application definition for Raman spectroscopy.-->
+# <!--
+# The document has the following main elements:
+# - Instrument used and is characteristics
+# - Sample: Properties of the sample
+# - Data: measured data, data errors
+# - Derived parameters: e.g. extra parameters derived in the measurement software-->
+# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXraman" extends="NXopt" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+#     <symbols>
+#         <doc>
+#              Variables used throughout the document, e.g. dimensions or parameters.
+#         </doc>
+#     </symbols>
+#     <doc>
+#          An application definition for Raman spectrocopy experiments.
+#          
+#          Information on Raman spectroscopy are provided in:
+#          
+#          General
+#          * Lewis, Ian R.; Edwards, Howell G. M.
+#            Handbook of Raman Spectroscopy
+#            ISBN 0-8247-0557-2
+#          
+#          Raman scattering selection rules
+#          * Dresselhaus, M. S.; Dresselhaus, G.; Jorio, A.
+#            Group Theory - Application to the Physics ofCondensed Matter
+#            ISBN 3540328971
+#          
+#          Semiconductors
+#          * Manuel Cardona
+#            Light Scattering in Solids I
+#            eBook ISBN: 978-3-540-37568-5
+#            DOI: https://doi.org/10.1007/978-3-540-37568-5
+#          
+#          * Manuel Cardona, Gernot Güntherodt
+#            Light Scattering in Solids II
+#            eBook ISBN:  978-3-540-39075-6
+#            DOI: https://doi.org/10.1007/3-540-11380-0
+#          
+#          * See as well other Books from the "Light Scattering in Solids" series:
+#            III: Recent Results
+#            IV: Electronic Scattering, Spin Effects, SERS, and Morphic Effects
+#            V: Superlattices and Other Microstructures 
+#            VI: Recent Results, Including High-Tc Superconductivity
+#            VII: Crystal-Field and Magnetic Excitations
+#            VIII: Fullerenes, Semiconductor Surfaces, Coherent Phonons
+#            IX: Novel Materials and Techniques
+#          
+#          Glasses, Liquids, Gasses, ...
+#          
+#          Review articles:
+#          Stimulated Raman scattering, Coherent anti-Stokes Raman scattering,
+#          Surface-enhanced Raman scattering, Tip-enhanced Raman scattering
+#          * https://doi.org/10.1186/s11671-019-3039-2
+#     </doc>
+#     <group type="NXentry">
+#         <doc>
+#              This is the application definition describing Raman spectroscopy experiments.
+#              
+#              Such experiments may be as simple a single Raman spectrum from spontanous 
+#              Raman scattering and range to Raman imaging Raman spectrometer,
+#              surface- and tip-enhanced Raman techniques, x-Ray Raman scattering, as well
+#              as resonant Raman scattering phenomena or multidimenional Raman spectra (i.e.
+#              varying temperature, pressure, electric field, ....)
+#              
+#              The application definition defines:
+#              
+#              * elements of the experimental instrument
+#              * calibration information if available
+#              * parameters used to tune the state of the sample
+#              * sample description
+#         </doc>
+#         <field name="definition">
+#             <doc>
+#                  An application definition for ellipsometry.
+#             </doc>
+#             <attribute name="version">
+#                 <doc>
+#                      Version number to identify which definition of this application
+#                      definition was used for this entry/data.
+#                 </doc>
+#             </attribute>
+#             <attribute name="url">
+#                 <doc>
+#                      URL where to find further material (documentation, examples) relevant
+#                      to the application definition.
+#                 </doc>
+#             </attribute>
+#             <enumeration>
+#                 <item value="NXraman"/>
+#             </enumeration>
+#         </field>
+#         <field name="experiment_description">
+#             <doc>
+#                  An optional free-text description of the experiment.
+#                  
+#                  However, details of the experiment should be defined in the specific
+#                  fields of this application definition rather than in this experiment
+#                  description.
+#             </doc>
+#         </field>
+#         <field name="experiment_type">
+#             <doc>
+#                  Specify the type of Raman measurement.
+#             </doc>
+#             <enumeration>
+#                 <item value="in situ Raman spectroscopy"/>
+#                 <item value="resonant Raman spectroscopy"/>
+#                 <item value="non-resonant Raman spectroscopy"/>
+#                 <item value="Raman imaging"/>
+#                 <item value="Tip-enhanced Raman spectroscopy (TERS)"/>
+#                 <item value="Surface-enhanced Raman spectroscopy (SERS)"/>
+#                 <item value="Surface plasmon polariton enhanced Raman scattering (SPPERS)"/>
+#                 <item value="Hyper Raman spectroscopy (HRS)"/>
+#                 <item value="Stimulated Raman spectroscopy (SRS)"/>
+#                 <item value="Inverse Raman spectroscopy (IRS)"/>
+#                 <item value="Coherent anti-Stokes Raman spectroscopy (CARS)"/>
+#             </enumeration>
+#         </field>
+#         <!--Spontanous / far Field Raman Techniques-->
+#         <!--Enhanced / near Field Raman Techniques-->
+#         <!--Nonlinear Raman spectroscopy-->
+#         <group type="NXinstrument">
+#             <doc>
+#                  Properties of the Instruments used for Raman instrumeasurements.
+#             </doc>
+#             <field name="company" optional="true">
+#                 <doc>
+#                      Name of the company which build the instrument.
+#                 </doc>
+#             </field>
+#             <field name="construction_year" type="NX_DATE_TIME" optional="true">
+#                 <doc>
+#                      ISO8601 date when the instrument was constructed.
+#                      UTC offset should be specified.
+#                 </doc>
+#             </field>
+#             <group name="software" type="NXprocess">
+#                 <field name="program">
+#                     <doc>
+#                          Commercial or otherwise defined given name of the program that was
+#                          used to generate the result file(s) with measured data and metadata.
+#                          This program converts the measured signals to Raman data. If
+#                          home written, one can provide the actual steps in the NOTE subfield
+#                          here.
+#                     </doc>
+#                 </field>
+#             </group>
+#             <field name="incident_source_wavelength" type="NX_NUMBER" units="NX_LENGTH">
+#                 <doc>
+#                      Which indicent wavelength was used for e.g. a laser source.
+#                      For multiple excitation wavelengths, please state the specific discret
+#                      wavelengths (i.e. for dye laser) or the specific contnious range 
+#                      (i.e for white light laser source)
+#                 </doc>
+#             </field>
+#             <field name="scattering_configuration" type="NX_CHAR">
+#                 <!--
+# unit: NX_LENGTH
+# -->
+#                 <doc>
+#                      Scattering configuration as defined by the porto notation by three 
+#                      states, which are othogonal to each other. Example: z(xx)z for
+#                      parallel polarized backscattering configuration.
+#                      
+#                      See:
+#                      https://www.cryst.ehu.es/cgi-bin/cryst/programs/nph-doc-raman
+#                      
+#                      A(BC)D
+#                      
+#                      A = The propagation direction of the incident light (k_i)
+#                      B = The polarization direction of the incident light (E_i)
+#                      C = The polarization direction of the scattered light (E_s)
+#                      D = The propagation direction of the scattered light (k_s)
+#                      
+#                      An orthogonal base is assumed.
+#                      Linear polarized light is displayed by e.g. "x","y" or "z"
+#                      Unpolarized light is displayed by "."
+#                 </doc>
+#                 <field name="non_orthogonal_base_vectors" type="NX_NUMBER">
+#                     <!--
+# unit: NX_LENGTH
+# -->
+#                     <doc>
+#                          Scattering configuration as defined by the porto notation given by
+#                          respective vectors.
+#                          
+#                          Vectors in the porto notation are defined as for A, B, C, D above.
+#                          Linear light polarization is assumed.
+#                     </doc>
+#                     <dimensions rank="2">
+#                         <doc>
+#                              3 x 4 Matrix, which lists the porto notation vectors A, B, C, D. 
+#                              A has to be perpendicular to B and C perpendicular to D.
+#                         </doc>
+#                         <dim index="1" value="4"/>
+#                         <dim index="2" value="3"/>
+#                     </dimensions>
+#                 </field>
+#             </field>
+#             <group type="NXbeam_path">
+#                 <group name="light_source" type="NXsource">
+#                     <doc>
+#                          Specify the used light source. Multiple selection possible.
+#                     </doc>
+#                     <field name="source_type">
+#                         <enumeration>
+#                             <item value="laser"/>
+#                             <item value="dye-laser"/>
+#                             <item value="broadband tunable light source"/>
+#                             <item value="other"/>
+#                         </enumeration>
+#                     </field>
+#                 </group>
+#                 <group name="incident_light_optics" type="NXlens_opt" recommended="true">
+#                     <doc>
+#                          This is the optical element used for the incident light in the Raman
+#                          scattering process.
+#                          
+#                          This can be for example a simple lens or microscope
+#                          objective.
+#                     </doc>
+#                     <field name="type">
+#                         <enumeration>
+#                             <item value="objective"/>
+#                             <item value="lens"/>
+#                             <item value="glass fiber"/>
+#                             <item value="none"/>
+#                             <item value="other"/>
+#                         </enumeration>
+#                     </field>
+#                     <field name="numerical_aperture" type="NX_NUMBER">
+#                         <doc>
+#                              The numerical aperture of the used incident light optics.
+#                         </doc>
+#                     </field>
+#                 </group>
+#                 <group name="scattered_light_optics" type="NXlens_opt" optional="true">
+#                     <doc>
+#                          This is the optical element used for the incident light in the Raman
+#                          scattering process.
+#                          
+#                          This can be for example a simple lens or microscope
+#                          objective.
+#                     </doc>
+#                     <attribute name="is_same_as_for_incident_light"/>
+#                     <field name="type">
+#                         <enumeration>
+#                             <item value="objective"/>
+#                             <item value="lens"/>
+#                             <item value="glass fiber"/>
+#                             <item value="none"/>
+#                             <item value="other"/>
+#                         </enumeration>
+#                     </field>
+#                     <field name="numerical_aperture" type="NX_NUMBER">
+#                         <doc>
+#                              The numerical aperture of the used incident light optics.
+#                         </doc>
+#                     </field>
+#                 </group>
+#                 <group type="NXdetector">
+#                     <doc>
+#                          Properties of the detector used. Integration time is the count time
+#                          field, or the real time field. See their definition.
+#                     </doc>
+#                 </group>
+#                 <group name="polarization_manipulator_N" type="NXwaveplate" optional="true">
+#                     <doc>
+#                          Device for the manipulation of the state of light which is a half wave
+#                          plate.
+#                     </doc>
+#                     <field name="type">
+#                         <enumeration>
+#                             <item value="objective"/>
+#                             <item value="lens"/>
+#                             <item value="glass fiber"/>
+#                             <item value="none"/>
+#                             <item value="other"/>
+#                         </enumeration>
+#                     </field>
+#                 </group>
+#                 <field name="polarization_filter" optional="true">
+#                     <doc>
+#                          Physical principle of the polarization filter used to create a 
+#                          defined incident or scattered light state.
+#                     </doc>
+#                     <field name="type">
+#                         <enumeration>
+#                             <item value="Polarization by Fresnel reflection"/>
+#                             <item value="Birefringent polarizers"/>
+#                             <item value="Thin film polarizers"/>
+#                             <item value="Wire-grid polarizers"/>
+#                         </enumeration>
+#                     </field>
+#                     <field name="specific_polarizer_type">
+#                         <doc>
+#                              Specific name or type of the polarizer used.
+#                              
+#                              For example: Glan-Thompson, Glan-Taylor, Rochon Prism, Wollaston 
+#                              Polarizer...
+#                         </doc>
+#                     </field>
+#                 </field>
+#                 <field name="laser_line_filter" optional="true">
+#                     <doc>
+#                          Type of laserline filter used to supress the laser, if measurements
+#                          close to the laserline are performed.
+#                     </doc>
+#                     <field name="type">
+#                         <enumeration>
+#                             <item value="Long-pass filter"/>
+#                             <item value="Short-pass filter"/>
+#                             <item value="Notch Filter"/>
+#                         </enumeration>
+#                     </field>
+#                     <field name="filter_design_wavelength" type="NX_NUMBER">
+#                         <doc>
+#                              Design wavelength for the laser line filter.
+#                         </doc>
+#                     </field>
+#                     <field name="filter_spectral_steepness">
+#                         <doc>
+#                              Steepness of the filter by normal incidence of the light as defined
+#                              by 10% - 90% transmittance of the respective filter.
+#                         </doc>
+#                     </field>
+#                     <!--for a notch filter in principle two steepness have to be defined..-->
+#                     <field name="filter_strength" type="NX_float">
+#                         <doc>
+#                              Designed supression strength of the laserline at optimal condition
+#                              given in orders of magnitude.
+#                         </doc>
+#                     </field>
+#                 </field>
+#                 <group name="rotating_element" type="NXwaveplate" optional="true">
+#                     <doc>
+#                          Properties of the rotating element defined in
+#                          'instrument/rotating_element_type'.
+#                     </doc>
+#                     <field name="revolutions" type="NX_NUMBER" optional="true" units="NX_COUNT">
+#                         <doc>
+#                              Define how many revolutions of the rotating element were averaged
+#                              for each measurement. If the number of revolutions was fixed to a
+#                              certain value use the field 'fixed_revolutions' instead.
+#                         </doc>
+#                     </field>
+#                     <field name="fixed_revolutions" type="NX_NUMBER" optional="true" units="NX_COUNT">
+#                         <doc>
+#                              Define how many revolutions of the rotating element were taken
+#                              into account for each measurement (if number of revolutions was
+#                              fixed to a certain value, i.e. not averaged).
+#                         </doc>
+#                     </field>
+#                     <field name="max_revolutions" type="NX_NUMBER" optional="true" units="NX_COUNT">
+#                         <doc>
+#                              Specify the maximum value of revolutions of the rotating element
+#                              for each measurement.
+#                         </doc>
+#                     </field>
+#                 </group>
+#                 <group name="spectrometer" type="NXmonochromator" optional="true">
+#                     <doc>
+#                          The spectroscope element of the ellipsometer before the detector,
+#                          but often integrated to form one closed unit. Information on the
+#                          dispersive element can be specified in the subfield GRATING. Note
+#                          that different gratings might be used for different wavelength
+#                          ranges. The dispersion of the grating for each wavelength range can
+#                          be stored in grating_dispersion.
+#                     </doc>
+#                 </group>
+#             </group>
+#         </group>
+#         <group type="NXsample">
+#             <field name="backside_roughness" type="NX_BOOLEAN">
+#                 <doc>
+#                      Was the backside of the sample roughened? Relevant for infrared
+#                      ellipsometry.
+#                 </doc>
+#             </field>
+#         </group>
+#         <group name="data_collection" type="NXprocess">
+#             <field name="data_type">
+#                 <doc>
+#                      Select which type of data was recorded, for example a simple spectrum
+#                      with intensity vs. Raman shift, CCD image or a set of spectra with
+#                      probe, reference and background signals for pump beam on and off.
+#                 </doc>
+#                 <enumeration>
+#                     <item value="Integrated single spectrum"/>
+#                     <item value="CCD image"/>
+#                     <item value="Probe + Background + Reference for Pump-on and Pump-off (i.e. for FSRS)"/>
+#                 </enumeration>
+#             </field>
+#         </group>
+#     </group>
+# </definition>

--- a/contributed_definitions/nyaml/NXraman.yaml
+++ b/contributed_definitions/nyaml/NXraman.yaml
@@ -46,6 +46,31 @@ doc: |
 symbols:
   doc: |
     Variables used throughout the document, e.g. dimensions or parameters.
+  N_spectrum: |
+    Length of the spectrum array (e.g. wavelength or energy) of the measured
+    data.
+  N_sensors: |
+    Number of sensors used to measure parameters that influence the sample,
+    such as temperature or pressure.
+  N_measurements: |
+    Number of measurements (1st dimension of measured_data array). This is
+    equal to the number of parameters scanned. For example, if the experiment
+    was performed at three different temperatures and two different pressures
+    N_measurements = 2*3 = 6.
+  N_scattering_configurations: |
+    Number of scattering configurations used in the measurement.
+    It is 1 for only parallel polarization meausement, 2 for parallel and cross 
+    polarization measurement or larger, if i.e. the incident and scattered photon
+    direction is varied.
+  N_observables: |
+    Number of observables that are saved in a measurement. e.g. one for
+    intensity, reflectivity or transmittance, two for Psi and Delta etc. This
+    is equal to the second dimension of the data array 'measured_data' and the
+    number of column names.
+  N_time: |
+    Number of time points measured, the length of NXsample/time_points
+  N_spectrum_filter: |
+    Number of points for a spectral filter used in the setup
 
 # 03/2024
 # A draft version of a NeXus application definition for Raman spectroscopy.
@@ -157,51 +182,85 @@ NXraman(NXopt):
               3 x 4 Matrix, which lists the porto notation vectors A, B, C, D.
               A has to be perpendicular to B and C perpendicular to D.
             dim: [[1, 4], [2, 3]]
-      (NXbeam_path):
-        light_source(NXsource):
+      opt_source(NXbeam_device):
+        doc: |
+          beam device instance of the optical source.
+        device:
           doc: |
-            Specify the used light source. Multiple selection possible.
-          source_type:
-            enumeration: [laser, dye-laser, broadband tunable light source, other]
-        incident_light_optics(NXlens_opt):
-          exists: recommended
+            It should contain the name of the Nexus source group.
+      (NXsource):
+        doc: |
+          Light source with arbitrary choice of name. This shall be referenced
+          by source(NXbeam_device)
+        source_type:
+          enumeration: [laser, dye-laser, broadband tunable light source, other]
+      incident_light_optics(NXbeam_device):
+        doc: |
+          Beam device instance of the incident light optics.
+        device:
           doc: |
-            This is the optical element used for the incident light in the Raman
-            scattering process.
-            
-            This can be for example a simple lens or microscope
-            objective.
-          type:
-            enumeration: [objective, lens, glass fiber, none, other]
-          numerical_aperture(NX_NUMBER):
-            doc: |
-              The numerical aperture of the used incident light optics.
-        scattered_light_optics(NXlens_opt):
-          exists: optional
+            It should contain the name of the "incident_light_lens(NXlens_opt)" group
+      scattered_light_optics(NXbeam_device):
+        doc: |
+          Beam device instance of the scattered light optics.
+        device:
           doc: |
-            This is the optical element used for the incident light in the Raman
-            scattering process.
-            
-            This can be for example a simple lens or microscope
-            objective.
-          \@is_same_as_for_incident_light:
-          type:
-            enumeration: [objective, lens, glass fiber, none, other]
-          numerical_aperture(NX_NUMBER):
-            doc: |
-              The numerical aperture of the used incident light optics.
-        (NXdetector):
+            It should contain the name of the "scattered_light_lens(NXlens_opt)" group
+      incident_light_lens(NXlens_opt):        
+        doc: |
+          This is the optical element used for the incident light in the Raman
+          scattering process.
+          
+          This can be for example a simple lens or microscope
+          objective.
+        exists: recommended
+        type:
+          enumeration: [objective, lens, glass fiber, none, other]
+        numerical_aperture(NX_NUMBER):
           doc: |
-            Properties of the detector used. Integration time is the count time
-            field, or the real time field. See their definition.
-        polarization_manipulator_N(NXwaveplate):
-          exists: optional
+            The numerical aperture of the used incident light optics.
+      scattered_light_lens(NXlens_opt):
+        doc: |
+          This is the optical element used for the incident light in the Raman
+          scattering process.
+          
+          This can be for example a simple lens or microscope
+          objective.
+        exists: recommended
+        type:
+          enumeration: [objective, lens, glass fiber, none, other]
+        numerical_aperture(NX_NUMBER):
           doc: |
-            Device for the manipulation of the state of light which is a half wave
-            plate.
-          type:
-            enumeration: [objective, lens, glass fiber, none, other]
-        polarization_filter(NX_CHAR):
+            The numerical aperture of the used incident light optics.
+      opt_detector(NXbeam_device):
+        doc: |
+          Properties of the detector to link it via NXbeam_device to other beam
+          elements
+        device:
+          doc: |
+            It should contain the name of the Nexus detector group
+      (NXdetector):
+        doc: |
+          Detector with arbitrary choice of the name, which shall be referenced
+          by the detector(NXbeam_device). 
+      polarization_manipulator_NAME(NXbeam_device):
+        exists: optional
+        doc: |
+          Link to the device, that it can be used to generate a beam path via
+          NXbeam_device. The string >NAME< in the name of this NXbeam_device
+          has to identical to >NAME< in waveplate_NAME(NXwaveplate).
+        device:
+          doc: |
+            This should contain the name for each halfwave plate used in the
+            NXwaveplate group.
+      waveplate_NAME(NXwaveplate):
+        doc: |
+          Properties of the device for the manipulation of the state of light which is a half wave
+          plate.
+        type:
+          enumeration: [objective, lens, glass fiber, none, other]
+      polarization_filter(NXbeam_device):
+        filter_mechanism(NX_CHAR):
           exists: optional
           doc: |
             Physical principle of the polarization filter used to create a
@@ -211,32 +270,56 @@ NXraman(NXopt):
           doc: |
             Specific name or type of the polarizer used.
             
-            For example: Glan-Thompson, Glan-Taylor, Rochon Prism, Wollaston
+            Free text, for example: Glan-Thompson, Glan-Taylor, Rochon Prism, Wollaston
             Polarizer...
-        laser_line_filter_type:
+      spectral_filter_N(NXbeam_device):
+        filter_type:
           exists: optional
           doc: |
             Type of laserline filter used to supress the laser, if measurements
             close to the laserline are performed.
-          enumeration: [Long-pass filter, Short-pass filter, Notch Filter]
-        laser_line_filter_steepness(NX_float):
-          doc: |
-            Steepness of the filter by normal incidence of the light as defined
-            by 10% - 90% transmittance of the respective filter, given in cm^-1.
-          # for a notch filter in principle two steepness have to be defined..
-        laser_line_filter_strength(NX_float):
-          doc: |
-            Designed supression strength of the laserline at optimal condition
-            given in orders of magnitude.
-        spectrometer(NXmonochromator):
+          enumeration: [long-pass filter, short-pass filter, Notch filter, reflection filter, neutral density filter, other]
+        intended_use:
           exists: optional
           doc: |
-            The spectroscope element of the ellipsometer before the detector,
-            but often integrated to form one closed unit. Information on the
-            dispersive element can be specified in the subfield GRATING. Note
-            that different gratings might be used for different wavelength
-            ranges. The dispersion of the grating for each wavelength range can
-            be stored in grating_dispersion.
+            Type of laserline filter used to supress the laser, if measurements
+            close to the laserline are performed.
+          enumeration: [laser line cleanup, raylight line removal, spectral filtering, intensity manipulation, other]
+        filter_characteristics(NX_NUMBER):
+          exists: optional
+          doc: |
+            Properties of the spectral filter such as wavelength dependent Transmission
+            or reflectivity.
+          dimensions:
+            rank: 2
+            dim: [[1, 2], [2, N_spectrum_filter]]
+            # 2 -> [Wavelength, Transmission]
+            # N_spectrum_filter --> Number of wavelengths
+          \@characteristics_type:
+            exists: optional
+            doc: |
+              Which property is used to form the spectral properties of light,
+              i.e. transmission or reflection properties.
+            enumeration: [transmission, reflection]
+      opt_monochromator(NXbeam_device):
+        exists: optional
+        doc: |
+          Dispersive element to create e.g. an energetic resolution used in the 
+          measurement.
+        device:
+          doc: |
+            It should contain the name of the Nexus Monochromator group
+      (NXmonochromator):
+        doc: |
+          Monochromator with arbitrary choice of the name, which shall be referenced
+          by the spectrometer(NXbeam_device).
+      Sample_as_beam_element(NXbeam_device):
+        doc: |
+          Enables beam path description of the sample in the setup.
+          it in a beam path.
+        device:
+          doc: |
+            Contains the link to the sample.
     (NXsample):
     data_collection(NXprocess):
       data_type:

--- a/contributed_definitions/nyaml/NXraman.yaml
+++ b/contributed_definitions/nyaml/NXraman.yaml
@@ -5,16 +5,19 @@ doc: |
   Information on Raman spectroscopy are provided in:
   
   General
+
   * Lewis, Ian R.; Edwards, Howell G. M.
     Handbook of Raman Spectroscopy
     ISBN 0-8247-0557-2
   
   Raman scattering selection rules
+
   * Dresselhaus, M. S.; Dresselhaus, G.; Jorio, A.
     Group Theory - Application to the Physics ofCondensed Matter
     ISBN 3540328971
   
   Semiconductors
+  
   * Manuel Cardona
     Light Scattering in Solids I
     eBook ISBN: 978-3-540-37568-5

--- a/contributed_definitions/nyaml/NXraman.yaml
+++ b/contributed_definitions/nyaml/NXraman.yaml
@@ -72,7 +72,12 @@ symbols:
   N_spectrum_filter: |
     Number of points for a spectral filter used in the setup
 
-# 03/2024
+  #N_incident_wavelengths: |
+  #  Number of the incident wavelen
+  #N_incident_beams: |
+  #  to be done....
+
+# 04/2024
 # A draft version of a NeXus application definition for Raman spectroscopy.
 
 # The document has the following main elements:
@@ -100,7 +105,7 @@ NXraman(NXopt):
       * sample description
     definition:
       doc: |
-        An application definition for ellipsometry.
+        An application definition for Raman spectrsocopy.
       \@version:
         doc: |
           Version number to identify which definition of this application
@@ -111,6 +116,7 @@ NXraman(NXopt):
           to the application definition.
       enumeration: [NXraman]
     experiment_description:
+      exists: optional
       doc: |
         An optional free-text description of the experiment.
         
@@ -139,28 +145,28 @@ NXraman(NXopt):
           exists: recommended
         identifier:
           exists: recommended
-        construction_year(NX_DATE_TIME): # is 1 indention ok?
-          exists: optional
-          doc: |
-            ISO8601 date when the instrument was constructed.
-            UTC offset should be specified.
-      software(NXprocess): ## NXChar=
-        program:
+      construction_year(NX_DATE_TIME):
+        exists: optional
+        doc: |
+          ISO8601 date when the instrument was constructed.
+          UTC offset should be specified.
+      software(NXfabrication):
+        exists: recommended
+        program_name:
           doc: |
             Commercial or otherwise defined given name of the program that was
             used to generate the result file(s) with measured data and metadata.
             This program converts the measured signals to Raman data. If
             home written, one can provide the actual steps in the NOTE subfield
             here.
-      incident_source_wavelength(NX_NUMBER):
-        unit: NX_LENGTH
+      incident_beam_wavelength(NX_NUMBER):
+        unit: NX_WAVELENGTH
         doc: |
-          Which indicent wavelength was used for e.g. a laser source.
+          Which wavelength the incident beam has, e.g. a single wavelength for a laser source.
           For multiple excitation wavelengths, please state the specific discret
           wavelengths (i.e. for dye laser) or the specific contnious range
-          (i.e for white light laser source)
+          (i.e for white light laser source).
       scattering_configuration(NX_CHAR):
-        # unit: NX_LENGTH
         doc: |
           Scattering configuration as defined by the porto notation by three
           states, which are othogonal to each other. Example: z(xx)z for
@@ -179,7 +185,8 @@ NXraman(NXopt):
           An orthogonal base is assumed.
           Linear polarized light is displayed by e.g. "x","y" or "z"
           Unpolarized light is displayed by "."
-        \@non_orthogonal_base_vectors(NX_NUMBER):
+          For non-orthogonal vectors, use the attribute porto_notation_vectors.
+        \@porto_notation_vectors(NX_NUMBER):
           # unit: NX_LENGTH
           doc: |
             Scattering configuration as defined by the porto notation given by
@@ -198,6 +205,7 @@ NXraman(NXopt):
       # beam path description of the setup, while using the up now available
       # Nexus definitions for source, detector, monochromator, ... 
       opt_source(NXbeam_device):
+        exists: optional
         doc: |
           This is the beam device instance of the optical source.
 
@@ -212,18 +220,21 @@ NXraman(NXopt):
           doc: |
             It should contain the name of the Nexus source group.
       incident_light_optics(NXbeam_device):
+        exists: optional
         doc: |
           Beam device instance of the incident light optics.
         \@device:
           doc: |
             It should contain the name of the "incident_light_lens(NXlens_opt)" group
       scattered_light_optics(NXbeam_device):
+        exists: optional
         doc: |
           Beam device instance of the scattered light optics.
         \@device:
           doc: |
             It should contain the name of the "scattered_light_lens(NXlens_opt)" group
       opt_detector(NXbeam_device):
+        exists: optional
         doc: |
           Properties of the detector to link it via NXbeam_device to other beam
           elements
@@ -249,70 +260,100 @@ NXraman(NXopt):
           doc: |
             It should contain the name of the Nexus Monochromator group
       sample_as_beam_element(NXbeam_device):
+        exists: optional
         doc: |
           Enables beam path description of the sample in the setup.
           it in a beam path.
         \@device:
           doc: |
             Contains the link to the sample.
-      # End of Auxillary NXbeam_devices
 
-
-      # Below:
-      # generic NeXus definition for optical elements of the setup
+      # Below: generic NeXus definition for optical elements of the setup
       (NXsource):
         doc: |
           Light source with arbitrary choice of name. This shall be referenced
           by source(NXbeam_device)
         source_type:
           enumeration: [laser, dye-laser, broadband tunable light source, other]
+        source_polarization:
+          doc: |
+            The type of light polarization procuded by the source.
+          enumeration: [linear, unpolarized, circular, elliptically, other]
+        device_information(NXfabrication):
+          doc: |
+            Details about the specific device information if available. 
       (NXdetector):
         doc: |
           Detector with arbitrary choice of the name, which shall be referenced
-          by the detector(NXbeam_device). 
+          by the detector(NXbeam_device).
+        device_information(NXfabrication):
+          doc: |
+            Details about the specific device information if available.
+        data_type:
+          exists: optional
+          doc: |
+            Select which type of data was recorded, for example a simple spectrum
+            with intensity vs. Raman shift, CCD image or a set of spectra with
+            probe, reference and background signals for pump beam on and off.
+          enumeration: [Integrated single spectrum, CCD image, Probe + Background + Reference for Pump-on and Pump-off (i.e. for FSRS)]
       (NXmonochromator):
+        exists: optional
         doc: |
           Monochromator with arbitrary choice of the name, which shall be referenced
           by the spectrometer(NXbeam_device).
+        device_information(NXfabrication):
+          doc: |
+            Details about the specific device information if available. 
 
       # Below:
       # NeXus definition derived optical elements of the setup
-      incident_light_lens(NXlens_opt):        
+      incident_light_lens(NXlens_opt):
         doc: |
-          This is the optical element used for the incident light in the Raman
-          scattering process.
+          This is the optical element used to focus the incident light in the
+          Raman scattering process.
           
-          This can be for example a simple lens or microscope
-          objective.
-        exists: recommended
+          This can be for example a simple lens or microscope objective.
+        exists: optional
         type:
           enumeration: [objective, lens, glass fiber, none, other]
         numerical_aperture(NX_NUMBER):
           doc: |
             The numerical aperture of the used incident light optics.
+        magnification:
+          doc: |
+            Magnification of the lens.
+        device_information(NXfabrication):
+          doc: |
+            Details about the optical component, if available. 
       scattered_light_lens(NXlens_opt):
         doc: |
-          This is the optical element used for the incident light in the Raman
-          scattering process.
+          This is the optical element used to collect the scattered light in the
+          Raman scattering process.
           
-          This can be for example a simple lens or microscope
-          objective.
-        exists: recommended
+          This can be for example a simple lens or microscope objective.
+        exists: optional
         type:
           enumeration: [objective, lens, glass fiber, none, other]
         numerical_aperture(NX_NUMBER):
           doc: |
             The numerical aperture of the used incident light optics.
-      waveplate_NAME(NXwaveplate):
+        magnification:
+          doc: |
+            Magnification of the lens.
+        device_information(NXfabrication):
+          doc: |
+            Details about the optical component, if available. 
+      waveplate_N(NXwaveplate):
+        exists: optional
         doc: |
-          Properties of the device for the manipulation of the state of light which is a half wave
-          plate.
-        type:
-          enumeration: [objective, lens, glass fiber, none, other]
+          Properties of a wave plate to manipulate the polarization state of light.
+        device_information(NXfabrication):
+          doc: |
+            Details about the optical component, if available. 
         
-      # Below:
-      # NXraman specific optical elements
+      # Below: NXraman specific optical elements
       polarization_filter(NXbeam_device):
+        exists: optional
         filter_mechanism(NX_CHAR):
           exists: optional
           doc: |
@@ -320,12 +361,19 @@ NXraman(NXopt):
             defined incident or scattered light state.
           enumeration: [Polarization by Fresnel reflection, Birefringent polarizers, Thin film polarizers, Wire-grid polarizers, other]
         specific_polarization_filter_type(NX_CHAR):
+          exists: optional
           doc: |
             Specific name or type of the polarizer used.
             
             Free text, for example: Glan-Thompson, Glan-Taylor, Rochon Prism, Wollaston
             Polarizer...      
+        device_information(NXfabrication):
+          doc: |
+            Details about the optical component, if available. 
       spectral_filter_N(NXbeam_device):
+        exists: optional
+        doc: |
+          Spectral filter used to modify properties of the scattered or incident light.
         filter_type:
           exists: optional
           doc: |
@@ -354,20 +402,16 @@ NXraman(NXopt):
               Which property is used to form the spectral properties of light,
               i.e. transmission or reflection properties.
             enumeration: [transmission, reflection]
-    (NXsample):
+        device_information(NXfabrication):
+          doc: |
+            Details about the optical component, if available. 
+    (NXsample): 
       name:
         exists: required
       sample_id:
         exists: recommended
       chemical_formula:
         exists: recommended
-    data_collection(NXprocess):
-      data_type:
-        doc: |
-          Select which type of data was recorded, for example a simple spectrum
-          with intensity vs. Raman shift, CCD image or a set of spectra with
-          probe, reference and background signals for pump beam on and off.
-        enumeration: [Integrated single spectrum, CCD image, Probe + Background + Reference for Pump-on and Pump-off (i.e. for FSRS)]
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
 # 80b03b96b60b3c124d11d834654b3e57e09716088e8dca121f7903148c7b06e3

--- a/contributed_definitions/nyaml/NXraman.yaml
+++ b/contributed_definitions/nyaml/NXraman.yaml
@@ -120,20 +120,31 @@ NXraman(NXopt):
     experiment_type:
       doc: |
         Specify the type of Raman measurement.
-      enumeration: [in situ Raman spectroscopy, resonant Raman spectroscopy, non-resonant Raman spectroscopy, Raman imaging, Tip-enhanced Raman spectroscopy (TERS), Surface-enhanced Raman spectroscopy (SERS), Surface plasmon polariton enhanced Raman scattering (SPPERS), Hyper Raman spectroscopy (HRS), Stimulated Raman spectroscopy (SRS), Inverse Raman spectroscopy (IRS), Coherent anti-Stokes Raman spectroscopy (CARS)]
+      enumeration: [in situ Raman spectroscopy, resonant Raman spectroscopy, non-resonant Raman spectroscopy, Raman imaging, Tip-enhanced Raman spectroscopy (TERS), Surface-enhanced Raman spectroscopy (SERS), Surface plasmon polariton enhanced Raman scattering (SPPERS), Hyper Raman spectroscopy (HRS), Stimulated Raman spectroscopy (SRS), Inverse Raman spectroscopy (IRS), Coherent anti-Stokes Raman spectroscopy (CARS), other]
+    experiment_type_other:
+      exists: optional
+      doc: |
+        If the experiment_type is `other`, a name should be specified here.
     (NXinstrument):
       doc: |
-        Properties of the Instruments used for Raman instrumeasurements.
-      company:
-        exists: optional
+         Metadata of the setup, its optical elements and physical properites which
+         defines the Raman measurement.
+      device_information(NXfabrication):      
         doc: |
           Name of the company which build the instrument.
-      construction_year(NX_DATE_TIME):
-        exists: optional
-        doc: |
-          ISO8601 date when the instrument was constructed.
-          UTC offset should be specified.
-      software(NXprocess):
+        exists: recommended
+        vendor:
+          exists: recommended
+        model:
+          exists: recommended
+        identifier:
+          exists: recommended
+        construction_year(NX_DATE_TIME): # is 1 indention ok?
+          exists: optional
+          doc: |
+            ISO8601 date when the instrument was constructed.
+            UTC offset should be specified.
+      software(NXprocess): ## NXChar=
         program:
           doc: |
             Commercial or otherwise defined given name of the program that was
@@ -182,30 +193,90 @@ NXraman(NXopt):
               3 x 4 Matrix, which lists the porto notation vectors A, B, C, D.
               A has to be perpendicular to B and C perpendicular to D.
             dim: [[1, 4], [2, 3]]
+
+      # In the following - Auxillary NXbeam_devices are defined, to enable a 
+      # beam path description of the setup, while using the up now available
+      # Nexus definitions for source, detector, monochromator, ... 
       opt_source(NXbeam_device):
         doc: |
-          beam device instance of the optical source.
-        device:
+          This is the beam device instance of the optical source.
+
+          It enables a description of the optical setup via NXbeam_devices to 
+          be able to connect the components. This connection is then a "beam path".
+
+          The properties of the source are located in a NXsource group.
+          [Note: the idea is to incorporate later NXbeam_device into NXsource]
+
+          This is done similarily with NXlens_opt, NXdetector, NXwaveplate and NXmonochromator.
+        \@device:
           doc: |
             It should contain the name of the Nexus source group.
+      incident_light_optics(NXbeam_device):
+        doc: |
+          Beam device instance of the incident light optics.
+        \@device:
+          doc: |
+            It should contain the name of the "incident_light_lens(NXlens_opt)" group
+      scattered_light_optics(NXbeam_device):
+        doc: |
+          Beam device instance of the scattered light optics.
+        \@device:
+          doc: |
+            It should contain the name of the "scattered_light_lens(NXlens_opt)" group
+      opt_detector(NXbeam_device):
+        doc: |
+          Properties of the detector to link it via NXbeam_device to other beam
+          elements
+        \@device:
+          doc: |
+            It should contain the name of the Nexus detector group
+      polarization_manipulator_NAME(NXbeam_device):
+        exists: optional
+        doc: |
+          Link to the device, that it can be used to generate a beam path via
+          NXbeam_device. The string >NAME< in the name of this NXbeam_device
+          has to identical to >NAME< in waveplate_NAME(NXwaveplate).
+        \@device:
+          doc: |
+            This should contain the name for each halfwave plate used in the
+            NXwaveplate group.
+      opt_monochromator(NXbeam_device):
+        exists: optional
+        doc: |
+          Dispersive element to create e.g. an energetic resolution used in the 
+          measurement.
+        \@device:
+          doc: |
+            It should contain the name of the Nexus Monochromator group
+      sample_as_beam_element(NXbeam_device):
+        doc: |
+          Enables beam path description of the sample in the setup.
+          it in a beam path.
+        \@device:
+          doc: |
+            Contains the link to the sample.
+      # End of Auxillary NXbeam_devices
+
+
+      # Below:
+      # generic NeXus definition for optical elements of the setup
       (NXsource):
         doc: |
           Light source with arbitrary choice of name. This shall be referenced
           by source(NXbeam_device)
         source_type:
           enumeration: [laser, dye-laser, broadband tunable light source, other]
-      incident_light_optics(NXbeam_device):
+      (NXdetector):
         doc: |
-          Beam device instance of the incident light optics.
-        device:
-          doc: |
-            It should contain the name of the "incident_light_lens(NXlens_opt)" group
-      scattered_light_optics(NXbeam_device):
+          Detector with arbitrary choice of the name, which shall be referenced
+          by the detector(NXbeam_device). 
+      (NXmonochromator):
         doc: |
-          Beam device instance of the scattered light optics.
-        device:
-          doc: |
-            It should contain the name of the "scattered_light_lens(NXlens_opt)" group
+          Monochromator with arbitrary choice of the name, which shall be referenced
+          by the spectrometer(NXbeam_device).
+
+      # Below:
+      # NeXus definition derived optical elements of the setup
       incident_light_lens(NXlens_opt):        
         doc: |
           This is the optical element used for the incident light in the Raman
@@ -232,33 +303,15 @@ NXraman(NXopt):
         numerical_aperture(NX_NUMBER):
           doc: |
             The numerical aperture of the used incident light optics.
-      opt_detector(NXbeam_device):
-        doc: |
-          Properties of the detector to link it via NXbeam_device to other beam
-          elements
-        device:
-          doc: |
-            It should contain the name of the Nexus detector group
-      (NXdetector):
-        doc: |
-          Detector with arbitrary choice of the name, which shall be referenced
-          by the detector(NXbeam_device). 
-      polarization_manipulator_NAME(NXbeam_device):
-        exists: optional
-        doc: |
-          Link to the device, that it can be used to generate a beam path via
-          NXbeam_device. The string >NAME< in the name of this NXbeam_device
-          has to identical to >NAME< in waveplate_NAME(NXwaveplate).
-        device:
-          doc: |
-            This should contain the name for each halfwave plate used in the
-            NXwaveplate group.
       waveplate_NAME(NXwaveplate):
         doc: |
           Properties of the device for the manipulation of the state of light which is a half wave
           plate.
         type:
           enumeration: [objective, lens, glass fiber, none, other]
+        
+      # Below:
+      # NXraman specific optical elements
       polarization_filter(NXbeam_device):
         filter_mechanism(NX_CHAR):
           exists: optional
@@ -271,7 +324,7 @@ NXraman(NXopt):
             Specific name or type of the polarizer used.
             
             Free text, for example: Glan-Thompson, Glan-Taylor, Rochon Prism, Wollaston
-            Polarizer...
+            Polarizer...      
       spectral_filter_N(NXbeam_device):
         filter_type:
           exists: optional
@@ -301,26 +354,13 @@ NXraman(NXopt):
               Which property is used to form the spectral properties of light,
               i.e. transmission or reflection properties.
             enumeration: [transmission, reflection]
-      opt_monochromator(NXbeam_device):
-        exists: optional
-        doc: |
-          Dispersive element to create e.g. an energetic resolution used in the 
-          measurement.
-        device:
-          doc: |
-            It should contain the name of the Nexus Monochromator group
-      (NXmonochromator):
-        doc: |
-          Monochromator with arbitrary choice of the name, which shall be referenced
-          by the spectrometer(NXbeam_device).
-      Sample_as_beam_element(NXbeam_device):
-        doc: |
-          Enables beam path description of the sample in the setup.
-          it in a beam path.
-        device:
-          doc: |
-            Contains the link to the sample.
     (NXsample):
+      name:
+        exists: required
+      sample_id:
+        exists: recommended
+      chemical_formula:
+        exists: recommended
     data_collection(NXprocess):
       data_type:
         doc: |


### PR DESCRIPTION
I want to implement the first NeXus definition for NXraman.

As the latest version of NXellipsometry is derived from NXopt, the NXraman here is as well derived from NXopt.
Therefore, the Version here used "NXbeam_path", which will be replaced in the future by using "NXbeam_device" via "previous_devices". This was motivated by the fact, that there is right now no "NXlens_opt(NXbeam_device)" or "NXdetector(NXbeam_device)" [see [Issue #202](https://github.com/FAIRmat-NFDI/nexus_definitions/issues/202)]

**What is necessary?**
From a physical point of view, these are the most important things for a Raman scattering experiment:
1) The incident wavelength (a quite trivial parameter and the spectral shape of a Raman spectrum can be extremely sensitive to this)
2) The scattering configuration, i.e. what is the incident and scattered light direction and polarization.

Beyond this, there are many nice to have parameters, but from my point of view not necessary to be able to use this spectrum.

**Questions:**
A) No symbols were used here, as these were not used in the original NXellipsometry(NXopt) definition. It this fine that way, or at which pointare these symbols used?
B) Is the "scattering_configuration" implemented fine this way? Usually, the "Porto notation" is enough to describe the experiment and beatiful simple. But, it can be the case, that you want to give the specific vectors instead of x,y,z. I just wanted to do this as List of 4 Vectors with dimension 3. Is this okay?
C) Depending on the NXbeam_path or NXbeam_device approach, I may have to completely redo this PR. What is the strategy?

**TL;DR:** Created NXraman.yaml file similar to NXellipsometry.yaml