### PR TITLE
NXdata linking of signal

### DIFF
--- a/base_classes/NXdata.nxdl.xml
+++ b/base_classes/NXdata.nxdl.xml
@@ -235,6 +235,20 @@ without this attribute being set to "true".-->
              the axes attribute can be omitted.
         </doc>
     </attribute>
+    <attribute name="reference">
+        <doc>
+             Points to the path of a field defining the data to which the `DATA` group refers.
+             
+             This concept allows to link the data to a respective field in the NeXus hierarchy, thereby
+             defining the physical quantity it represents.
+             
+             Example:
+                 If the data corresponds to a readout of a detector, ``@reference`` links
+                 to that detectors data:
+             
+                   @reference: '/entry/instrument/detector/data' for a 2D detector
+        </doc>
+    </attribute>
     <attribute name="AXISNAME_indices" type="NX_INT">
         <!--
 nxdl.xsd rules do not allow us to show this as a variable name
@@ -283,33 +297,6 @@ AXISNAME_indices documentation copied from datarules.rst
                 to avoid string parsing in reading applications.
         </doc>
     </attribute>
-    <attribute name="AXISNAME_depends">
-        <doc>
-             Points to the path of a field defining the axis on which the ``AXISNAME`` axis depends.
-             
-             This concept allows to link an axis to a respective field in the NeXus hierarchy, thereby
-             defining the physical quantity it represents.
-             
-             Here, *AXISNAME* is to be replaced by the name of each
-             field described in the ``axes`` attribute.
-             
-             Examples:
-                 If a calibration has been performed, ``@AXISNAME_depends`` links to the result of
-                 that calibration:
-             
-                   @AXISNAME_depends: '/entry/process/calibration/calibrated_axis'
-             
-                 If the axis corresponds to a coordinate of a detector, ``@AXISNAME_depends`` links
-                 to that detector axis:
-             
-                   @AXISNAME_depends: '/entry/instrument/detector/axis/some_axis' for a 2D detector
-             
-                 If the axis is a scanned motor, ``@AXISNAME_depends`` links to the transformation
-                 describing the respective motion, e.g.:
-             
-                   @AXISNAME_depends: '/entry/instrument/detector/transformations/some_transformation' for a motion of the detector
-        </doc>
-    </attribute>
     <field name="AXISNAME" type="NX_NUMBER" nameType="any">
         <doc>
              Dimension scale defining an axis of the data.
@@ -352,6 +339,30 @@ AXISNAME_indices documentation copied from datarules.rst
                  N.B. The ``axis`` attribute is the old way of designating a link.
                  Do not use the ``axes`` attribute with the ``axis`` attribute.
                  The ``axes`` *group* attribute is now preferred.
+            </doc>
+        </attribute>
+        <attribute name="reference">
+            <doc>
+                 Points to the path of a field defining the axis to which the ``AXISNAME`` axis refers.
+                 
+                 This concept allows to link an axis to a respective field in the NeXus hierarchy, thereby
+                 defining the physical quantity it represents.
+                 
+                 Examples:
+                     If a calibration has been performed, ``@reference`` links to the result of
+                     that calibration:
+                 
+                       @reference: '/entry/process/calibration/calibrated_axis'
+                 
+                     If the axis corresponds to a coordinate of a detector, ``@reference`` links
+                     to that detector axis:
+                 
+                       @reference: '/entry/instrument/detector/axis/some_axis' for a 2D detector
+                 
+                     If the axis is a scanned motor, ``@reference`` links to the transformation
+                     describing the respective motion, e.g.:
+                 
+                       @reference: '/entry/instrument/detector/transformations/some_transformation' for a motion of the detector
             </doc>
         </attribute>
     </field>
@@ -408,24 +419,24 @@ AXISNAME_indices documentation copied from datarules.rst
                  data label
             </doc>
         </attribute>
+        <attribute name="reference">
+            <doc>
+                 Points to the path of a field defining the data to which the `DATA` field refers.
+                 
+                 This concept allows to link the data to a respective field in the NeXus hierarchy, thereby
+                 defining the physical quantity it represents.
+                 
+                 Here, *DATA* is to be replaced by the name of each
+                 data field.
+                 
+                 Example:
+                     If the data corresponds to a readout of a detector, ``@reference`` links
+                     to that detectors data:
+                 
+                       @reference: '/entry/instrument/detector/data' for a 2D detector
+            </doc>
+        </attribute>
     </field>
-    <attribute name="DATA_depends" type="NX_CHAR">
-        <doc>
-             Points to the path of a field defining the data on which the `DATA` field depends.
-             
-             This concept allows to link the data to a respective field in the NeXus hierarchy, thereby
-             defining the physical quantity it represents.
-             
-             Here, *DATA* is to be replaced by the name of each
-             data field.
-             
-             Example:
-                 If the data corresponds to a readout of a detector, ``@DATA_depends`` links
-                 to that detectors data:
-             
-                   @DATA_depends: '/entry/instrument/detector/data' for a 2D detector
-        </doc>
-    </attribute>
     <field name="errors" type="NX_NUMBER" deprecated="Use ``DATA_errors`` instead (NIAC2018)">
         <doc>
              Standard deviations of data values -

--- a/base_classes/NXdata.nxdl.xml
+++ b/base_classes/NXdata.nxdl.xml
@@ -409,6 +409,23 @@ AXISNAME_indices documentation copied from datarules.rst
             </doc>
         </attribute>
     </field>
+    <attribute name="DATA_depends" type="NX_CHAR">
+        <doc>
+             Points to the path of a field defining the data on which the `DATA` field depends.
+             
+             This concept allows to link the data to a respective field in the NeXus hierarchy, thereby
+             defining the physical quantity it represents.
+             
+             Here, *DATA* is to be replaced by the name of each
+             data field.
+             
+             Example:
+                 If the data corresponds to a readout of a detector, ``@DATA_depends`` links
+                 to that detectors data:
+             
+                   @DATA_depends: '/entry/instrument/detector/data' for a 2D detector
+        </doc>
+    </attribute>
     <field name="errors" type="NX_NUMBER" deprecated="Use ``DATA_errors`` instead (NIAC2018)">
         <doc>
              Standard deviations of data values -

--- a/base_classes/nyaml/NXdata.yaml
+++ b/base_classes/nyaml/NXdata.yaml
@@ -193,6 +193,18 @@ NXdata(NXobject):
       
       If there are no axes at all (such as with a stack of images),
       the axes attribute can be omitted.
+  \@reference:
+    doc: |
+      Points to the path of a field defining the data to which the `DATA` group refers.
+      
+      This concept allows to link the data to a respective field in the NeXus hierarchy, thereby
+      defining the physical quantity it represents.
+      
+      Example:
+          If the data corresponds to a readout of a detector, ``@reference`` links
+          to that detectors data:
+      
+            @reference: '/entry/instrument/detector/data' for a 2D detector
   \@AXISNAME_indices:
     type: NX_INT
     
@@ -238,31 +250,6 @@ NXdata(NXobject):
       .. note::  Attributes potentially containing multiple values
          (axes and _indices) are to be written as string or integer arrays,
          to avoid string parsing in reading applications.
-  \@AXISNAME_depends:
-    doc: |
-      Points to the path of a field defining the axis on which the ``AXISNAME`` axis depends.
-      
-      This concept allows to link an axis to a respective field in the NeXus hierarchy, thereby
-      defining the physical quantity it represents.
-      
-      Here, *AXISNAME* is to be replaced by the name of each
-      field described in the ``axes`` attribute.
-      
-      Examples:
-          If a calibration has been performed, ``@AXISNAME_depends`` links to the result of
-          that calibration:
-      
-            @AXISNAME_depends: '/entry/process/calibration/calibrated_axis'
-      
-          If the axis corresponds to a coordinate of a detector, ``@AXISNAME_depends`` links
-          to that detector axis:
-      
-            @AXISNAME_depends: '/entry/instrument/detector/axis/some_axis' for a 2D detector
-      
-          If the axis is a scanned motor, ``@AXISNAME_depends`` links to the transformation
-          describing the respective motion, e.g.:
-      
-            @AXISNAME_depends: '/entry/instrument/detector/transformations/some_transformation' for a motion of the detector
   AXISNAME(NX_NUMBER):
     nameType: any
     doc: |
@@ -301,6 +288,28 @@ NXdata(NXobject):
         N.B. The ``axis`` attribute is the old way of designating a link.
         Do not use the ``axes`` attribute with the ``axis`` attribute.
         The ``axes`` *group* attribute is now preferred.
+    \@reference:
+      doc: |
+        Points to the path of a field defining the axis to which the ``AXISNAME`` axis refers.
+      
+        This concept allows to link an axis to a respective field in the NeXus hierarchy, thereby
+        defining the physical quantity it represents.
+        
+        Examples:
+            If a calibration has been performed, ``@reference`` links to the result of
+            that calibration:
+        
+              @reference: '/entry/process/calibration/calibrated_axis'
+        
+            If the axis corresponds to a coordinate of a detector, ``@reference`` links
+            to that detector axis:
+        
+              @reference: '/entry/instrument/detector/axis/some_axis' for a 2D detector
+        
+            If the axis is a scanned motor, ``@reference`` links to the transformation
+            describing the respective motion, e.g.:
+        
+              @reference: '/entry/instrument/detector/transformations/some_transformation' for a motion of the detector
   FIELDNAME_errors(NX_NUMBER):
     nameType: any
     doc: |
@@ -350,21 +359,21 @@ NXdata(NXobject):
     \@long_name:
       doc: |
         data label
-  \@DATA_depends(NX_CHAR):
-    doc: |
-      Points to the path of a field defining the data on which the `DATA` field depends.
+    \@reference:
+      doc: |
+        Points to the path of a field defining the data to which the `DATA` field refers.
       
-      This concept allows to link the data to a respective field in the NeXus hierarchy, thereby
-      defining the physical quantity it represents.
-      
-      Here, *DATA* is to be replaced by the name of each
-      data field.
-      
-      Example:
-          If the data corresponds to a readout of a detector, ``@DATA_depends`` links
-          to that detectors data:
-      
-            @DATA_depends: '/entry/instrument/detector/data' for a 2D detector
+        This concept allows to link the data to a respective field in the NeXus hierarchy, thereby
+        defining the physical quantity it represents.
+        
+        Here, *DATA* is to be replaced by the name of each
+        data field.
+        
+        Example:
+            If the data corresponds to a readout of a detector, ``@reference`` links
+            to that detectors data:
+        
+              @reference: '/entry/instrument/detector/data' for a 2D detector
   errors(NX_NUMBER):
     deprecated: Use ``DATA_errors`` instead (NIAC2018)
     doc: |

--- a/base_classes/nyaml/NXdata.yaml
+++ b/base_classes/nyaml/NXdata.yaml
@@ -350,6 +350,21 @@ NXdata(NXobject):
     \@long_name:
       doc: |
         data label
+  \@DATA_depends(NX_CHAR):
+    doc: |
+      Points to the path of a field defining the data on which the `DATA` field depends.
+      
+      This concept allows to link the data to a respective field in the NeXus hierarchy, thereby
+      defining the physical quantity it represents.
+      
+      Here, *DATA* is to be replaced by the name of each
+      data field.
+      
+      Example:
+          If the data corresponds to a readout of a detector, ``@DATA_depends`` links
+          to that detectors data:
+      
+            @DATA_depends: '/entry/instrument/detector/data' for a 2D detector
   errors(NX_NUMBER):
     deprecated: Use ``DATA_errors`` instead (NIAC2018)
     doc: |

--- a/contributed_definitions/NXdata_mpes.nxdl.xml
+++ b/contributed_definitions/NXdata_mpes.nxdl.xml
@@ -33,9 +33,7 @@
         <doc>
              Calibrated energy axis.
              
-             In an application definition, this could be a link to either
-             /entry/process/energy_calibration/calibrated_axis or
-             /entry/process/energy_correction/calibrated_axis.
+             Could be linked from the respective '@reference' field.
         </doc>
         <attribute name="type" type="NX_CHAR">
             <doc>
@@ -61,6 +59,16 @@
                     </doc>
                 </item>
             </enumeration>
+        </attribute>
+        <attribute name="reference">
+            <doc>
+                 The energy can be dispersed according to different strategies. ``@reference`` points to
+                 the path of a field defining the calibrated axis which the ``energy`` axis refers.
+                 
+                 For example:
+                   @reference: 'entry/process/energy_calibration/calibrated_axis'
+                   @reference: 'entry/process/energy_referencing/calibrated_axis'
+            </doc>
         </attribute>
     </field>
     <field name="kN" type="NX_NUMBER" units="NX_WAVENUMBER">

--- a/contributed_definitions/NXmpes.nxdl.xml
+++ b/contributed_definitions/NXmpes.nxdl.xml
@@ -870,21 +870,49 @@
                 <doc>
                      Calibrated energy axis.
                      
-                     This could be a link to either
-                     /entry/process/energy_calibration/calibrated_axis or
-                     /entry/process/energy_correction/calibrated_axis.
+                     Could be linked from the respective '@reference' field.
                 </doc>
-                <attribute name="type" recommended="true"/>
+                <attribute name="type" type="NX_CHAR">
+                    <doc>
+                         The energy can be either stored as kinetic or as binding energy.
+                    </doc>
+                    <enumeration>
+                        <item value="kinetic">
+                            <doc>
+                                 Calibrated kinetic energy axis.
+                                 
+                                 In case the kinetic energy axis is referenced to the Fermi level :math:`E_F`
+                                 (e.g., in entry/process/energy_referencing), kinetic energies :math:`E` are
+                                 provided as :math:`E-E_F`.
+                                 
+                                 This concept is related to term `3.35`_ of the ISO 18115-1:2023 standard.
+                                 
+                                 .. _3.35: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:3.35
+                            </doc>
+                        </item>
+                        <item value="binding">
+                            <doc>
+                                 Calibrated binding energy axis.
+                                 
+                                 This concept is related to term `12.16`_ of the ISO 18115-1:2023 standard.
+                                 
+                                 .. _12.16: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:12.16
+                            </doc>
+                        </item>
+                    </enumeration>
+                </attribute>
+                <attribute name="reference" type="NX_CHAR" recommended="true">
+                    <doc>
+                         The energy can be dispersed according to different strategies. ``@reference`` points to
+                         the path of a field defining the calibrated axis which the ``energy`` axis refers.
+                         
+                         For example:
+                           @reference: 'entry/process/energy_calibration/calibrated_axis'
+                           @reference: 'entry/process/energy_calibration/calibrated_axis'
+                    </doc>
+                </attribute>
             </field>
-            <attribute name="energy_depends" type="NX_CHAR" optional="true">
-                <doc>
-                     The energy can be dispersed according to different strategies. ``energy_depends`` points to
-                     the path of a field defining the calibrated axis on which the energy axis depends.
-                     
-                     For example:
-                       @energy_depends: 'entry/process/energy_calibration'
-                </doc>
-            </attribute>
+            <attribute name="energy_indices" recommended="true"/>
         </group>
     </group>
 </definition>

--- a/contributed_definitions/NXmpes.nxdl.xml
+++ b/contributed_definitions/NXmpes.nxdl.xml
@@ -908,7 +908,6 @@
                          
                          For example:
                            @reference: 'entry/process/energy_calibration/calibrated_axis'
-                           @reference: 'entry/process/energy_calibration/calibrated_axis'
                     </doc>
                 </attribute>
             </field>

--- a/contributed_definitions/NXmpes_arpes.nxdl.xml
+++ b/contributed_definitions/NXmpes_arpes.nxdl.xml
@@ -355,52 +355,54 @@ with higher granularity in the data description.
             <attribute name="energy_indices"/>
             <attribute name="angular0_indices"/>
             <attribute name="angular1_indices"/>
-            <attribute name="angular0_depends">
-                <doc>
-                     Points to the path to a field defining the axis on which the angular axis depends.
-                     For example:
-                     @angular0_depends: '/entry/sample/transformations/sample_tilt' for a manipulator angular scan
-                     @angular0_depends: '/entry/instrument/detector/sensor_x' for a 2D detector
-                     @angular0_depends: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
-                     @angular0_depends: '/entry/process/calibration/angular0_calibration/calibrated_axis' for a preprocessed axis.
-                </doc>
-            </attribute>
-            <attribute name="angular1_depends">
-                <doc>
-                     Points to the path to a field defining the axis on which the angular axis depends.
-                     For example:
-                     @angular1_depends: '/entry/sample/transformations/sample_polar' for a manipulator angular scan
-                     @angular1_depends: '/entry/instrument/detector/sensor_x' for a 2D detector
-                     @angular1_depends: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
-                     @angular1_depends: '/entry/process/calibration/angular1_calibration/calibrated_axis' for a preprocessed axis.
-                </doc>
-            </attribute>
-            <attribute name="energy_depends">
-                <doc>
-                     Points to the path to a field defining the axis on which the energy axis depends.
-                     For example:
-                     @energy_depends: '/entry/instrument/detector/sensor_y' for a 2D detector
-                     @energy_depends: '/entry/instrument/energydispersion/center_kinetic_energy' for a swept scan
-                     @energy_depends: '/entry/process/calibration/energy_calibration/calibrated_axis' for a preprocessed axis.
-                </doc>
-            </attribute>
             <field name="energy" type="NX_NUMBER" units="NX_ENERGY">
                 <doc>
-                     Trace of the energy axis. Could be linked from the respective 'AXISNAME_depends'
+                     Trace of the energy axis. Could be linked from the respective '@reference'
                      field.
                 </doc>
+                <attribute name="reference" recommended="true">
+                    <doc>
+                         Points to the path of a field defining the calibrated axis which the ``energy`` axis refers.
+                         
+                         For example:
+                           @reference: '/entry/instrument/detector/sensor_y' for a 2D detector
+                           @reference: '/entry/instrument/energydispersion/center_kinetic_energy' for a swept scan
+                           @reference: '/entry/process/calibration/energy_calibration/calibrated_axis' for a preprocessed axis.
+                    </doc>
+                </attribute>
             </field>
             <field name="angular0" type="NX_NUMBER" units="NX_ANGLE">
                 <doc>
                      Trace of the first angular axis. Could be linked from the respective
-                     'AXISNAME_depends' field.
+                     '@reference' field.
                 </doc>
+                <attribute name="reference" recommended="true">
+                    <doc>
+                         Points to the path of a field defining the calibrated axis which the ``angular0`` axis refers.
+                         
+                         For example:
+                           @reference: '/entry/sample/transformations/sample_tilt' for a manipulator angular scan
+                           @reference: '/entry/instrument/detector/sensor_x' for a 2D detector
+                           @reference: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
+                           @reference: '/entry/process/calibration/angular0_calibration/calibrated_axis' for a preprocessed axis.
+                    </doc>
+                </attribute>
             </field>
             <field name="angular1" type="NX_NUMBER" units="NX_ANGLE">
                 <doc>
-                     Trace of the second axis. Could be linked from the respective 'AXISNAME_depends'
+                     Trace of the second axis. Could be linked from the respective '@reference'
                      field.
                 </doc>
+                <attribute name="reference" recommended="true">
+                    <doc>
+                         Points to the path to a field defining the axis  which the ``angular1`` axis refers.
+                         For example:
+                           @reference: '/entry/sample/transformations/sample_polar' for a manipulator angular scan
+                           @reference: '/entry/instrument/detector/sensor_y' for a 2D detector
+                           @reference: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
+                           @reference: '/entry/process/calibration/angular1_calibration/calibrated_axis' for a preprocessed axis.
+                    </doc>
+                </attribute>
             </field>
             <field name="data" type="NX_NUMBER" units="NX_ANY">
                 <doc>

--- a/contributed_definitions/NXmpes_arpes.nxdl.xml
+++ b/contributed_definitions/NXmpes_arpes.nxdl.xml
@@ -357,12 +357,12 @@ with higher granularity in the data description.
             <attribute name="angular1_indices"/>
             <field name="energy" type="NX_NUMBER" units="NX_ENERGY">
                 <doc>
-                     Trace of the energy axis. Could be linked from the respective '@reference'
+                     Trace of the energy axis. Could be linked from the respective ``@reference``
                      field.
                 </doc>
                 <attribute name="reference" recommended="true">
                     <doc>
-                         Points to the path of a field defining the calibrated axis which the ``energy`` axis refers.
+                         Points to the path of a field defining the calibrated axis which the energy axis refers.
                          
                          For example:
                            @reference: '/entry/instrument/detector/sensor_y' for a 2D detector
@@ -374,7 +374,7 @@ with higher granularity in the data description.
             <field name="angular0" type="NX_NUMBER" units="NX_ANGLE">
                 <doc>
                      Trace of the first angular axis. Could be linked from the respective
-                     '@reference' field.
+                     ``@reference`` field.
                 </doc>
                 <attribute name="reference" recommended="true">
                     <doc>
@@ -390,12 +390,13 @@ with higher granularity in the data description.
             </field>
             <field name="angular1" type="NX_NUMBER" units="NX_ANGLE">
                 <doc>
-                     Trace of the second axis. Could be linked from the respective '@reference'
+                     Trace of the second axis. Could be linked from the respective ``@reference``
                      field.
                 </doc>
                 <attribute name="reference" recommended="true">
                     <doc>
-                         Points to the path to a field defining the axis  which the ``angular1`` axis refers.
+                         Points to the path of a field defining the calibrated axis which the ``angular1`` axis refers.
+                         
                          For example:
                            @reference: '/entry/sample/transformations/sample_polar' for a manipulator angular scan
                            @reference: '/entry/instrument/detector/sensor_y' for a 2D detector

--- a/contributed_definitions/nyaml/NXdata_mpes.yaml
+++ b/contributed_definitions/nyaml/NXdata_mpes.yaml
@@ -14,9 +14,7 @@ NXdata_mpes(NXdata):
     doc: |
       Calibrated energy axis.
       
-      In an application definition, this could be a link to either
-      /entry/process/energy_calibration/calibrated_axis or
-      /entry/process/energy_correction/calibrated_axis.
+      Could be linked from the respective '@reference' field.
     \@type:
       type: NX_CHAR
       doc: |
@@ -40,6 +38,14 @@ NXdata_mpes(NXdata):
               spec: ISO 18115-1:2023
               term: 12.16
               url: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:12.16
+    \@reference:
+      doc: |
+        The energy can be dispersed according to different strategies. ``@reference`` points to
+        the path of a field defining the calibrated axis which the ``energy`` axis refers.
+        
+        For example:
+          @reference: 'entry/process/energy_calibration/calibrated_axis'
+          @reference: 'entry/process/energy_referencing/calibrated_axis'
   kN(NX_NUMBER):
     unit: NX_WAVENUMBER
     doc: |
@@ -96,7 +102,7 @@ NXdata_mpes(NXdata):
       /entry/instrument/beam/final_ellipticity if they exist.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 4b087c0544eec9b6d7a621779cae0cc23b754cbccc06a07e88f59398346cf5fe
+# 573cec819375e8bb2e4895fc3869450883e1ad5d4756d4784807f3678792460d
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -132,9 +138,7 @@ NXdata_mpes(NXdata):
 #         <doc>
 #              Calibrated energy axis.
 #              
-#              In an application definition, this could be a link to either
-#              /entry/process/energy_calibration/calibrated_axis or
-#              /entry/process/energy_correction/calibrated_axis.
+#              Could be linked from the respective '@reference' field.
 #         </doc>
 #         <attribute name="type" type="NX_CHAR">
 #             <doc>
@@ -160,6 +164,16 @@ NXdata_mpes(NXdata):
 #                     </doc>
 #                 </item>
 #             </enumeration>
+#         </attribute>
+#         <attribute name="reference">
+#             <doc>
+#                  The energy can be dispersed according to different strategies. ``@reference`` points to
+#                  the path of a field defining the calibrated axis which the ``energy`` axis refers.
+#                  
+#                  For example:
+#                    @reference: 'entry/process/energy_calibration/calibrated_axis'
+#                    @reference: 'entry/process/energy_referencing/calibrated_axis'
+#             </doc>
 #         </attribute>
 #     </field>
 #     <field name="kN" type="NX_NUMBER" units="NX_WAVENUMBER">

--- a/contributed_definitions/nyaml/NXmpes.yaml
+++ b/contributed_definitions/nyaml/NXmpes.yaml
@@ -778,23 +778,49 @@ NXmpes(NXobject):
         doc: |
           Calibrated energy axis.
           
-          This could be a link to either
-          /entry/process/energy_calibration/calibrated_axis or
-          /entry/process/energy_correction/calibrated_axis.
+          Could be linked from the respective '@reference' field.
         \@type:
+          type: NX_CHAR
+          doc: |
+            The energy can be either stored as kinetic or as binding energy.
+          enumeration:
+            kinetic:
+              doc:
+              - |
+                Calibrated kinetic energy axis.
+              - |
+                In case the kinetic energy axis is referenced to the Fermi level :math:`E_F`
+                (e.g., in entry/process/energy_referencing), kinetic energies :math:`E` are
+                provided as :math:`E-E_F`.
+              - |
+                xref:
+                  spec: ISO 18115-1:2023
+                  term: 3.35
+                  url: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:3.35
+            binding:
+              doc:
+              - |
+                Calibrated binding energy axis.
+              - |
+                xref:
+                  spec: ISO 18115-1:2023
+                  term: 12.16
+                  url: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:12.16
+        \@reference:
+          type: NX_CHAR
           exists: recommended
-      \@energy_depends:
-        type: NX_CHAR
-        exists: optional
-        doc: |
-          The energy can be dispersed according to different strategies. ``energy_depends`` points to
-          the path of a field defining the calibrated axis on which the energy axis depends.
-          
-          For example:
-            @energy_depends: 'entry/process/energy_calibration'
+          doc: |
+            The energy can be dispersed according to different strategies. ``@reference`` points to
+            the path of a field defining the calibrated axis which the ``energy`` axis refers.
+            
+            For example:
+              @reference: 'entry/process/energy_calibration/calibrated_axis'
+              @reference: 'entry/process/energy_calibration/calibrated_axis'
+      \@energy_indices:
+        exists: recommended
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 6160b91a61ca173d4edfb5387255cfa174deb259b0b7d262bf45b45c493dd669
+# a234cd0d00b4e271886032630f3b03664c3a293da78870813433d7205d9e1607
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -1667,21 +1693,49 @@ NXmpes(NXobject):
 #                 <doc>
 #                      Calibrated energy axis.
 #                      
-#                      This could be a link to either
-#                      /entry/process/energy_calibration/calibrated_axis or
-#                      /entry/process/energy_correction/calibrated_axis.
+#                      Could be linked from the respective '@reference' field.
 #                 </doc>
-#                 <attribute name="type" recommended="true"/>
+#                 <attribute name="type" type="NX_CHAR">
+#                     <doc>
+#                          The energy can be either stored as kinetic or as binding energy.
+#                     </doc>
+#                     <enumeration>
+#                         <item value="kinetic">
+#                             <doc>
+#                                  Calibrated kinetic energy axis.
+#                                  
+#                                  In case the kinetic energy axis is referenced to the Fermi level :math:`E_F`
+#                                  (e.g., in entry/process/energy_referencing), kinetic energies :math:`E` are
+#                                  provided as :math:`E-E_F`.
+#                                  
+#                                  This concept is related to term `3.35`_ of the ISO 18115-1:2023 standard.
+#                                  
+#                                  .. _3.35: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:3.35
+#                             </doc>
+#                         </item>
+#                         <item value="binding">
+#                             <doc>
+#                                  Calibrated binding energy axis.
+#                                  
+#                                  This concept is related to term `12.16`_ of the ISO 18115-1:2023 standard.
+#                                  
+#                                  .. _12.16: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:12.16
+#                             </doc>
+#                         </item>
+#                     </enumeration>
+#                 </attribute>
+#                 <attribute name="reference" type="NX_CHAR" recommended="true">
+#                     <doc>
+#                          The energy can be dispersed according to different strategies. ``@reference`` points to
+#                          the path of a field defining the calibrated axis which the ``energy`` axis refers.
+#                          
+#                          For example:
+#                            @reference: 'entry/process/energy_calibration/calibrated_axis'
+#                            @reference: 'entry/process/energy_calibration/calibrated_axis'
+#                     </doc>
+#                 </attribute>
 #             </field>
-#             <attribute name="energy_depends" type="NX_CHAR" optional="true">
-#                 <doc>
-#                      The energy can be dispersed according to different strategies. ``energy_depends`` points to
-#                      the path of a field defining the calibrated axis on which the energy axis depends.
-#                      
-#                      For example:
-#                        @energy_depends: 'entry/process/energy_calibration'
-#                 </doc>
-#             </attribute>
+#             <attribute name="energy_indices" recommended="true"/>
 #         </group>
 #     </group>
 # </definition>

--- a/contributed_definitions/nyaml/NXmpes.yaml
+++ b/contributed_definitions/nyaml/NXmpes.yaml
@@ -815,12 +815,11 @@ NXmpes(NXobject):
             
             For example:
               @reference: 'entry/process/energy_calibration/calibrated_axis'
-              @reference: 'entry/process/energy_calibration/calibrated_axis'
       \@energy_indices:
         exists: recommended
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# a234cd0d00b4e271886032630f3b03664c3a293da78870813433d7205d9e1607
+# 42afcf3e913ccfb71ad3cf68713406ace3a757ff817a22b1cf47ad63551912ea
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -1730,7 +1729,6 @@ NXmpes(NXobject):
 #                          the path of a field defining the calibrated axis which the ``energy`` axis refers.
 #                          
 #                          For example:
-#                            @reference: 'entry/process/energy_calibration/calibrated_axis'
 #                            @reference: 'entry/process/energy_calibration/calibrated_axis'
 #                     </doc>
 #                 </attribute>

--- a/contributed_definitions/nyaml/NXmpes_arpes.yaml
+++ b/contributed_definitions/nyaml/NXmpes_arpes.yaml
@@ -202,44 +202,49 @@ NXmpes_arpes(NXmpes):
       \@energy_indices:
       \@angular0_indices:
       \@angular1_indices:
-      \@angular0_depends:
-        doc: |
-          Points to the path to a field defining the axis on which the angular axis depends.
-          For example:
-          @angular0_depends: '/entry/sample/transformations/sample_tilt' for a manipulator angular scan
-          @angular0_depends: '/entry/instrument/detector/sensor_x' for a 2D detector
-          @angular0_depends: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
-          @angular0_depends: '/entry/process/calibration/angular0_calibration/calibrated_axis' for a preprocessed axis.
-      \@angular1_depends:
-        doc: |
-          Points to the path to a field defining the axis on which the angular axis depends.
-          For example:
-          @angular1_depends: '/entry/sample/transformations/sample_polar' for a manipulator angular scan
-          @angular1_depends: '/entry/instrument/detector/sensor_x' for a 2D detector
-          @angular1_depends: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
-          @angular1_depends: '/entry/process/calibration/angular1_calibration/calibrated_axis' for a preprocessed axis.
-      \@energy_depends:
-        doc: |
-          Points to the path to a field defining the axis on which the energy axis depends.
-          For example:
-          @energy_depends: '/entry/instrument/detector/sensor_y' for a 2D detector
-          @energy_depends: '/entry/instrument/energydispersion/center_kinetic_energy' for a swept scan
-          @energy_depends: '/entry/process/calibration/energy_calibration/calibrated_axis' for a preprocessed axis.
       energy(NX_NUMBER):
         unit: NX_ENERGY
         doc: |
-          Trace of the energy axis. Could be linked from the respective 'AXISNAME_depends'
+          Trace of the energy axis. Could be linked from the respective '@reference'
           field.
+        \@reference:
+          exists: recommended
+          doc: |
+            Points to the path of a field defining the calibrated axis which the ``energy`` axis refers.
+            
+            For example:
+              @reference: '/entry/instrument/detector/sensor_y' for a 2D detector
+              @reference: '/entry/instrument/energydispersion/center_kinetic_energy' for a swept scan
+              @reference: '/entry/process/calibration/energy_calibration/calibrated_axis' for a preprocessed axis.
       angular0(NX_NUMBER):
         unit: NX_ANGLE
         doc: |
           Trace of the first angular axis. Could be linked from the respective
-          'AXISNAME_depends' field.
+          '@reference' field.
+        \@reference:
+          exists: recommended
+          doc: |
+            Points to the path of a field defining the calibrated axis which the ``angular0`` axis refers.
+            
+            For example:
+              @reference: '/entry/sample/transformations/sample_tilt' for a manipulator angular scan
+              @reference: '/entry/instrument/detector/sensor_x' for a 2D detector
+              @reference: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
+              @reference: '/entry/process/calibration/angular0_calibration/calibrated_axis' for a preprocessed axis.
       angular1(NX_NUMBER):
         unit: NX_ANGLE
         doc: |
-          Trace of the second axis. Could be linked from the respective 'AXISNAME_depends'
+          Trace of the second axis. Could be linked from the respective '@reference'
           field.
+        \@reference:
+          exists: recommended
+          doc: |
+            Points to the path to a field defining the axis  which the ``angular1`` axis refers.
+            For example:
+              @reference: '/entry/sample/transformations/sample_polar' for a manipulator angular scan
+              @reference: '/entry/instrument/detector/sensor_y' for a 2D detector
+              @reference: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
+              @reference: '/entry/process/calibration/angular1_calibration/calibrated_axis' for a preprocessed axis.
       data(NX_NUMBER):
         unit: NX_ANY
         doc: |
@@ -248,7 +253,7 @@ NXmpes_arpes(NXmpes):
           should be linked to the actual encoder position in NXinstrument or calibrated axes in NXprocess.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# b550ab06085897f916a57c3670dbe3222913b72b29731c6ba6cd0d5d4f1e160f
+# 20400bee49a8823607813b31aea621d3f92a505ce27e88b354d6e9bb68901da0
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -606,52 +611,54 @@ NXmpes_arpes(NXmpes):
 #             <attribute name="energy_indices"/>
 #             <attribute name="angular0_indices"/>
 #             <attribute name="angular1_indices"/>
-#             <attribute name="angular0_depends">
+#             <field name="energy" type="NX_NUMBER" units="NX_ENERGY">
 #                 <doc>
-#                      Points to the path to a field defining the axis on which the angular axis depends.
-#                      For example:
-#                      @angular0_depends: '/entry/sample/transformations/sample_tilt' for a manipulator angular scan
-#                      @angular0_depends: '/entry/instrument/detector/sensor_x' for a 2D detector
-#                      @angular0_depends: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
-#                      @angular0_depends: '/entry/process/calibration/angular0_calibration/calibrated_axis' for a preprocessed axis.
-#                 </doc>
-#             </attribute>
-#             <attribute name="angular1_depends">
-#                 <doc>
-#                      Points to the path to a field defining the axis on which the angular axis depends.
-#                      For example:
-#                      @angular1_depends: '/entry/sample/transformations/sample_polar' for a manipulator angular scan
-#                      @angular1_depends: '/entry/instrument/detector/sensor_x' for a 2D detector
-#                      @angular1_depends: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
-#                      @angular1_depends: '/entry/process/calibration/angular1_calibration/calibrated_axis' for a preprocessed axis.
-#                 </doc>
-#             </attribute>
-#             <attribute name="energy_depends">
-#                 <doc>
-#                      Points to the path to a field defining the axis on which the energy axis depends.
-#                      For example:
-#                      @energy_depends: '/entry/instrument/detector/sensor_y' for a 2D detector
-#                      @energy_depends: '/entry/instrument/energydispersion/center_kinetic_energy' for a swept scan
-#                      @energy_depends: '/entry/process/calibration/energy_calibration/calibrated_axis' for a preprocessed axis.
-#                 </doc>
-#             </attribute>
-#             <field name="energy" type="NX_NUMBER" units="NY_ENERGY">
-#                 <doc>
-#                      Trace of the energy axis. Could be linked from the respective 'AXISNAME_depends'
+#                      Trace of the energy axis. Could be linked from the respective '@reference'
 #                      field.
 #                 </doc>
+#                 <attribute name="reference" recommended="true">
+#                     <doc>
+#                          Points to the path of a field defining the calibrated axis which the ``energy`` axis refers.
+#                          
+#                          For example:
+#                            @reference: '/entry/instrument/detector/sensor_y' for a 2D detector
+#                            @reference: '/entry/instrument/energydispersion/center_kinetic_energy' for a swept scan
+#                            @reference: '/entry/process/calibration/energy_calibration/calibrated_axis' for a preprocessed axis.
+#                     </doc>
+#                 </attribute>
 #             </field>
 #             <field name="angular0" type="NX_NUMBER" units="NX_ANGLE">
 #                 <doc>
 #                      Trace of the first angular axis. Could be linked from the respective
-#                      'AXISNAME_depends' field.
+#                      '@reference' field.
 #                 </doc>
+#                 <attribute name="reference" recommended="true">
+#                     <doc>
+#                          Points to the path of a field defining the calibrated axis which the ``angular0`` axis refers.
+#                          
+#                          For example:
+#                            @reference: '/entry/sample/transformations/sample_tilt' for a manipulator angular scan
+#                            @reference: '/entry/instrument/detector/sensor_x' for a 2D detector
+#                            @reference: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
+#                            @reference: '/entry/process/calibration/angular0_calibration/calibrated_axis' for a preprocessed axis.
+#                     </doc>
+#                 </attribute>
 #             </field>
-#             <field name="angular1" type="NX_NUMBER" units="ANX_ANGLE">
+#             <field name="angular1" type="NX_NUMBER" units="NX_ANGLE">
 #                 <doc>
-#                      Trace of the second axis. Could be linked from the respective 'AXISNAME_depends'
+#                      Trace of the second axis. Could be linked from the respective '@reference'
 #                      field.
 #                 </doc>
+#                 <attribute name="reference" recommended="true">
+#                     <doc>
+#                          Points to the path to a field defining the axis  which the ``angular1`` axis refers.
+#                          For example:
+#                            @reference: '/entry/sample/transformations/sample_polar' for a manipulator angular scan
+#                            @reference: '/entry/instrument/detector/sensor_y' for a 2D detector
+#                            @reference: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
+#                            @reference: '/entry/process/calibration/angular1_calibration/calibrated_axis' for a preprocessed axis.
+#                     </doc>
+#                 </attribute>
 #             </field>
 #             <field name="data" type="NX_NUMBER" units="NX_ANY">
 #                 <doc>

--- a/contributed_definitions/nyaml/NXmpes_arpes.yaml
+++ b/contributed_definitions/nyaml/NXmpes_arpes.yaml
@@ -205,12 +205,12 @@ NXmpes_arpes(NXmpes):
       energy(NX_NUMBER):
         unit: NX_ENERGY
         doc: |
-          Trace of the energy axis. Could be linked from the respective '@reference'
+          Trace of the energy axis. Could be linked from the respective ``@reference``
           field.
         \@reference:
           exists: recommended
           doc: |
-            Points to the path of a field defining the calibrated axis which the ``energy`` axis refers.
+            Points to the path of a field defining the calibrated axis which the energy axis refers.
             
             For example:
               @reference: '/entry/instrument/detector/sensor_y' for a 2D detector
@@ -220,7 +220,7 @@ NXmpes_arpes(NXmpes):
         unit: NX_ANGLE
         doc: |
           Trace of the first angular axis. Could be linked from the respective
-          '@reference' field.
+          ``@reference`` field.
         \@reference:
           exists: recommended
           doc: |
@@ -234,12 +234,13 @@ NXmpes_arpes(NXmpes):
       angular1(NX_NUMBER):
         unit: NX_ANGLE
         doc: |
-          Trace of the second axis. Could be linked from the respective '@reference'
+          Trace of the second axis. Could be linked from the respective ``@reference``
           field.
         \@reference:
           exists: recommended
           doc: |
-            Points to the path to a field defining the axis  which the ``angular1`` axis refers.
+            Points to the path of a field defining the calibrated axis which the ``angular1`` axis refers.
+            
             For example:
               @reference: '/entry/sample/transformations/sample_polar' for a manipulator angular scan
               @reference: '/entry/instrument/detector/sensor_y' for a 2D detector
@@ -253,7 +254,7 @@ NXmpes_arpes(NXmpes):
           should be linked to the actual encoder position in NXinstrument or calibrated axes in NXprocess.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 20400bee49a8823607813b31aea621d3f92a505ce27e88b354d6e9bb68901da0
+# 3b1e58cabb7b243061af49cd2bc38324b715a2320bab79fc406b3d2c18e4c9d1
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -613,12 +614,12 @@ NXmpes_arpes(NXmpes):
 #             <attribute name="angular1_indices"/>
 #             <field name="energy" type="NX_NUMBER" units="NX_ENERGY">
 #                 <doc>
-#                      Trace of the energy axis. Could be linked from the respective '@reference'
+#                      Trace of the energy axis. Could be linked from the respective ``@reference``
 #                      field.
 #                 </doc>
 #                 <attribute name="reference" recommended="true">
 #                     <doc>
-#                          Points to the path of a field defining the calibrated axis which the ``energy`` axis refers.
+#                          Points to the path of a field defining the calibrated axis which the energy axis refers.
 #                          
 #                          For example:
 #                            @reference: '/entry/instrument/detector/sensor_y' for a 2D detector
@@ -630,7 +631,7 @@ NXmpes_arpes(NXmpes):
 #             <field name="angular0" type="NX_NUMBER" units="NX_ANGLE">
 #                 <doc>
 #                      Trace of the first angular axis. Could be linked from the respective
-#                      '@reference' field.
+#                      ``@reference`` field.
 #                 </doc>
 #                 <attribute name="reference" recommended="true">
 #                     <doc>
@@ -646,12 +647,13 @@ NXmpes_arpes(NXmpes):
 #             </field>
 #             <field name="angular1" type="NX_NUMBER" units="NX_ANGLE">
 #                 <doc>
-#                      Trace of the second axis. Could be linked from the respective '@reference'
+#                      Trace of the second axis. Could be linked from the respective ``@reference``
 #                      field.
 #                 </doc>
 #                 <attribute name="reference" recommended="true">
 #                     <doc>
-#                          Points to the path to a field defining the axis  which the ``angular1`` axis refers.
+#                          Points to the path of a field defining the calibrated axis which the ``angular1`` axis refers.
+#                          
 #                          For example:
 #                            @reference: '/entry/sample/transformations/sample_polar' for a manipulator angular scan
 #                            @reference: '/entry/instrument/detector/sensor_y' for a 2D detector


### PR DESCRIPTION
This enables the option to describe where the signal data of an NXdata comes from. It's a similar concept as the `AXISNAME_depends`. It's just a proposal open for discussion and I'm not entirely sure if this is the right path to do it. So I welcome your feedback @lukaspie and @rettigl. Also general feedback from @FAIRmat-NFDI/areab is welcome.

Different options could be:
- Additionally or instead provide a `depends` field for the NXdata group to denote that it was linked to somewhere else. This is essentially a shortcut for writing out `AXISNAME_depends` + `DATA_depends` if they belong to the same target group.
- Allowing an array or different mechanism here to also describe composite data, e.g., if we combine two detectors together and need to denote which axis comes from where. There we'd need an additional mechanism to tie the axisname to the data depends.

This is coming from a recent discussion with Anders Hahlin and Anders Frisk. They are trying to combine multiple detector readings into the top-level `data` (e.g., for spin-resolved measurements).