### PR TITLE
Change associated_beam and _source to NX_CHAR

### DIFF
--- a/contributed_definitions/NXmpes.nxdl.xml
+++ b/contributed_definitions/NXmpes.nxdl.xml
@@ -195,15 +195,16 @@
                     <field name="model" recommended="true"/>
                     <field name="identifier" recommended="true"/>
                 </group>
-                <group name="associated_beam" type="NXbeam">
+                <field name="associated_beam" type="NX_CHAR">
                     <doc>
-                         The beam emitted by this source.
+                         A reference to a beam emitted by this source.
                          Should be named with the same appendix, e.g.,
                          for `source_probe` it should refer to `beam_probe`.
-                         Refers to the same concept as /NXentry/NXinstrument/beamTYPE
-                         and may be linked.
+                         
+                         Example:
+                           * /entry/instrument/source_probe = /entry/instrument/beam_probe
                     </doc>
-                </group>
+                </field>
             </group>
             <group name="beamTYPE" type="NXbeam">
                 <doc>
@@ -223,16 +224,17 @@
                 <field name="incident_energy_spread" type="NX_NUMBER" recommended="true" units="NX_ENERGY"/>
                 <field name="incident_polarization" type="NX_NUMBER" recommended="true" units="NX_ANY"/>
                 <field name="extent" type="NX_FLOAT" recommended="true"/>
-                <group name="associated_source" type="NXsource" recommended="true">
+                <field name="associated_source" type="NX_CHAR" recommended="true">
                     <doc>
                          The source that emitted this beam.
                          Should be named with the same appendix, e.g.,
                          for `beam_probe` it should refer to `source_probe`.
-                         Refers to the same concept as /NXentry/NXinstrument/sourceTYPE
-                         and may be linked.
-                         Should be specified if an associated source exists.
+                         This should be specified if an associated source exists.
+                         
+                         Example:
+                           * /entry/instrument/beam_probe = /entry/instrument/source_probe
                     </doc>
-                </group>
+                </field>
             </group>
             <group type="NXelectronanalyser">
                 <group name="device_information" type="NXfabrication" recommended="true">

--- a/contributed_definitions/nyaml/NXmpes.yaml
+++ b/contributed_definitions/nyaml/NXmpes.yaml
@@ -148,13 +148,14 @@ NXmpes(NXobject):
             exists: recommended
           identifier:
             exists: recommended
-        associated_beam(NXbeam):
+        associated_beam(NX_CHAR):
           doc: |
-            The beam emitted by this source.
+            A reference to a beam emitted by this source.
             Should be named with the same appendix, e.g.,
             for `source_probe` it should refer to `beam_probe`.
-            Refers to the same concept as /NXentry/NXinstrument/beamTYPE
-            and may be linked.
+
+            Example:
+              * /entry/instrument/source_probe = /entry/instrument/beam_probe
       beamTYPE(NXbeam):
         doc: |
           Properties of the photon beam at a given location.
@@ -178,15 +179,16 @@ NXmpes(NXobject):
           unit: NX_ANY
         extent(NX_FLOAT):
           exists: recommended
-        associated_source(NXsource):
+        associated_source(NX_CHAR):
           exists: recommended
           doc: |
             The source that emitted this beam.
             Should be named with the same appendix, e.g.,
             for `beam_probe` it should refer to `source_probe`.
-            Refers to the same concept as /NXentry/NXinstrument/sourceTYPE
-            and may be linked.
-            Should be specified if an associated source exists.
+            This should be specified if an associated source exists.
+
+            Example:
+              * /entry/instrument/beam_probe = /entry/instrument/source_probe
       (NXelectronanalyser):
         device_information(NXfabrication):
           exists: recommended


### PR DESCRIPTION
This changes `associated_source` and `associated_beam` to NX_CHARs to just link them to the other concept.
I think it's the better approach than actually hard-linking the groups, because
1. We get recursion when viewing the file when both groups are present
2. The referred base classes `NXsource` and `NXbeam` are not the correct ones. It should be `NXmpes/ENTRY/INSTRUMENT/NXsource`/`NXbeam` but we cannot actually refer to this in the nxdl (at least that's what I think). This is also problematic when this gets parsed because NOMAD expects a class `NXsource`, which for example does not contain `HHG laser` as we define this in the appdef.

There might be solutions to support the current way but I think making this text links is much simpler and I don't really have an argument for actually linking this as group. We just would want to know which beams comes from which source and vice versa, right?