### PR TITLE
Additions to NXsource and NXdeflector

### DIFF
--- a/base_classes/NXsource.nxdl.xml
+++ b/base_classes/NXsource.nxdl.xml
@@ -113,9 +113,9 @@
     </field>
     <field name="energy" type="NX_FLOAT" units="NX_ENERGY">
         <doc>
-             Source energy.
-             For storage rings, this would be the particle beam energy.
-             For X-ray tubes, this would be the excitation voltage.
+             Source energy. Typically, this would be the energy of
+             the emitted beam. For storage rings, this would be
+             the particle beam energy.
         </doc>
     </field>
     <field name="current" type="NX_FLOAT" units="NX_CURRENT">
@@ -245,9 +245,44 @@
              by the pulse duration
         </doc>
     </field>
+    <field name="anode_material">
+        <doc>
+             Material of the anode (for X-ray tubes).
+        </doc>
+    </field>
+    <field name="filament_current" type="NX_FLOAT">
+        <doc>
+             Filament current (for X-ray tubes).
+        </doc>
+    </field>
+    <field name="emission_current" type="NX_FLOAT">
+        <doc>
+             Emission current of the generated beam.
+        </doc>
+    </field>
+    <field name="gas_pressure" type="NX_FLOAT">
+        <doc>
+             Gas pressure inside ionization source.
+        </doc>
+    </field>
     <group name="geometry" type="NXgeometry" deprecated="Use the field `depends_on` and :ref:`NXtransformations` to position the source and NXoff_geometry to describe its shape instead">
         <doc>
              "Engineering" location of source.
+        </doc>
+    </group>
+    <group type="NXaperture">
+        <doc>
+             The size and position of an aperture inside the source.
+        </doc>
+    </group>
+    <group type="NXdeflector">
+        <doc>
+             Deflectors inside the source.
+        </doc>
+    </group>
+    <group type="NXlens_em">
+        <doc>
+             Individual electromagnetic lenses inside the source.
         </doc>
     </group>
     <group type="NXfabrication"/>

--- a/base_classes/NXsource.nxdl.xml
+++ b/base_classes/NXsource.nxdl.xml
@@ -250,17 +250,17 @@
              Material of the anode (for X-ray tubes).
         </doc>
     </field>
-    <field name="filament_current" type="NX_FLOAT">
+    <field name="filament_current" type="NX_FLOAT" units="NX_CURRENT">
         <doc>
              Filament current (for X-ray tubes).
         </doc>
     </field>
-    <field name="emission_current" type="NX_FLOAT">
+    <field name="emission_current" type="NX_FLOAT" units="NX_CURRENT">
         <doc>
              Emission current of the generated beam.
         </doc>
     </field>
-    <field name="gas_pressure" type="NX_FLOAT">
+    <field name="gas_pressure" type="NX_FLOAT" units="NX_PRESSURE">
         <doc>
              Gas pressure inside ionization source.
         </doc>

--- a/base_classes/nyaml/NXsource.yaml
+++ b/base_classes/nyaml/NXsource.yaml
@@ -149,12 +149,15 @@ NXsource(NXobject):
     doc: |
       Material of the anode (for X-ray tubes).
   filament_current(NX_FLOAT):
+    unit: NX_CURRENT
     doc: |
       Filament current (for X-ray tubes).
   emission_current(NX_FLOAT):
+    unit: NX_CURRENT
     doc: |
       Emission current of the generated beam.
   gas_pressure(NX_FLOAT):
+    unit: NX_PRESSURE
     doc: |
       Gas pressure inside ionization source.
   geometry(NXgeometry):
@@ -212,7 +215,7 @@ NXsource(NXobject):
       other component groups.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# adecbe1ee83c23125e44451d029bbe1b3437f6cd840150ced711f13a74478b92
+# 2e2112dcd5b309b4339af1ac92e7ff2d12e639c98146519a85e6f4bdd85adbb2
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -465,17 +468,17 @@ NXsource(NXobject):
 #              Material of the anode (for X-ray tubes).
 #         </doc>
 #     </field>
-#     <field name="filament_current" type="NX_FLOAT">
+#     <field name="filament_current" type="NX_FLOAT" units="NX_CURRENT">
 #         <doc>
 #              Filament current (for X-ray tubes).
 #         </doc>
 #     </field>
-#     <field name="emission_current" type="NX_FLOAT">
+#     <field name="emission_current" type="NX_FLOAT" units="NX_CURRENT">
 #         <doc>
 #              Emission current of the generated beam.
 #         </doc>
 #     </field>
-#     <field name="gas_pressure" type="NX_FLOAT">
+#     <field name="gas_pressure" type="NX_FLOAT" units="NX_PRESSURE">
 #         <doc>
 #              Gas pressure inside ionization source.
 #         </doc>

--- a/base_classes/nyaml/NXsource.yaml
+++ b/base_classes/nyaml/NXsource.yaml
@@ -53,9 +53,9 @@ NXsource(NXobject):
   energy(NX_FLOAT):
     unit: NX_ENERGY
     doc: |
-      Source energy.
-      For storage rings, this would be the particle beam energy.
-      For X-ray tubes, this would be the excitation voltage.
+      Source energy. Typically, this would be the energy of
+      the emitted beam. For storage rings, this would be
+      the particle beam energy.
   current(NX_FLOAT):
     unit: NX_CURRENT
     doc: |
@@ -145,11 +145,32 @@ NXsource(NXobject):
     doc: |
       For pulsed sources, the pulse energy divided
       by the pulse duration
+  anode_material:
+    doc: |
+      Material of the anode (for X-ray tubes).
+  filament_current(NX_FLOAT):
+    doc: |
+      Filament current (for X-ray tubes).
+  emission_current(NX_FLOAT):
+    doc: |
+      Emission current of the generated beam.
+  gas_pressure(NX_FLOAT):
+    doc: |
+      Gas pressure inside ionization source.
   geometry(NXgeometry):
     deprecated: |
       Use the field `depends_on` and :ref:`NXtransformations` to position the source and NXoff_geometry to describe its shape instead
     doc: |
       "Engineering" location of source.
+  (NXaperture):
+    doc: |
+      The size and position of an aperture inside the source.
+  (NXdeflector):
+    doc: |
+      Deflectors inside the source.
+  (NXlens_em):
+    doc: |
+      Individual electromagnetic lenses inside the source.
   (NXfabrication):
   (NXoff_geometry):
     exists: ['min', '0']
@@ -191,7 +212,7 @@ NXsource(NXobject):
       other component groups.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 45f1f3aa580c93a57ab6b7b0f301f8e4b91e19c36f63e65109da961f88402285
+# adecbe1ee83c23125e44451d029bbe1b3437f6cd840150ced711f13a74478b92
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -307,9 +328,9 @@ NXsource(NXobject):
 #     </field>
 #     <field name="energy" type="NX_FLOAT" units="NX_ENERGY">
 #         <doc>
-#              Source energy.
-#              For storage rings, this would be the particle beam energy.
-#              For X-ray tubes, this would be the excitation voltage.
+#              Source energy. Typically, this would be the energy of
+#              the emitted beam. For storage rings, this would be
+#              the particle beam energy.
 #         </doc>
 #     </field>
 #     <field name="current" type="NX_FLOAT" units="NX_CURRENT">
@@ -439,9 +460,44 @@ NXsource(NXobject):
 #              by the pulse duration
 #         </doc>
 #     </field>
+#     <field name="anode_material">
+#         <doc>
+#              Material of the anode (for X-ray tubes).
+#         </doc>
+#     </field>
+#     <field name="filament_current" type="NX_FLOAT">
+#         <doc>
+#              Filament current (for X-ray tubes).
+#         </doc>
+#     </field>
+#     <field name="emission_current" type="NX_FLOAT">
+#         <doc>
+#              Emission current of the generated beam.
+#         </doc>
+#     </field>
+#     <field name="gas_pressure" type="NX_FLOAT">
+#         <doc>
+#              Gas pressure inside ionization source.
+#         </doc>
+#     </field>
 #     <group name="geometry" type="NXgeometry" deprecated="Use the field `depends_on` and :ref:`NXtransformations` to position the source and NXoff_geometry to describe its shape instead">
 #         <doc>
 #              "Engineering" location of source.
+#         </doc>
+#     </group>
+#     <group type="NXaperture">
+#         <doc>
+#              The size and position of an aperture inside the source.
+#         </doc>
+#     </group>
+#     <group type="NXdeflector">
+#         <doc>
+#              Deflectors inside the source.
+#         </doc>
+#     </group>
+#     <group type="NXlens_em">
+#         <doc>
+#              Individual electromagnetic lenses inside the source.
 #         </doc>
 #     </group>
 #     <group type="NXfabrication"/>

--- a/contributed_definitions/NXdeflector.nxdl.xml
+++ b/contributed_definitions/NXdeflector.nxdl.xml
@@ -61,6 +61,18 @@
              higher orders, it is an array.
         </doc>
     </field>
+    <field name="offset_x" type="NX_NUMBER" units="NX_LENGTH">
+        <doc>
+             Spatial offset of the deflector in x direction (perpendicular to
+             ```offset_y```).
+        </doc>
+    </field>
+    <field name="offset_y" type="NX_NUMBER" units="NX_LENGTH">
+        <doc>
+             Spatial offset of the deflector in y direction (perpendicular to
+             ```offset_x```).
+        </doc>
+    </field>
     <attribute name="depends_on" type="NX_CHAR">
         <doc>
              Specifies the position of the deflector by pointing to the last transformation

--- a/contributed_definitions/NXdeflector.nxdl.xml
+++ b/contributed_definitions/NXdeflector.nxdl.xml
@@ -79,7 +79,6 @@
              in the transformation chain in the NXtransformations group.
         </doc>
     </attribute>
-    <!--discuss NXcomponent_mpes ?-->
     <group type="NXtransformations">
         <doc>
              Collection of axis-based translations and rotations to describe the location and

--- a/contributed_definitions/nyaml/NXdeflector.yaml
+++ b/contributed_definitions/nyaml/NXdeflector.yaml
@@ -41,8 +41,6 @@ NXdeflector(NXobject):
     doc: |
       Specifies the position of the deflector by pointing to the last transformation
       in the transformation chain in the NXtransformations group.
-  
-  # discuss NXcomponent_mpes ?
   (NXtransformations):
     doc: |
       Collection of axis-based translations and rotations to describe the location and
@@ -55,7 +53,7 @@ NXdeflector(NXobject):
       the reference coordinate system.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 0a4b2319a9b964e563adfe3b7206dae2a9667bb19228346d3c3d011d74c1166c
+# e16416dcbac006d9e2a7fff7c0ed1d61a6bed2d1f6254a419f10f6ab36922cc5
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -137,7 +135,6 @@ NXdeflector(NXobject):
 #              in the transformation chain in the NXtransformations group.
 #         </doc>
 #     </attribute>
-#     <!--discuss NXcomponent_mpes ?-->
 #     <group type="NXtransformations">
 #         <doc>
 #              Collection of axis-based translations and rotations to describe the location and

--- a/contributed_definitions/nyaml/NXdeflector.yaml
+++ b/contributed_definitions/nyaml/NXdeflector.yaml
@@ -12,24 +12,36 @@ NXdeflector(NXobject):
       Colloquial or short name for the deflector. For manufacturer names and
       identifiers use respective manufacturer fields.
   (NXfabrication):
-  description(NX_CHAR):  # NXidentifier
+  description(NX_CHAR):
     doc: |
       Ideally an identifier, persistent link, or free text which gives
       further details about the deflector.
   voltage(NX_NUMBER):
+    unit: NX_VOLTAGE
     doc: |
       Excitation voltage of the deflector. For dipoles it is a single number.
       For higher order multipoles, it is an array.
-    unit: NX_VOLTAGE
   current(NX_NUMBER):
+    unit: NX_CURRENT
     doc: |
       Excitation current of the deflector. For dipoles it is a single number. For
       higher orders, it is an array.
-    unit: NX_CURRENT
-  \@depends_on(NX_CHAR):
+  offset_x(NX_NUMBER):
+    unit: NX_LENGTH
+    doc: |
+      Spatial offset of the deflector in x direction (perpendicular to
+      ```offset_y```).
+  offset_y(NX_NUMBER):
+    unit: NX_LENGTH
+    doc: |
+      Spatial offset of the deflector in y direction (perpendicular to
+      ```offset_x```).
+  \@depends_on:
+    type: NX_CHAR
     doc: |
       Specifies the position of the deflector by pointing to the last transformation
       in the transformation chain in the NXtransformations group.
+  
   # discuss NXcomponent_mpes ?
   (NXtransformations):
     doc: |
@@ -41,3 +53,101 @@ NXdeflector(NXobject):
       relative to the experimental setup. Typically, the components of a system should
       all be related relative to each other and only one component should relate to
       the reference coordinate system.
+
+# ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
+# 0a4b2319a9b964e563adfe3b7206dae2a9667bb19228346d3c3d011d74c1166c
+# <?xml version='1.0' encoding='UTF-8'?>
+# <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+# <!--
+# # NeXus - Neutron and X-ray Common Data Format
+# #
+# # Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+# #
+# # This library is free software; you can redistribute it and/or
+# # modify it under the terms of the GNU Lesser General Public
+# # License as published by the Free Software Foundation; either
+# # version 3 of the License, or (at your option) any later version.
+# #
+# # This library is distributed in the hope that it will be useful,
+# # but WITHOUT ANY WARRANTY; without even the implied warranty of
+# # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# # Lesser General Public License for more details.
+# #
+# # You should have received a copy of the GNU Lesser General Public
+# # License along with this library; if not, write to the Free Software
+# # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# #
+# # For further information, see http://www.nexusformat.org
+# -->
+# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXdeflector" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+#     <doc>
+#          Deflectors as they are used e.g. in an electron analyser.
+#     </doc>
+#     <field name="type" type="NX_CHAR">
+#         <doc>
+#              Qualitative type of deflector with respect to the number of pole pieces.
+#         </doc>
+#         <enumeration>
+#             <item value="dipole"/>
+#             <item value="quadrupole"/>
+#             <item value="hexapole"/>
+#             <item value="octupole"/>
+#         </enumeration>
+#     </field>
+#     <field name="name" type="NX_CHAR">
+#         <doc>
+#              Colloquial or short name for the deflector. For manufacturer names and
+#              identifiers use respective manufacturer fields.
+#         </doc>
+#     </field>
+#     <group type="NXfabrication"/>
+#     <field name="description" type="NX_CHAR">
+#         <doc>
+#              Ideally an identifier, persistent link, or free text which gives
+#              further details about the deflector.
+#         </doc>
+#     </field>
+#     <field name="voltage" type="NX_NUMBER" units="NX_VOLTAGE">
+#         <doc>
+#              Excitation voltage of the deflector. For dipoles it is a single number.
+#              For higher order multipoles, it is an array.
+#         </doc>
+#     </field>
+#     <field name="current" type="NX_NUMBER" units="NX_CURRENT">
+#         <doc>
+#              Excitation current of the deflector. For dipoles it is a single number. For
+#              higher orders, it is an array.
+#         </doc>
+#     </field>
+#     <field name="offset_x" type="NX_NUMBER" units="NX_LENGTH">
+#         <doc>
+#              Spatial offset of the deflector in x direction (perpendicular to
+#              ```offset_y```).
+#         </doc>
+#     </field>
+#     <field name="offset_y" type="NX_NUMBER" units="NX_LENGTH">
+#         <doc>
+#              Spatial offset of the deflector in y direction (perpendicular to
+#              ```offset_x```).
+#         </doc>
+#     </field>
+#     <attribute name="depends_on" type="NX_CHAR">
+#         <doc>
+#              Specifies the position of the deflector by pointing to the last transformation
+#              in the transformation chain in the NXtransformations group.
+#         </doc>
+#     </attribute>
+#     <!--discuss NXcomponent_mpes ?-->
+#     <group type="NXtransformations">
+#         <doc>
+#              Collection of axis-based translations and rotations to describe the location and
+#              geometry of the deflector as a component in the instrument. Conventions from the
+#              :ref:`NXtransformations` base class are used. In principle, the McStas coordinate
+#              system is used. The first transformation has to point either to another
+#              component of the system or . (for pointing to the reference frame) to relate it
+#              relative to the experimental setup. Typically, the components of a system should
+#              all be related relative to each other and only one component should relate to
+#              the reference coordinate system.
+#         </doc>
+#     </group>
+# </definition>


### PR DESCRIPTION
Adds some groups/fields to NXsource and NXdeflector. For NXsource specifically, generic `(NXaperture)`, `(NXdeflector)`, and `(NXlens_em)` are added which allow for a more detailed description of the individual components of the source.

These concepts inside NXsource were shown to be useful for the PHI XPS data reader (see [here](https://github.com/FAIRmat-NFDI/pynxtools-xps/blob/00bdee3cd15451e86a34597c9120ebf1c65f47c2/pynxtools_xps/config/config_phi.json#L50) for the config file making use of them), but should be generally enough also for other sources.