### PR TITLE
Overhaul of NXopt

### DIFF
--- a/contributed_definitions/NXellipsometry.nxdl.xml
+++ b/contributed_definitions/NXellipsometry.nxdl.xml
@@ -183,76 +183,97 @@ A rework of the draft version(06/2022) of a NeXus application definition for ell
                     <item value="compensator (detector side)"/>
                 </enumeration>
             </field>
-            <group type="NXbeam_path">
-                <!--light_source(NXsource):
- doc: |
-   Specify the used light source. Multiple selection possible.
- source_type:
-   enumeration: [arc lamp, halogen lamp, LED, other]-->
-                <group name="focussing_probes" type="NXlens_opt" optional="true">
+            <group name="focussing_probes" type="NXlens_opt" optional="true">
+                <doc>
+                     If focussing probes (lenses) were used, please state if the data
+                     were corrected for the window effects.
+                </doc>
+                <!--This as well can be stated in window/aperture-->
+                <field name="data_correction" type="NX_BOOLEAN">
                     <doc>
-                         If focussing probes (lenses) were used, please state if the data
-                         were corrected for the window effects.
+                         Were the recorded data corrected by the window effects of the
+                         focussing probes (lenses)?
                     </doc>
-                    <!--This as well can be stated in window/aperture-->
-                    <field name="data_correction" type="NX_BOOLEAN">
-                        <doc>
-                             Were the recorded data corrected by the window effects of the
-                             focussing probes (lenses)?
-                        </doc>
-                    </field>
-                    <field name="angular_spread" type="NX_NUMBER" recommended="true" units="NX_ANGLE">
-                        <doc>
-                             Specify the angular spread caused by the focussing probes.
-                        </doc>
-                    </field>
-                </group>
-                <group name="rotating_element" type="NXwaveplate" optional="true">
+                </field>
+                <field name="angular_spread" type="NX_NUMBER" recommended="true" units="NX_ANGLE">
                     <doc>
-                         Properties of the rotating element defined in
-                         'instrument/rotating_element_type'.
+                         Specify the angular spread caused by the focussing probes.
                     </doc>
-                    <field name="revolutions" type="NX_NUMBER" optional="true" units="NX_COUNT">
-                        <doc>
-                             Define how many revolutions of the rotating element were averaged
-                             for each measurement. If the number of revolutions was fixed to a
-                             certain value use the field 'fixed_revolutions' instead.
-                        </doc>
-                    </field>
-                    <field name="fixed_revolutions" type="NX_NUMBER" optional="true" units="NX_COUNT">
-                        <doc>
-                             Define how many revolutions of the rotating element were taken
-                             into account for each measurement (if number of revolutions was
-                             fixed to a certain value, i.e. not averaged).
-                        </doc>
-                    </field>
-                    <field name="max_revolutions" type="NX_NUMBER" optional="true" units="NX_COUNT">
-                        <doc>
-                             Specify the maximum value of revolutions of the rotating element
-                             for each measurement.
-                        </doc>
-                    </field>
-                </group>
+                </field>
+            </group>
+            <group name="rotating_element" type="NXwaveplate" optional="true">
+                <doc>
+                     Properties of the rotating element defined in
+                     'instrument/rotating_element_type'.
+                </doc>
+                <field name="revolutions" type="NX_NUMBER" optional="true" units="NX_COUNT">
+                    <doc>
+                         Define how many revolutions of the rotating element were averaged
+                         for each measurement. If the number of revolutions was fixed to a
+                         certain value use the field 'fixed_revolutions' instead.
+                    </doc>
+                </field>
+                <field name="fixed_revolutions" type="NX_NUMBER" optional="true" units="NX_COUNT">
+                    <doc>
+                         Define how many revolutions of the rotating element were taken
+                         into account for each measurement (if number of revolutions was
+                         fixed to a certain value, i.e. not averaged).
+                    </doc>
+                </field>
+                <field name="max_revolutions" type="NX_NUMBER" optional="true" units="NX_COUNT">
+                    <doc>
+                         Specify the maximum value of revolutions of the rotating element
+                         for each measurement.
+                    </doc>
+                </field>
             </group>
         </group>
         <group type="NXsample">
-            <field name="backside_roughness" type="NX_BOOLEAN" recommended="true">
+            <field name="backside_roughness" type="NX_BOOLEAN" optional="true">
                 <doc>
                      Was the backside of the sample roughened? Relevant for infrared
                      ellipsometry.
                 </doc>
             </field>
         </group>
-        <group type="NXdata">
+        <!--The following NXdata setction called data_collection, is specialization
+from the old (NXopt and NXellipsometry) for the new NXellipometry.
+The generic description of the data collection will in future be
+included in the generic NXopt, but is now keept limited to
+NXellipsometry.-->
+        <group name="data_collection" type="NXdata">
+            <doc>
+                 Measured data, data errors, and varied parameters. This may be used to describe
+                 indirectly derived data or data transformed between different descriptions,
+                 such as:
+                 Raw Data --&gt; Psi
+                 Delta Psi, Delta --&gt; N,C,S
+                 Mueller matrix --&gt; N,C,S
+                 Mueller matrix --&gt; Psi, Delta
+                 etc.
+                 
+                 Other types of data, such as temperature or sample location, may be saved
+                 in a generic (NXdata) concept from NXopt, or better directly in the
+                 location of the sample positioner or temperature sensor.
+            </doc>
+            <field name="data_identifier" type="NX_NUMBER">
+                <doc>
+                     An identifier to correlate data to the experimental conditions,
+                     if several were used in this measurement; typically an index of 0-N.
+                </doc>
+            </field>
             <field name="data_type">
                 <doc>
-                     Select which type of data was recorded, for example Psi and Delta
-                     (see: https://en.wikipedia.org/wiki/Ellipsometry#Data_acquisition).
-                     It is possible to have multiple selections. Data types may also be
-                     converted to each other, e.g. a Mueller matrix contains N,C,S data
-                     as well.
+                     Select which type of data was recorded, for example intensity,
+                     reflectivity, transmittance, Psi and Delta etc.
+                     It is possible to have multiple selections. The enumeration list
+                     depends on the type of experiment and may differ for different
+                     application definitions.
                 </doc>
                 <enumeration>
+                    <item value="intensity"/>
+                    <item value="reflectivity"/>
+                    <item value="transmittance"/>
                     <item value="Psi/Delta"/>
                     <item value="tan(Psi)/cos(Delta)"/>
                     <item value="Mueller matrix"/>
@@ -261,6 +282,111 @@ A rework of the draft version(06/2022) of a NeXus application definition for ell
                     <item value="raw data"/>
                 </enumeration>
             </field>
+            <field name="NAME_spectrum" type="NX_FLOAT" optional="true" units="NX_ANY">
+                <doc>
+                     Spectral values (e.g. wavelength or energy) used for the measurement.
+                     An array of 1 or more elements. Length defines N_spectrum. Replace
+                     'SPECTRUM' by the physical quantity that is used, e.g. wavelength.
+                </doc>
+                <dimensions rank="1">
+                    <dim index="1" value="N_spectrum"/>
+                </dimensions>
+                <attribute name="units" optional="true">
+                    <doc>
+                         If applicable, change 'unit: NX_ANY' to the appropriate NXDL unit.
+                         If the unit of the measured data is not covered by NXDL units state
+                         here which unit was used.
+                    </doc>
+                </attribute>
+            </field>
+            <field name="measured_data" type="NX_FLOAT" units="NX_ANY">
+                <doc>
+                     Resulting data from the measurement, described by 'data_type'.
+                     
+                     The first dimension is defined by the number of measurements taken,
+                     (N_measurements). The instructions on how to order the values
+                     contained in the parameter vectors given in the doc string of
+                     INSTRUMENT/sample_stage/environment_conditions/PARAMETER/values,
+                     define the N_measurements parameter sets. For example, if the
+                     experiment was performed at three different temperatures
+                     (T1, T2, T3), two different pressures (p1, p2) and two different
+                     angles of incidence (a1, a2), the first measurement was taken at the
+                     parameters {a1,p1,T1}, the second measurement at {a1,p1,T2} etc.
+                </doc>
+                <dimensions rank="3">
+                    <dim index="1" value="N_measurements"/>
+                    <dim index="2" value="N_observables"/>
+                    <dim index="3" value="N_spectrum"/>
+                </dimensions>
+                <attribute name="units" optional="true">
+                    <doc>
+                         If applicable, change 'unit: NX_ANY' to the appropriate NXDL unit.
+                         If the unit of the measured data is not covered by NXDL units state
+                         here which unit was used.
+                    </doc>
+                </attribute>
+            </field>
+            <field name="measured_data_errors" type="NX_FLOAT" optional="true" units="NX_ANY">
+                <doc>
+                     Specified uncertainties (errors) of the data described by 'data_type'
+                     and provided in 'measured_data'.
+                </doc>
+                <dimensions rank="3">
+                    <dim index="1" value="N_measurements"/>
+                    <dim index="2" value="N_observables"/>
+                    <dim index="3" value="N_spectrum"/>
+                </dimensions>
+                <attribute name="units" optional="true">
+                    <doc>
+                         If applicable, change 'unit: NX_ANY' to the appropriate NXDL unit.
+                         If the unit of the measured data is not covered by NXDL units state
+                         here which unit was used.
+                    </doc>
+                </attribute>
+            </field>
+            <field name="varied_parameter_link" optional="true">
+                <doc>
+                     List of links to the values of the sensors. Add a link for each
+                     varied parameter (i.e. for each sensor).
+                </doc>
+                <dimensions rank="1">
+                    <dim index="1" value="N_sensors"/>
+                </dimensions>
+            </field>
+            <field name="reference_data_link" optional="true">
+                <doc>
+                     Link to the NeXus file which describes the reference data if a
+                     reference measurement was performed. Ideally, the reference
+                     measurement was performed using the same conditions as the actual
+                     measurement and should be as close in time to the actual measurement
+                     as possible.
+                </doc>
+            </field>
+            <group name="data_software" type="NXprogram" optional="true">
+                <field name="program">
+                    <doc>
+                         Commercial or otherwise defined given name of the program that was
+                         used to generate the result file(s) with measured data and/or
+                         metadata (in most cases, this is the same as INSTRUMENT/software).
+                         If home written, one can provide the actual steps in the NOTE
+                         subfield here.
+                    </doc>
+                </field>
+                <field name="version">
+                    <doc>
+                         Either version with build number, commit hash, or description of a
+                         (online) repository where the source code of the program and build
+                         instructions can be found so that the program can be configured in
+                         such a way that result files can be created ideally in a
+                         deterministic manner.
+                    </doc>
+                </field>
+                <attribute name="url" optional="true">
+                    <doc>
+                         Website of the software.
+                    </doc>
+                </attribute>
+            </group>
         </group>
     </group>
 </definition>

--- a/contributed_definitions/NXellipsometry.nxdl.xml
+++ b/contributed_definitions/NXellipsometry.nxdl.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format
-# 
-# Copyright (C) 2014-2022 NeXus International Advisory Committee (NIAC)
-# 
+#
+# Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+#
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -21,28 +21,10 @@
 #
 # For further information, see http://www.nexusformat.org
 -->
-<!--06/2022
-A draft version of a NeXus application definition for ellipsometry.-->
-<!--The document has the following main elements:
-- Instrument used and is characteristics
-- Sample: Properties of the sample
-- Data: measured data, data errors
-- Derived parameters: e.g. extra parameters derived in the measurement software-->
-<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" name="NXellipsometry" extends="NXopt" type="group" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
-    <!--symbols:
-  doc: "Variables used throughout the document, e.g. dimensions and important parameters"
-  N_wavelength: "Size of the energy or wavelength vector used, the length of
-    NXinstrument/spectrometer/wavelength array"
-  N_variables: "How many variables are saved in a measurement. e.g. 2 for Psi
-    and Delta, 16 for Mueller matrix elements, 15 for normalized
-    Mueller matrix, 3 for NCS, the length of NXsample/column_names"
-  N_angles: "Number of incident angles used, the length of
-    NXinstrument/angle_of_incidence array"-->
-    <!--  N_p1:
-    "Number of sample parameters scanned, if you varied any of the parameters
-    such as temperature, pressure, or pH, the maximal length of the arrays
-    specified by NXsample/environment_conditions/SENSOR/value if it exists."
-  N_time: "Number of time points measured, the length of NXsample/time_points"-->
+<!--
+04/2024
+A rework of the draft version(06/2022) of a NeXus application definition for ellipsometry.-->
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXellipsometry" extends="NXopt" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
     <symbols>
         <doc>
              Variables used throughout the document, e.g. dimensions or parameters.
@@ -51,12 +33,6 @@ A draft version of a NeXus application definition for ellipsometry.-->
             <doc>
                  Length of the spectrum array (e.g. wavelength or energy) of the measured
                  data.
-            </doc>
-        </symbol>
-        <symbol name="N_sensors">
-            <doc>
-                 Number of sensors used to measure parameters that influence the sample,
-                 such as temperature or pressure.
             </doc>
         </symbol>
         <symbol name="N_measurements">
@@ -78,22 +54,16 @@ A draft version of a NeXus application definition for ellipsometry.-->
                  Number of angles of incidence of the incident beam.
             </doc>
         </symbol>
-        <symbol name="N_observables">
-            <doc>
-                 Number of observables that are saved in a measurement. e.g. one for
-                 intensity, reflectivity or transmittance, two for Psi and Delta etc. This
-                 is equal to the second dimension of the data array 'measured_data' and the
-                 number of column names.
-            </doc>
-        </symbol>
-        <symbol name="N_time">
-            <doc>
-                 Number of time points measured, the length of NXsample/time_points
-            </doc>
-        </symbol>
     </symbols>
     <doc>
-         Ellipsometry, complex systems, up to variable angle spectroscopy.
+         This is the application definition describing ellipsometry experiments.
+         
+         Such experiments may be as simple as identifying how a reflected
+         beam of light with a single wavelength changes its polarization state,
+         to a variable angle spectroscopic ellipsometry experiment.
+         
+         The application definition specifies optical spectroscopy (NXopt), by extending
+         the terms and setting specific requirements.
          
          Information on ellipsometry is provided, e.g. in:
          
@@ -111,38 +81,24 @@ A draft version of a NeXus application definition for ellipsometry.-->
          
          Review articles:
          
-         * T. E. Jenkins, &quot;Multiple-angle-of-incidence ellipsometry&quot;,
+         * T. E. Jenkins, "Multiple-angle-of-incidence ellipsometry",
            J. Phys. D: Appl. Phys. 32, R45 (1999),
            https://doi.org/10.1088/0022-3727/32/9/201
-         * D. E. Aspnes, &quot;Spectroscopic ellipsometry - Past, present, and future&quot;,
+         * D. E. Aspnes, "Spectroscopic ellipsometry - Past, present, and future",
            Thin Solid Films 571, 334-344 (2014),
            https://doi.org/10.1016/j.tsf.2014.03.056
-         * R. M. A. Azzam, &quot;Mueller-matrix ellipsometry: a review&quot;,
+         * R. M. A. Azzam, "Mueller-matrix ellipsometry: a review",
            Proc. SPIE 3121, Polarization: Measurement, Analysis, and Remote Sensing,
            (3 October 1997),
            https://doi.org/10.1117/12.283870
-         * E. A. Irene, &quot;Applications of spectroscopic ellipsometry to microelectronics&quot;,
+         * E. A. Irene, "Applications of spectroscopic ellipsometry to microelectronics",
            Thin Solid Films 233, 96-111 (1993),
            https://doi.org/10.1016/0040-6090(93)90069-2
-         * S. Zollner et al., &quot;Spectroscopic ellipsometry from 10 to 700 K&quot;,
+         * S. Zollner et al., "Spectroscopic ellipsometry from 10 to 700 K",
            Adv. Opt. Techn., (2022),
            https://doi.org/10.1515/aot-2022-0016
     </doc>
     <group type="NXentry">
-        <doc>
-             This is the application definition describing ellipsometry experiments.
-             
-             Such experiments may be as simple as identifying how a reflected
-             beam of light with a single wavelength changes its polarization state,
-             to a variable angle spectroscopic ellipsometry experiment.
-             
-             The application definition defines:
-             
-             * elements of the experimental instrument
-             * calibration information if available
-             * parameters used to tune the state of the sample
-             * sample description
-        </doc>
         <field name="definition">
             <doc>
                  An application definition for ellipsometry.
@@ -163,16 +119,18 @@ A draft version of a NeXus application definition for ellipsometry.-->
                 <item value="NXellipsometry"/>
             </enumeration>
         </field>
-        <field name="experiment_description">
-            <doc>
-                 An optional free-text description of the experiment.
-                 
-                 However, details of the experiment should be defined in the specific
-                 fields of this application definition rather than in this experiment
-                 description.
-            </doc>
-        </field>
+        <field name="title"/>
         <field name="experiment_type">
+            <doc>
+                 Specify the type of the optical experiment.
+                 
+                 You may specify fundamental characteristics or properties in the experimental sub-type.
+            </doc>
+            <enumeration>
+                <item value="ellipsometry"/>
+            </enumeration>
+        </field>
+        <field name="ellipsometry_experiment_type">
             <doc>
                  Specify the type of ellipsometry.
             </doc>
@@ -183,35 +141,18 @@ A draft version of a NeXus application definition for ellipsometry.-->
                 <item value="ultraviolet spectroscopic ellipsometry"/>
                 <item value="uv-vis spectroscopic ellipsometry"/>
                 <item value="NIR-Vis-UV spectroscopic ellipsometry"/>
-                <item value="imaging ellipsometry"/>
+                <item value="other"/>
             </enumeration>
+        </field>
+        <field name="ellipsometry_experiment_type_other" optional="true">
+            <doc>
+                 If the ellipsometry_experiment_type is `other`, a name should be specified here.
+            </doc>
         </field>
         <group type="NXinstrument">
             <doc>
                  Properties of the ellipsometry equipment.
             </doc>
-            <field name="company" optional="true">
-                <doc>
-                     Name of the company which build the instrument.
-                </doc>
-            </field>
-            <field name="construction_year" type="NX_DATE_TIME" optional="true">
-                <doc>
-                     ISO8601 date when the instrument was constructed.
-                     UTC offset should be specified.
-                </doc>
-            </field>
-            <group name="software" type="NXprocess">
-                <field name="program">
-                    <doc>
-                         Commercial or otherwise defined given name of the program that was
-                         used to generate the result file(s) with measured data and metadata.
-                         This program converts the measured signals to ellipsometry data. If
-                         home written, one can provide the actual steps in the NOTE subfield
-                         here.
-                    </doc>
-                </field>
-            </group>
             <field name="ellipsometer_type">
                 <doc>
                      What type of ellipsometry was used? See Fujiwara Table 4.2.
@@ -243,24 +184,17 @@ A draft version of a NeXus application definition for ellipsometry.-->
                 </enumeration>
             </field>
             <group type="NXbeam_path">
-                <group name="light_source" type="NXsource">
-                    <doc>
-                         Specify the used light source. Multiple selection possible.
-                    </doc>
-                    <field name="source_type">
-                        <enumeration>
-                            <item value="arc lamp"/>
-                            <item value="halogen lamp"/>
-                            <item value="LED"/>
-                            <item value="other"/>
-                        </enumeration>
-                    </field>
-                </group>
+                <!--light_source(NXsource):
+ doc: |
+   Specify the used light source. Multiple selection possible.
+ source_type:
+   enumeration: [arc lamp, halogen lamp, LED, other]-->
                 <group name="focussing_probes" type="NXlens_opt" optional="true">
                     <doc>
                          If focussing probes (lenses) were used, please state if the data
                          were corrected for the window effects.
                     </doc>
+                    <!--This as well can be stated in window/aperture-->
                     <field name="data_correction" type="NX_BOOLEAN">
                         <doc>
                              Were the recorded data corrected by the window effects of the
@@ -272,12 +206,6 @@ A draft version of a NeXus application definition for ellipsometry.-->
                              Specify the angular spread caused by the focussing probes.
                         </doc>
                     </field>
-                </group>
-                <group type="NXdetector">
-                    <doc>
-                         Properties of the detector used. Integration time is the count time
-                         field, or the real time field. See their definition.
-                    </doc>
                 </group>
                 <group name="rotating_element" type="NXwaveplate" optional="true">
                     <doc>
@@ -305,35 +233,24 @@ A draft version of a NeXus application definition for ellipsometry.-->
                         </doc>
                     </field>
                 </group>
-                <group name="spectrometer" type="NXmonochromator" optional="true">
-                    <doc>
-                         The spectroscope element of the ellipsometer before the detector,
-                         but often integrated to form one closed unit. Information on the
-                         dispersive element can be specified in the subfield GRATING. Note
-                         that different gratings might be used for different wavelength
-                         ranges. The dispersion of the grating for each wavelength range can
-                         be stored in grating_dispersion.
-                    </doc>
-                </group>
             </group>
         </group>
         <group type="NXsample">
-            <field name="backside_roughness" type="NX_BOOLEAN">
+            <field name="backside_roughness" type="NX_BOOLEAN" recommended="true">
                 <doc>
                      Was the backside of the sample roughened? Relevant for infrared
                      ellipsometry.
                 </doc>
             </field>
         </group>
-        <group name="data_collection" type="NXprocess">
+        <group type="NXdata">
             <field name="data_type">
                 <doc>
                      Select which type of data was recorded, for example Psi and Delta
                      (see: https://en.wikipedia.org/wiki/Ellipsometry#Data_acquisition).
                      It is possible to have multiple selections. Data types may also be
                      converted to each other, e.g. a Mueller matrix contains N,C,S data
-                     as well. This selection defines how many columns (N_observables) are
-                     stored in the data array.
+                     as well.
                 </doc>
                 <enumeration>
                     <item value="Psi/Delta"/>
@@ -346,12 +263,4 @@ A draft version of a NeXus application definition for ellipsometry.-->
             </field>
         </group>
     </group>
-    <!--column_names:
-  doc: |
-    Please list in this array the column names used in your actual data.
-    That is ['Psi', 'Delta'] or ['MM1', 'MM2', 'MM3', ..., 'MM16] for
-    a full Mueller matrix, etc.
-  dimensions:
-    rank: 1
-    dim: [[1, N_observables]]-->
 </definition>

--- a/contributed_definitions/NXfabrication.nxdl.xml
+++ b/contributed_definitions/NXfabrication.nxdl.xml
@@ -41,6 +41,15 @@
              a serial number or hash identifier of the component.
         </doc>
     </field>
+    <field name="construction_year" type="NX_DATE_TIME">
+        <doc>
+             Datetime of components initial construction. This refers to the date of
+             first measurement after new construction or to the relocation date,
+             if it describes a multicomponent/custom-build setup.
+             Should be a ISO8601 date/time stamp. It is recommended to add an explicit time zone,
+             otherwise the local time zone is assumed per ISO8601.
+        </doc>
+    </field>
     <field name="capability" type="NX_CHAR">
         <doc>
              Free-text list with eventually multiple terms of

--- a/contributed_definitions/NXfabrication.nxdl.xml
+++ b/contributed_definitions/NXfabrication.nxdl.xml
@@ -32,12 +32,12 @@
     </field>
     <field name="model" type="NX_CHAR">
         <doc>
-             Version or model of the component named by the manufacturer. 
+             Version or model of the component named by the manufacturer.
         </doc>
         <attribute name="version" type="NX_CHAR">
             <doc>
-                If different versions exist are possible, the value in this field should be made specific enough to resolve the version.
-
+                 If different versions exist are possible, the value in this field should be made
+                 specific enough to resolve the version.
             </doc>
         </attribute>
     </field>

--- a/contributed_definitions/NXhistory.nxdl.xml
+++ b/contributed_definitions/NXhistory.nxdl.xml
@@ -52,6 +52,13 @@ definition: ["NXactivity"]-->
              experiment.
         </doc>
     </group>
+    <group type="NXidentifier">
+        <doc>
+             An ID or reference to the location or a unique (globally
+             persistent) identifier of e.g. another file which gives
+             as many as possible details of the history event.
+        </doc>
+    </group>
     <!--There should be more activities here, like measurement.-->
     <group name="notes" type="NXnote">
         <doc>

--- a/contributed_definitions/NXopt.nxdl.xml
+++ b/contributed_definitions/NXopt.nxdl.xml
@@ -24,7 +24,19 @@
 <!--
 04/2024
 Extension of the Draft Version (05/2023) of a NeXus application definition which
-serves as a template for various optical spectroscopy experiments-->
+serves as a template for various optical spectroscopy experiments
+
+TODO:
+- Merge reference_frames with angle_reference_frame
+- Rework instrument_calibration_DEVICE - use NXcalibration?
+- Beam polarizations: Own Polarization concept with angle or from NXbeam via beam coordinates? (solve reference frame problem first)
+- Describe angle_of_detection by NXtransformations
+- remove NXmonchromator? as it is already in NXinstrument
+- Add NXlens_opt and NXwaveplate to NXinstrument?
+- Make sample stage_stage(NXmanipulator)/reference_frame via NXtransformations
+- Add properties from NXlens_opt from NXopt to NXlens_opt base class
+- Make polfilter_TYPE(NXbeam_device) own base class -\-> rework NXpolarizer_opt. and add them to NXinstrument.
+- Make spectralfilter_TYPE(NXbeam_device) own base class -\-> extend NXfilter?  and add them to NXinstrument.-->
 <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXopt" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
     <symbols>
         <doc>
@@ -109,9 +121,9 @@ serves as a template for various optical spectroscopy experiments-->
                  principal investigator.
                  (ii) The identifier enables to link experiments to e.g. proposals.
             </doc>
-            <field name="service" type="NX_CHAR"/>
-            <field name="identifier" type="NX_CHAR"/>
-            <field name="is_persistent" type="NX_BOOLEAN"/>
+            <field name="service" type="NX_CHAR" optional="true"/>
+            <field name="identifier" type="NX_CHAR" recommended="true"/>
+            <field name="is_persistent" type="NX_BOOLEAN" optional="true"/>
         </group>
         <field name="experiment_description" optional="true">
             <doc>
@@ -130,7 +142,7 @@ serves as a template for various optical spectroscopy experiments-->
             <doc>
                  Specify the type of the optical experiment.
                  
-                 Chose other if non of these methods are suitable. You may specify
+                 Chose other if none of these methods are suitable. You may specify
                  fundamental characteristics or properties in the experimental sub-type.
             </doc>
             <enumeration>
@@ -142,7 +154,7 @@ serves as a template for various optical spectroscopy experiments-->
                 <item value="other"/>
             </enumeration>
         </field>
-        <field name="experiment_sub_type">
+        <field name="experiment_sub_type" optional="true">
             <doc>
                  Specify a special property or characteristic of the experiment, which specifies
                  the generic experiment type.
@@ -158,71 +170,35 @@ serves as a template for various optical spectroscopy experiments-->
 experimental technique -\-> pump-probe, parameters seperated (i.e. time, space)?
 The above listed things are related to beam properties? This is different
 compared to temperature or pressure. Is this a useful distinction?-->
-        <field name="experiment_type_other">
+        <field name="experiment_type_other" optional="true">
             <doc>
-                 If "other" was selected in "experiment_type", specify the experiment here
-                 with a free text name, which is knwon in the respective community of interest.
+                 If "other" was selected in "experiment_type" and/or in "experiment_sub_type",
+                 specify the experiment here with a free text name, which is knwon in the
+                 respective community of interest.
             </doc>
         </field>
+        <!--
+This should be extended later and hopefully replace angle_reference_frame
+and sample_normal_direction.
+Required reference frames:
+Sample normal, beam_z_axis, sample_stage
+-->
+        <group name="reference_frames" type="NXcoordinate_system_set" optional="true">
+            <doc>
+                 Description of one or more coordinate systems that are specific to the
+                 experiment.
+            </doc>
+        </group>
         <group type="NXuser" minOccurs="0" maxOccurs="unbounded">
             <doc>
                  Contact information and eventually details of at persons who
                  performed the measurements. This can be for example the principal
-                 investigator or student.
+                 investigator or student. Examples are: name, affiliation, address, telephone
+                 number, email, role as well as identifiers such as orcid or similar. 
                  It is recommended to add multiple users if relevant.
                  
                  Due to data privacy concerns, there is no minimum requirement.
             </doc>
-            <field name="name" type="NX_CHAR" recommended="true">
-                <doc>
-                     Given (first) name and surname of the user.
-                </doc>
-            </field>
-            <field name="affiliation" type="NX_CHAR" optional="true">
-                <doc>
-                     Name of the affiliation of the user at the point in time
-                     when the experiment was performed.
-                </doc>
-            </field>
-            <field name="address" type="NX_CHAR" optional="true">
-                <doc>
-                     Postal address of the user's affiliation.
-                </doc>
-            </field>
-            <field name="email" type="NX_CHAR" optional="true">
-                <doc>
-                     Email address of the user at the point in time when the experiment
-                     was performed. Writing the most permanently used email is recommended.
-                </doc>
-            </field>
-            <field name="orcid" type="NX_CHAR" recommended="true">
-                <doc>
-                     Author ID defined by https://orcid.org/.
-                </doc>
-            </field>
-            <field name="telephone_number" type="NX_CHAR" optional="true">
-                <doc>
-                     (Business) (tele)phone number of the user at the point
-                     in time when the experiment was performed.
-                </doc>
-            </field>
-            <field name="role" type="NX_CHAR" optional="true">
-                <doc>
-                     Which role does the user have in the place and at the point
-                     in time when the experiment was performed? Technician operating
-                     the setup, student, PhD-student, postdoc, principle investigator, or guest
-                     are common examples.
-                </doc>
-            </field>
-            <group name="identifier" type="NXidentifier" recommended="true">
-                <doc>
-                     Service as another mean of identification of a user other than by its name.
-                     Examples could be an ORCID or social media account of the user.
-                </doc>
-                <field name="service" type="NX_CHAR"/>
-                <field name="identifier" type="NX_CHAR"/>
-                <field name="is_persistent" type="NX_BOOLEAN"/>
-            </group>
         </group>
         <group type="NXinstrument">
             <doc>
@@ -249,14 +225,7 @@ compared to temperature or pressure. Is this a useful distinction?-->
                 <field name="vendor" recommended="true"/>
                 <field name="model" recommended="true"/>
                 <field name="identifier" recommended="true"/>
-                <field name="construction_year" type="NX_DATE_TIME" recommended="true">
-                    <doc>
-                         Datetime of setup's initial construction. This refers to the date of
-                         first measurement after new construction  or relocation of the setup.
-                         Should be a ISO8601 date/time stamp. It is recommended to add an explicit time zone,
-                         otherwise the local time zone is assumed per ISO8601.
-                    </doc>
-                </field>
+                <field name="construction_year" type="NX_DATE_TIME" optional="true"/>
             </group>
             <group name="software_TYPE" type="NXprogram" recommended="true">
                 <field name="program">
@@ -267,7 +236,7 @@ compared to temperature or pressure. Is this a useful distinction?-->
                          "software_detector" or "software_stage" to specify the respective
                          program or software components.
                     </doc>
-                    <attribute name="version">
+                    <attribute name="version" recommended="true">
                         <doc>
                              Either version with build number, commit hash, or description of a
                              (online) repository where the source code of the program and build
@@ -284,19 +253,9 @@ compared to temperature or pressure. Is this a useful distinction?-->
                     </attribute>
                 </field>
             </group>
-            <!--general properties and reference frames-->
-            <!--
-This should be extended later and hopefully replace angle_reference_frame
-and sample_normal_direction.
-Required reference frames:
-Sample normal, beam_z_axis, sample_stage
--->
-            <group name="reference_frames" type="NXcoordinate_system_set" optional="true">
-                <doc>
-                     Description of one or more coordinate systems that are specific to the
-                     experiment.
-                </doc>
-            </group>
+            <!--The angle_reference_frame will be connected later to general reference frames
+For this this solution enables the description of the beam relations for
+different optical spectroscopy methods in the reference frame they are used to-->
             <field name="angle_reference_frame">
                 <doc>
                      Defines the reference frame which is used to describe the sample orientation
@@ -354,7 +313,9 @@ geographic north pole: harder to determine? (What about GPS?), but constant with
             <group name="instrument_calibration_DEVICE" type="NXsubentry" recommended="true">
                 <doc>
                      Pre-calibration of an arbitrary device of the instrumental setup, which
-                     has the name DEVICE. You can specify here at which point
+                     has the name DEVICE. You can specify here how, at which time by which method
+                     the calibration was done. As well the accuracy and a link to the calibration
+                     dataset.
                 </doc>
                 <field name="device_path" recommended="true">
                     <doc>
@@ -419,27 +380,29 @@ This information may be as well stored in an incident and detection beam-->
                 <doc>
                      Beam characteristics between two beam_devices.
                      
-                     It is recommended, to at least define one incident and one detection beam.
-                     If this beam is directly connected to an source, chose here the same
+                     It is recommended to at least define one incident and one detection beam.
+                     If this beam is directly connected to a source, chose here the same
                      name appendix as for the NXsource (e.g. TYPE=532nm)
                 </doc>
-                <field name="incident_wavelength" type="NX_FLOAT" units="NX_WAVELENGTH"/>
-                <field name="incident_wavelength_spread" type="NX_NUMBER" recommended="true" units="NX_WAVELENGTH"/>
-                <field name="incident_polarization" type="NX_NUMBER" recommended="true" units="NX_ANY"/>
+                <field name="incident_wavelength" type="NX_NUMBER" recommended="true"/>
+                <field name="incident_wavelength_spread" type="NX_NUMBER" recommended="true"/>
+                <field name="incident_polarization" type="NX_NUMBER" recommended="true"/>
                 <field name="extent" type="NX_FLOAT" recommended="true"/>
-                <field name="associated_source" type="NX_CHAR" recommended="true">
+                <field name="associated_source" type="NX_CHAR" optional="true">
                     <doc>
-                         The path to a the source, which emitted this beam.
-                         Should be named with the same appendix as the source, e.g.,
-                         for TYPE=532nmlaser, there should as well be
-                         a NXsource named "source_532nmlaser" aside of this Beam
-                         instance named "beam_532nmlaser"
+                         The path to the source which emitted this beam.
+                         
+                         Is recommended, if the previous optical element is a photon source.
+                         In this way, the properties of the laser or light souce can be described
+                         and associated.
+                         The beam should be named with the same appendix as the source, e.g.,
+                         for TYPE=532nmlaser, there should be both a NXsource named
+                         "source_532nmlaser" and a NXbeam named "beam_532nmlaser".
                          
                          Example: /entry/instrument/source_532nmlaser
                     </doc>
                 </field>
-                <!--The two polarization descriptions may be completely replaced by
-incident_polarization-->
+                <!--The two polarization descriptions may be completely replaced by polarization-->
                 <field name="beam_polarization_type" optional="true">
                     <enumeration>
                         <item value="linear"/>
@@ -464,12 +427,8 @@ incident_polarization-->
                     </doc>
                 </field>
             </group>
-            <!--Discussion with florian:
-The user wants to use simple parameters, which they are used to.
-Though, via NXtransformations in principle maximum flexibility can be provided,
-even for unusual and complex experimental setups.
-The solution from mpes was: simple "front end" by only stating one angle
-with the "backend" to be customizable via NXtransformations.
+            <!--The given angles may be extended similar to NXmpes, to allow a simple
+as well as an arbitrary description via NXtransformations
 
 fundamental orientation of incident and detection beam-->
             <!--
@@ -540,6 +499,9 @@ this might require a different reference frame.
                         <item value="dye-laser"/>
                         <item value="broadband tunable light source"/>
                         <item value="X-ray Source"/>
+                        <item value="arc lamp"/>
+                        <item value="halogen lamp"/>
+                        <item value="LED"/>
                         <item value="other"/>
                     </enumeration>
                 </field>
@@ -549,18 +511,6 @@ this might require a different reference frame.
                     </doc>
                 </field>
                 <field name="name" recommended="true"/>
-                <field name="source_polarization" recommended="true">
-                    <doc>
-                         The type of light polarization produced by the source.
-                    </doc>
-                    <enumeration>
-                        <item value="linear"/>
-                        <item value="unpolarized"/>
-                        <item value="circular"/>
-                        <item value="elliptically"/>
-                        <item value="other"/>
-                    </enumeration>
-                </field>
                 <group name="device_information" type="NXfabrication">
                     <doc>
                          Details about the device information.
@@ -571,13 +521,19 @@ this might require a different reference frame.
                          The path to a beam emitted by this source.
                          Should be named with the same appendix, e.g.,
                          for TYPE=532nmlaser, there should as well be
-                         a NXbeam named "beam_532nmlaser" aside of this source
+                         a NXbeam named "beam_532nmlaser" together with this source
                          instance named "source_532nmlaser"
                          
                          Example: /entry/instrument/beam_532nmlaser
                     </doc>
                 </field>
-                <group name="device_characteristics" type="NXdata"/>
+                <group name="device_characteristics" type="NXdata" optional="true">
+                    <doc>
+                         You may add here data which characterises the source in more detail,
+                         such as spectral power density, power dependency on line width, line-shape
+                         of the laser line, etc.
+                    </doc>
+                </group>
             </group>
             <group name="detector_TYPE" type="NXdetector" minOccurs="1" maxOccurs="unbounded">
                 <field name="detector_channel_type" recommended="true">
@@ -598,9 +554,20 @@ this might require a different reference frame.
                         <item value="Bolometer"/>
                         <item value="Golay Detectors"/>
                         <item value="Pyroelectric Detector"/>
+                        <item value="other"/>
                     </enumeration>
                 </field>
-                <group name="device_characteristics" type="NXdata"/>
+                <field name="detector_type_other" optional="true">
+                    <doc>
+                         Type of detector, if "other" was selected in "detector_type".
+                    </doc>
+                </field>
+                <group name="device_characteristics" type="NXdata" optional="true">
+                    <doc>
+                         You may add here data which characterizes the detector, such as quantum
+                         efficiency as function of wavelength or angular dependency of intenty.
+                    </doc>
+                </group>
                 <group name="device_information" type="NXfabrication" recommended="true">
                     <field name="vendor" recommended="true"/>
                     <field name="model" recommended="true"/>
@@ -653,99 +620,54 @@ this might require a different reference frame.
                 </group>
             </group>
             <group type="NXmonochromator" optional="true">
-                <group name="device_characteristics" type="NXdata"/>
+                <group name="device_characteristics" type="NXdata" optional="true">
+                    <doc>
+                         Characteristics of the monochromator as diffraction efficiency as 
+                         wavelength and polarization dependence
+                    </doc>
+                </group>
+                <group name="device_information" type="NXfabrication" recommended="true">
+                    <field name="vendor" recommended="true"/>
+                    <field name="model" recommended="true"/>
+                    <field name="identifier" recommended="true"/>
+                </group>
             </group>
             <group type="NXlens_opt" optional="true">
+                <doc>
+                     This is the optical element used to focus or collect light. This may
+                     be a genereic lens or microcope objectives which are used for the
+                     Raman scattering process.
+                </doc>
+                <field name="type">
+                    <enumeration>
+                        <item value="objective"/>
+                        <item value="lens"/>
+                        <item value="glass fiber"/>
+                        <item value="none"/>
+                        <item value="other"/>
+                    </enumeration>
+                </field>
+                <field name="numerical_aperture" type="NX_NUMBER">
+                    <doc>
+                         The numerical aperture of the used incident light optics.
+                    </doc>
+                </field>
+                <field name="magnification" type="NX_FLOAT">
+                    <doc>
+                         Magnification of the lens.
+                    </doc>
+                </field>
+                <group name="device_information" type="NXfabrication" recommended="true">
+                    <doc>
+                         Details about the optical component, if available.
+                    </doc>
+                </group>
                 <group name="device_characteristics" type="NXdata"/>
             </group>
             <group type="NXwaveplate" optional="true">
                 <group name="device_characteristics" type="NXdata"/>
             </group>
-            <group name="WINDOW" type="NXaperture" optional="true">
-                <doc>
-                     For environmental measurements, the environment (liquid, vapor
-                     etc.) is enclosed in a cell, which has windows both in the
-                     direction of the source (entry window) and the detector (exit
-                     window) (looking from the sample). In case that the entry and exit
-                     windows are not the same type and do not have the same properties,
-                     use a second 'WINDOW(MXaperture)' field.
-                     
-                     The windows also add a phase shift to the light altering the
-                     measured signal. This shift has to be corrected based on measuring
-                     a known sample (reference sample) or the actual sample of interest
-                     in the environmental cell. State if a window correction has been
-                     performed in 'window_effects_corrected'. Reference data should be
-                     considered as a separate experiment, and a link to the NeXus file
-                     should be added in reference_data_link in measured_data.
-                     
-                     The window is considered to be a part of the sample stage but also
-                     beam path. Hence, its position within the beam path should be
-                     defined by the 'depends_on' field.
-                </doc>
-                <field name="window_effects_corrected" type="NX_BOOLEAN">
-                    <doc>
-                         Was a window correction performed? If 'True' describe the window
-                         correction procedure in 'window_correction/procedure'.
-                    </doc>
-                </field>
-                <group name="window_correction" type="NXprocess" optional="true">
-                    <doc>
-                         Was a window correction performed? If 'True' describe the
-                         window correction procedure in ''
-                    </doc>
-                    <field name="procedure">
-                        <doc>
-                             Describe when (before or after the main measurement + time
-                             stamp in 'date') and how the window effects have been
-                             corrected, i.e. either mathematically or by performing a
-                             reference measurement. In the latter case, provide the link to
-                             to the reference data in 'reference_data_link'.
-                        </doc>
-                    </field>
-                    <field name="reference_data_link" optional="true">
-                        <doc>
-                             Link to the NeXus file which describes the reference data if a
-                             reference measurement for window correction was performed.
-                             Ideally, the reference measurement was performed on a reference
-                             sample and on the same sample, and using the same conditions as
-                             for the actual measurement with and without windows. It should
-                             have been conducted as close in time to the actual measurement
-                             as possible.
-                        </doc>
-                    </field>
-                </group>
-                <field name="material" type="NX_CHAR">
-                    <doc>
-                         The material of the window.
-                    </doc>
-                    <enumeration>
-                        <item value="quartz"/>
-                        <item value="diamond"/>
-                        <item value="calcium fluoride"/>
-                        <item value="zinc selenide"/>
-                        <item value="thallium bromoiodide"/>
-                        <item value="alkali halide compound"/>
-                        <item value="Mylar"/>
-                        <item value="other"/>
-                    </enumeration>
-                </field>
-                <field name="material_other" type="NX_CHAR" optional="true">
-                    <doc>
-                         If you specified 'other' as material, decsribe here what it is.
-                    </doc>
-                </field>
-                <field name="thickness" type="NX_FLOAT" units="NX_LENGTH">
-                    <doc>
-                         Thickness of the window.
-                    </doc>
-                </field>
-                <field name="orientation_angle" type="NX_FLOAT" units="NX_ANGLE">
-                    <doc>
-                         Angle of the window normal (outer) vs. the substrate normal
-                         (similar to the angle of incidence).
-                    </doc>
-                </field>
-            </group>
+            <group type="NXopt_window"/>
             <field name="sample_medium_refractive_indices" type="NX_FLOAT" optional="true" units="NX_UNITLESS">
                 <doc>
                      Array of pairs of complex refractive indices n + ik of the medium
@@ -758,6 +680,90 @@ this might require a different reference frame.
                     <dim index="2" value="N_spectrum"/>
                 </dimensions>
             </field>
+            <group name="polfilter_TYPE" type="NXbeam_device" optional="true">
+                <doc>
+                     polarization filter to prepare light to be measured or to be incident 
+                     on the sample.
+                     Genereric polarization filter porperties may be implemented via NXfilter_pol
+                     at a later stage.
+                </doc>
+                <field name="filter_mechanism" type="NX_CHAR" optional="true">
+                    <doc>
+                         Physical principle of the polarization filter used to create a
+                         defined incident or scattered light state.
+                    </doc>
+                    <enumeration>
+                        <item value="Polarization by Fresnel reflection"/>
+                        <item value="Birefringent polarizers"/>
+                        <item value="Thin film polarizers"/>
+                        <item value="Wire-grid polarizers"/>
+                        <item value="other"/>
+                    </enumeration>
+                </field>
+                <field name="specific_polarization_filter_type" type="NX_CHAR" optional="true">
+                    <doc>
+                         Specific name or type of the polarizer used.
+                         
+                         Free text, for example: Glan-Thompson, Glan-Taylor, Rochon Prism, Wollaston
+                         Polarizer...
+                    </doc>
+                </field>
+                <group name="device_information" type="NXfabrication"/>
+            </group>
+            <group name="spectralfilter_TYPE" type="NXbeam_device" optional="true">
+                <doc>
+                     Spectral filter used to modify properties of the scattered or incident light.
+                     Genereric spectral filter porperties may be implemented via NXfilter_spec
+                     at a later stage.
+                </doc>
+                <field name="filter_type" optional="true">
+                    <doc>
+                         Type of laserline filter used to supress the laser, if measurements
+                         close to the laserline are performed.
+                    </doc>
+                    <enumeration>
+                        <item value="long-pass filter"/>
+                        <item value="short-pass filter"/>
+                        <item value="Notch filter"/>
+                        <item value="reflection filter"/>
+                        <item value="neutral density filter"/>
+                        <item value="other"/>
+                    </enumeration>
+                </field>
+                <field name="intended_use" optional="true">
+                    <doc>
+                         Type of laserline filter used to supress the laser, if measurements
+                         close to the laserline are performed.
+                    </doc>
+                    <enumeration>
+                        <item value="laser line cleanup"/>
+                        <item value="raylight line removal"/>
+                        <item value="spectral filtering"/>
+                        <item value="intensity manipulation"/>
+                        <item value="other"/>
+                    </enumeration>
+                </field>
+                <group name="filter_characteristics" type="NXdata" optional="true">
+                    <doc>
+                         Properties of the spectral filter such as wavelength dependent Transmission
+                         or reflectivity.
+                    </doc>
+                    <attribute name="characteristics_type" optional="true">
+                        <doc>
+                             Which property is used to form the spectral properties of light,
+                             i.e. transmission or reflection properties.
+                        </doc>
+                        <enumeration>
+                            <item value="transmission"/>
+                            <item value="reflection"/>
+                        </enumeration>
+                    </attribute>
+                </group>
+                <group name="device_information" type="NXfabrication"/>
+            </group>
+            <!--In the following - Auxillary NXbeam_devices are defined, to enable a
+beam path description of the setup, while using the up now available
+Nexus definitions for source, detector, monochromator, ...-->
             <!--beam devices for beam path description-->
             <group type="NXbeam_device" minOccurs="0" maxOccurs="unbounded">
                 <doc>
@@ -815,6 +821,7 @@ this might require a different reference frame.
                          of the stage type.
                     </doc>
                 </field>
+                <!--This is for now a placeholder and should be specified with NXtransformation-->
                 <field name="reference_frame" optional="true">
                     <doc>
                          This is a placeholder, to describe the relation between the samples
@@ -854,38 +861,15 @@ this might require a different reference frame.
                         <item value="temperature"/>
                     </enumeration>
                 </field>
-                <field name="cryo_or_heater" recommended="true">
+                <field name="cooler_or_heater" recommended="true">
                     <enumeration>
-                        <item value="cryostat"/>
+                        <item value="cooler"/>
                         <item value="heater"/>
                     </enumeration>
                 </field>
                 <field name="type" optional="true">
                     <doc>
                          Hardware used for actuation, i.e. laser, gas lamp, filament, resistive
-                    </doc>
-                </field>
-                <group type="NXpid">
-                    <field name="setpoint" type="NX_FLOAT" recommended="true"/>
-                </group>
-                <group name="device_information" type="NXfabrication"/>
-            </group>
-            <group name="PARAMETER_SENSOR" type="NXsensor" recommended="true">
-                <field name="name" recommended="true"/>
-                <field name="measurement"/>
-                <field name="type" optional="true"/>
-                <field name="value" type="NX_FLOAT"/>
-                <group name="device_information" type="NXfabrication"/>
-            </group>
-            <group name="PARAMETER_ACTUATOR" type="NXactuator" optional="true">
-                <doc>
-                     Control of arbitrary parameter - compare to temperature above.
-                </doc>
-                <field name="name" recommended="true"/>
-                <field name="physical_quantity"/>
-                <field name="type" optional="true">
-                    <doc>
-                         Hardware used for actuation
                     </doc>
                 </field>
                 <group type="NXpid">
@@ -909,7 +893,7 @@ this might require a different reference frame.
             </field>
             <field name="sample_id" recommended="true">
                 <doc>
-                     Uniquely identifying name of the sample.
+                     Uniquely identifying ID of the sample.
                 </doc>
             </field>
             <field name="physical_form" recommended="true">
@@ -923,18 +907,6 @@ this might require a different reference frame.
                 <doc>
                      Free text description of the sample.
                 </doc>
-            </field>
-            <field name="situation" recommended="true">
-                <enumeration>
-                    <item value="air"/>
-                    <item value="vacuum"/>
-                    <item value="inert atmosphere"/>
-                    <item value="oxidising atmosphere"/>
-                    <item value="reducing atmosphere"/>
-                    <item value="sealed can"/>
-                    <item value="water"/>
-                    <item value="other"/>
-                </enumeration>
             </field>
             <field name="chemical_formula" recommended="true">
                 <doc>
@@ -968,14 +940,6 @@ this might require a different reference frame.
                 <doc>
                      A set of activities that occurred to the sample prior to/during the experiment.
                 </doc>
-                <group name="history_id" type="NXidentifier">
-                    <doc>
-                         A reference to the location or a unique (globally
-                         persistent) identifier (e.g.) of e.g. another file which gives
-                         as many as possible details of the material, its microstructure,
-                         and its thermo-chemo-mechanical processing/preparation history.
-                    </doc>
-                </group>
             </group>
             <group name="temperature" type="NXenvironment" recommended="true">
                 <doc>
@@ -993,9 +957,9 @@ this might require a different reference frame.
                          This should be a link to /entry/instrument/manipulator/sample_heater.
                     </doc>
                 </group>
-                <group name="cryostat" type="NXactuator" optional="true">
+                <group name="sample_cooler" type="NXactuator" optional="true">
                     <doc>
-                         Cryostat for cooling the sample.
+                         Device for cooling the sample (Cryostat, Airflow cooler, etc.).
                          This should be a link to /entry/instrument/manipulator/cryostat.
                     </doc>
                 </group>
@@ -1006,8 +970,18 @@ this might require a different reference frame.
                      and controlled by a device. Examples are pressure, voltage, magnetic field etc.
                      Similar to the temperautre description of the sample.
                 </doc>
-                <group type="NXsensor" optional="true"/>
-                <group type="NXactuator" optional="true"/>
+                <field name="sample_medium" recommended="true">
+                    <enumeration>
+                        <item value="air"/>
+                        <item value="vacuum"/>
+                        <item value="inert atmosphere"/>
+                        <item value="oxidising atmosphere"/>
+                        <item value="reducing atmosphere"/>
+                        <item value="sealed can"/>
+                        <item value="water"/>
+                        <item value="other"/>
+                    </enumeration>
+                </field>
             </group>
             <field name="thickness" type="NX_NUMBER" optional="true" units="NX_LENGTH">
                 <doc>

--- a/contributed_definitions/NXopt.nxdl.xml
+++ b/contributed_definitions/NXopt.nxdl.xml
@@ -983,6 +983,9 @@ Nexus definitions for source, detector, monochromator, ...-->
                     </enumeration>
                 </field>
             </group>
+            <!--
+Make something like NXlayer_structure_sample?
+-->
             <field name="thickness" type="NX_NUMBER" optional="true" units="NX_LENGTH">
                 <doc>
                      (Measured) sample thickness.
@@ -1001,6 +1004,9 @@ Nexus definitions for source, detector, monochromator, ...-->
                      determined.
                 </doc>
             </field>
+            <!--
+Maybe consider here to include NXsample_component_set.
+-->
             <field name="layer_structure" optional="true">
                 <doc>
                      Qualitative description of the layer structure for the sample,
@@ -1025,9 +1031,12 @@ Nexus definitions for source, detector, monochromator, ...-->
         </group>
         <group type="NXdata">
             <doc>
-                 A default view of the data provided in ENTRY/data_collection/measured_data. This
-                 should be the part of the data set which provides the most suitable
-                 representation of the data.
+                 Here generic types of data may be saved.. This may refer to data derived
+                 from single or multiple raw measurements (i.e. several intensities are
+                 evaluated for different parameters: ellipsometry -&gt; psi and delta) -
+                 i.e. non-raw data. 
+                 As well plotable data may be stored/linked here, which provides the most suitable
+                 representation of the data (for the respective community).
                  
                  You may provide multiple instances of NXdata
             </doc>
@@ -1052,7 +1061,9 @@ Nexus definitions for source, detector, monochromator, ...-->
             </group>
         </group>
         <!--The old "data_collection(NXprocess)" is now replaced by more flexbile
-NXdata. A detailed rework of this has to be done after the NXopt workshop-->
+NXdata. The detailed inclusion of a data collection description (i.e.
+raw data from ellipsometry as polarization values to the usually used
+psi and delta values), will be done later after the NXopt workshop.-->
         <group name="derived_parameters" type="NXprocess" optional="true">
             <doc>
                  &gt;&gt;&gt;This section is transfered from the first NXopt version and might
@@ -1069,7 +1080,7 @@ NXdata. A detailed rework of this has to be done after the NXopt workshop-->
                     <dim index="3" value="N_spectrum"/>
                 </dimensions>
             </field>
-            <field name="Jones_quality_factor" type="NX_NUMBER" optional="true" units="NX_UNITLESS">
+            <field name="jones_quality_factor" type="NX_NUMBER" optional="true" units="NX_UNITLESS">
                 <doc>
                      Jones quality factor.
                 </doc>

--- a/contributed_definitions/NXopt.nxdl.xml
+++ b/contributed_definitions/NXopt.nxdl.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format
-# 
-# Copyright (C) 2014-2022 NeXus International Advisory Committee (NIAC)
-# 
+#
+# Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+#
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -21,14 +21,11 @@
 #
 # For further information, see http://www.nexusformat.org
 -->
-<!--05/2023
-Draft of a NeXus application definition which serves as a template for various
-optical spectroscopy experiments-->
-<!--To do:
-[ ] Check base classes (NXbeam_path + base classes used by it)
-[ ] Harmonize NXopt and NXellipsometry
-[ ] Fix dimensions and ranks-->
-<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" name="NXopt" extends="NXobject" type="group" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+<!--
+04/2024
+Extension of the Draft Version (05/2023) of a NeXus application definition which
+serves as a template for various optical spectroscopy experiments-->
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXopt" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
     <symbols>
         <doc>
              Variables used throughout the document, e.g. dimensions or parameters.
@@ -37,12 +34,6 @@ optical spectroscopy experiments-->
             <doc>
                  Length of the spectrum array (e.g. wavelength or energy) of the measured
                  data.
-            </doc>
-        </symbol>
-        <symbol name="N_sensors">
-            <doc>
-                 Number of sensors used to measure parameters that influence the sample,
-                 such as temperature or pressure.
             </doc>
         </symbol>
         <symbol name="N_measurements">
@@ -64,27 +55,18 @@ optical spectroscopy experiments-->
                  Number of angles of incidence of the incident beam.
             </doc>
         </symbol>
-        <symbol name="N_observables">
-            <doc>
-                 Number of observables that are saved in a measurement. e.g. one for
-                 intensity, reflectivity or transmittance, two for Psi and Delta etc. This
-                 is equal to the second dimension of the data array 'measured_data' and the
-                 number of column names.
-            </doc>
-        </symbol>
     </symbols>
     <doc>
-         An application definition for optical spectroscopy experiments.
+         A general application definition of optical spectroscopy elements, which may 
+         be used as a template to derive specialized optical spectroscopy experiments.
+         
+         Possible specializations are ellipsometry, Raman spectroscopy, photoluminescence,
+         reflectivity/transmission spectroscopy.
+         
+         A general optical experiment consists of (i) a light/photon source, (ii) a sample,
+         (iii) a detector.
     </doc>
     <group type="NXentry">
-        <doc>
-             An application definition template for optical spectroscopy experiments.
-             
-             A general optical experiment consists of a light or excitation source, a
-             beam path, a sample + its stage + its environment, and a detection unit.
-             Examples are reflection or transmission measurements, photoluminescence,
-             Raman spectroscopy, ellipsometry etc.
-        </doc>
         <field name="definition">
             <doc>
                  An application definition describing a general optical experiment.
@@ -105,58 +87,112 @@ optical spectroscopy experiments-->
                 <item value="NXopt"/>
             </enumeration>
         </field>
-        <field name="experiment_identifier">
+        <field name="title"/>
+        <field name="start_time" type="NX_DATE_TIME">
             <doc>
-                 A (globally persistent) unique identifier of the experiment.
-                 (i) The identifier is usually defined by the facility or principle
-                 investigator.
-                 (ii) The identifier enables to link experiments to e.g. proposals.
+                 Datetime of the start of the measurement.
+                 Should be a ISO8601 date/time stamp. It is recommended to add an explicit time zone,
+                 otherwise, the local time zone is assumed per ISO8601.
             </doc>
         </field>
+        <field name="end_time" type="NX_DATE_TIME" recommended="true">
+            <doc>
+                 Datetime of the end of the measurement.
+                 Should be a ISO8601 date/time stamp. It is recommended to add an explicit time zone,
+                 otherwise the local time zone is assumed per ISO8601.
+            </doc>
+        </field>
+        <group name="experiment_identifier" type="NXidentifier" recommended="true">
+            <doc>
+                 A (globally persistent) unique identifier of the experiment.
+                 (i) The identifier is usually defined by the facility, laboratory or
+                 principal investigator.
+                 (ii) The identifier enables to link experiments to e.g. proposals.
+            </doc>
+            <field name="service" type="NX_CHAR"/>
+            <field name="identifier" type="NX_CHAR"/>
+            <field name="is_persistent" type="NX_BOOLEAN"/>
+        </group>
         <field name="experiment_description" optional="true">
             <doc>
                  An optional free-text description of the experiment.
                  
-                 However, details of the experiment should be defined in the specific
-                 fields of this application definition rather than in this experiment
-                 description.
+                 Users are strongly advised to parameterize the description of their experiment
+                 by using respective groups and fields and base classes instead of writing prose
+                 into this field.
+                 
+                 The reason is that such a free-text field is difficult to machine-interpret.
+                 The motivation behind keeping this field for now is to learn how far the
+                 current base classes need extension based on user feedback.
             </doc>
         </field>
         <field name="experiment_type">
             <doc>
                  Specify the type of the optical experiment.
+                 
+                 Chose other if non of these methods are suitable. You may specify
+                 fundamental characteristics or properties in the experimental sub-type.
+            </doc>
+            <enumeration>
+                <item value="ellipsometry"/>
+                <item value="Raman spectroscopy"/>
+                <item value="photoluminescence"/>
+                <item value="transmission spectroscopy"/>
+                <item value="reflection spectroscopy"/>
+                <item value="other"/>
+            </enumeration>
+        </field>
+        <field name="experiment_sub_type">
+            <doc>
+                 Specify a special property or characteristic of the experiment, which specifies
+                 the generic experiment type.
+            </doc>
+            <enumeration>
+                <item value="time resolved"/>
+                <item value="imaging"/>
+                <item value="pump-probe"/>
+                <item value="other"/>
+            </enumeration>
+        </field>
+        <!--Replace maybe sub_type with exp_technique?
+experimental technique -\-> pump-probe, parameters seperated (i.e. time, space)?
+The above listed things are related to beam properties? This is different
+compared to temperature or pressure. Is this a useful distinction?-->
+        <field name="experiment_type_other">
+            <doc>
+                 If "other" was selected in "experiment_type", specify the experiment here
+                 with a free text name, which is knwon in the respective community of interest.
             </doc>
         </field>
-        <field name="start_time" type="NX_DATE_TIME">
+        <group type="NXuser" minOccurs="0" maxOccurs="unbounded">
             <doc>
-                 Start time of the experiment. UTC offset should be specified.
+                 Contact information and eventually details of at persons who
+                 performed the measurements. This can be for example the principal
+                 investigator or student.
+                 It is recommended to add multiple users if relevant.
+                 
+                 Due to data privacy concerns, there is no minimum requirement.
             </doc>
-        </field>
-        <group type="NXuser">
-            <doc>
-                 Contact information of at least the user of the instrument or the
-                 investigator who performed this experiment.
-                 Adding multiple users, if relevant, is recommended.
-            </doc>
-            <field name="name" type="NX_CHAR">
+            <field name="name" type="NX_CHAR" recommended="true">
                 <doc>
-                     Name of the user.
+                     Given (first) name and surname of the user.
                 </doc>
             </field>
-            <field name="affiliation" type="NX_CHAR" recommended="true">
+            <field name="affiliation" type="NX_CHAR" optional="true">
                 <doc>
-                     Name of the affiliation of the user at the point in time when the
-                     experiment was performed.
+                     Name of the affiliation of the user at the point in time
+                     when the experiment was performed.
                 </doc>
             </field>
-            <field name="address" type="NX_CHAR" recommended="true">
+            <field name="address" type="NX_CHAR" optional="true">
                 <doc>
-                     Street address of the user's affiliation.
+                     Postal address of the user's affiliation.
                 </doc>
             </field>
-            <field name="email" type="NX_CHAR">
+            <field name="email" type="NX_CHAR" optional="true">
                 <doc>
-                     Email address of the user.
+                     Email address of the user at the point in time when the experiment
+                     was performed. Writing the most permanently used email is recommended.
                 </doc>
             </field>
             <field name="orcid" type="NX_CHAR" recommended="true">
@@ -164,106 +200,194 @@ optical spectroscopy experiments-->
                      Author ID defined by https://orcid.org/.
                 </doc>
             </field>
-            <field name="telephone_number" type="NX_CHAR" recommended="true">
+            <field name="telephone_number" type="NX_CHAR" optional="true">
                 <doc>
-                     Telephone number of the user.
+                     (Business) (tele)phone number of the user at the point
+                     in time when the experiment was performed.
                 </doc>
             </field>
+            <field name="role" type="NX_CHAR" optional="true">
+                <doc>
+                     Which role does the user have in the place and at the point
+                     in time when the experiment was performed? Technician operating
+                     the setup, student, PhD-student, postdoc, principle investigator, or guest
+                     are common examples.
+                </doc>
+            </field>
+            <group name="identifier" type="NXidentifier" recommended="true">
+                <doc>
+                     Service as another mean of identification of a user other than by its name.
+                     Examples could be an ORCID or social media account of the user.
+                </doc>
+                <field name="service" type="NX_CHAR"/>
+                <field name="identifier" type="NX_CHAR"/>
+                <field name="is_persistent" type="NX_BOOLEAN"/>
+            </group>
         </group>
         <group type="NXinstrument">
             <doc>
-                 Properties of the experimental setup. This includes general information
-                 about the instrument (such as model, company etc.), information about
-                 the calibration of the instrument, elements of the beam path including
-                 the excitation or light source and the detector unit, the sample stage
-                 (plus the sample environment, which also includes sensors used to
-                 monitor external conditions) and elements of the beam path.
+                 Devices or elements of the optical spectroscopy setup described with its
+                 properties and general information.
                  
-                 Meta data describing the sample should be specified in ENTRY/SAMPLE
-                 outside of ENTRY/INSTRUMENT.
+                 This includes for example:
+                 - The beam device's or instrument's model, company, serial number, construction year, etc.
+                 - Used software or code
+                 - Experiment descriptive parameters as reference frames, resolution, calibration
+                 - Photon beams with their respective properties such as angles and polarization
+                 - Various optical beam path devices, which interact, manipulate or measure optical beams
+                 - Characteristics of the medium surrounding the sample
+                 - "Beam devices" for a beam path description
+                 - Stages(NXmanipulator)
+                 - Sensors and actuators to control or measure sample or beam properties
             </doc>
-            <field name="model">
+            <group name="device_information" type="NXfabrication" recommended="true">
                 <doc>
-                     The name of the instrument.
+                     General device information of the optical spectroscopy setup, if
+                     suitable (e.g. for a tabletop spectrometer or other non-custom build setups).
+                     For custom build setups, this may be limited to the construction year.
                 </doc>
-                <attribute name="version">
+                <field name="vendor" recommended="true"/>
+                <field name="model" recommended="true"/>
+                <field name="identifier" recommended="true"/>
+                <field name="construction_year" type="NX_DATE_TIME" recommended="true">
                     <doc>
-                         The used version of the hardware if available. If not a commercial
-                         instrument use date of completion of the hardware.
+                         Datetime of setup's initial construction. This refers to the date of
+                         first measurement after new construction  or relocation of the setup.
+                         Should be a ISO8601 date/time stamp. It is recommended to add an explicit time zone,
+                         otherwise the local time zone is assumed per ISO8601.
                     </doc>
-                </attribute>
-            </field>
-            <field name="company" optional="true">
-                <doc>
-                     Name of the company which build the instrument.
-                </doc>
-            </field>
-            <field name="construction_year" type="NX_DATE_TIME" optional="true">
-                <doc>
-                     ISO8601 date when the instrument was constructed.
-                     UTC offset should be specified.
-                </doc>
-            </field>
-            <group name="software" type="NXprocess">
+                </field>
+            </group>
+            <group name="software_TYPE" type="NXprogram" recommended="true">
                 <field name="program">
                     <doc>
                          Commercial or otherwise defined given name of the program that was
-                         used to measure the data, i.e. the software used to start and
-                         record the measured data and/or metadata.
-                         If home written, one can provide the actual steps in the NOTE
-                         subfield here.
+                         used to control any parts of the optical spectroscopy setup.
+                         The uppercase TYPE should be replaced by a specification name, i.e.
+                         "software_detector" or "software_stage" to specify the respective
+                         program or software components.
                     </doc>
+                    <attribute name="version">
+                        <doc>
+                             Either version with build number, commit hash, or description of a
+                             (online) repository where the source code of the program and build
+                             instructions can be found so that the program can be configured in
+                             such a way that result files can be created ideally in a
+                             deterministic manner.
+                        </doc>
+                    </attribute>
+                    <attribute name="url" optional="true">
+                        <doc>
+                             Description of the software by persistent resource, where the program,
+                             code, script etc. can be found.
+                        </doc>
+                    </attribute>
                 </field>
-                <field name="version">
-                    <doc>
-                         Either version with build number, commit hash, or description of a
-                         (online) repository where the source code of the program and build
-                         instructions can be found so that the program can be configured in
-                         such a way that result files can be created ideally in a
-                         deterministic manner.
-                    </doc>
-                </field>
-                <attribute name="url" optional="true">
-                    <doc>
-                         Website of the software.
-                    </doc>
-                </attribute>
             </group>
-            <group name="firmware" type="NXprogram" recommended="true">
+            <!--general properties and reference frames-->
+            <!--
+This should be extended later and hopefully replace angle_reference_frame
+and sample_normal_direction.
+Required reference frames:
+Sample normal, beam_z_axis, sample_stage
+-->
+            <group name="reference_frames" type="NXcoordinate_system_set" optional="true">
                 <doc>
-                     Commercial or otherwise defined name of the firmware that was used
-                     for the measurement - if available.
+                     Description of one or more coordinate systems that are specific to the
+                     experiment.
                 </doc>
-                <attribute name="version">
-                    <doc>
-                         Version and build number or commit hash of the software source code.
-                    </doc>
-                </attribute>
-                <attribute name="url" optional="true">
-                    <doc>
-                         Website of the software.
-                    </doc>
-                </attribute>
             </group>
-            <field name="calibration_status" type="NX_CHAR">
+            <field name="angle_reference_frame">
                 <doc>
-                     Was a calibration performed? If yes, when was it done? If the
-                     calibration time is provided, it should be specified in
-                     ENTRY/INSTRUMENT/calibration/calibration_time.
+                     Defines the reference frame which is used to describe the sample orientation
+                     with respect to the beam directions.
+                     
+                     A beam centered description is the default and uses 4 angles(similar to XRD):
+                       - Omega (angle between sample surface and incident beam)
+                       - 2Theta (angle between the transmitted beam and the detection beam)
+                       - Chi (sample tilt angle, angle between plane#1 and the surface normal,
+                             plane#1 = spanned by incidence beam and detection
+                             and detection. If Chi=0°, then plane#1 is the plane of
+                             incidence in reflection setups)
+                       - Phi (inplane rotation of sample, rotation axis is the samples 
+                             surface normal)
+                     
+                     
+                     A sample normal centered description is as well possible(similar to XX):
+                       - angle of incidence (angle between incident beam and sample surface)
+                       - angle of detection (angle between detection beam and sample surface)
+                       - angle of incident and detection beam (angle between the incident and scattering beam)
+                       - angle of in-plane sample rotation (direction along the sample's surface normal)
                 </doc>
+                <!--For the sample centered approach, it has to be avoided, that the detection beam,
+incident beam or surface normal beam are parallel to each other
+(Is this a problem for Raman backscattering?)
+For beam centered approach (as done for beamlines), the grativation and beam direction are used to define
+the coordinate system. As beamlines are usually built flat - there is no case
+in which these two vectors can be parallel to each other
+This is different with the surface normal. Aside of the surface normal,
+at least one further additional natural direction is required.
+This could be the magnetic/geographic north pole
+magnetic north pole: easy to determine, but time depenent (long term)
+geographic north pole: harder to determine? (What about GPS?), but constant with time-->
                 <enumeration>
-                    <item value="calibration time provided"/>
-                    <item value="no calibration"/>
-                    <item value="within 1 hour"/>
-                    <item value="within 1 day"/>
-                    <item value="within 1 week"/>
+                    <item value="beam centered"/>
+                    <item value="sample normal centered"/>
                 </enumeration>
             </field>
-            <group name="calibration" type="NXsubentry" recommended="true">
+            <group name="wavelength_resolution" type="NXresolution" optional="true">
                 <doc>
-                     The calibration data and metadata should be described in a separate NeXus file
-                     with the link provided in 'calibration_link'.
+                     The overall resolution of the optical instrument.
                 </doc>
+                <field name="physical_quantity">
+                    <enumeration>
+                        <item value="wavelength"/>
+                    </enumeration>
+                </field>
+                <field name="type" recommended="true"/>
+                <field name="resolution" type="NX_FLOAT" units="NX_WAVELENGTH">
+                    <doc>
+                         Minimum distinguishable wavelength separation of peaks in spectra.
+                    </doc>
+                </field>
+            </group>
+            <group name="instrument_calibration_DEVICE" type="NXsubentry" recommended="true">
+                <doc>
+                     Pre-calibration of an arbitrary device of the instrumental setup, which
+                     has the name DEVICE. You can specify here at which point
+                </doc>
+                <field name="device_path" recommended="true">
+                    <doc>
+                         Path to the device, which was calibrated.
+                         Example: entry/instrument/DEVICE
+                    </doc>
+                </field>
+                <field name="calibration_method" optional="true">
+                    <doc>
+                         Describe here the approach or method, used to perform the calibration, by a free
+                         text.
+                    </doc>
+                </field>
+                <group name="calibration_accuracy" type="NXdata" optional="true">
+                    <doc>
+                         Provide data about the determined accuracy of the device, this may
+                         may be a single value or a dataset like wavelength error vs. wavelength etc.
+                    </doc>
+                </group>
+                <field name="calibration_status" type="NX_CHAR" recommended="true">
+                    <doc>
+                         Was a calibration performed? If yes, when was it done? If the
+                         calibration time is provided, it should be specified in
+                         ENTRY/INSTRUMENT/calibration/calibration_time.
+                    </doc>
+                    <enumeration>
+                        <item value="calibration time provided"/>
+                        <item value="no calibration"/>
+                        <item value="within 1 hour"/>
+                        <item value="within 1 day"/>
+                        <item value="within 1 week"/>
+                    </enumeration>
+                </field>
                 <field name="calibration_time" type="NX_DATE_TIME" optional="true">
                     <doc>
                          If calibtration status is 'calibration time provided', specify the
@@ -271,53 +395,407 @@ optical spectroscopy experiments-->
                          measurement. UTC offset should be specified.
                     </doc>
                 </field>
-                <field name="calibration_data_link">
+                <group name="calibration_data_link" type="NXidentifier" recommended="true">
                     <doc>
                          Link to the NeXus file containing the calibration data and metadata.
                     </doc>
+                </group>
+            </group>
+            <!--Discussion
+##########
+The basic idea was: You have always an incident source and a detector.
+Therefore, you always have an incident beam and a "detection beam".
+These beams can be assigned clear incident and detection angles.
+
+This information is always of relevance for ellipsometry,
+but for Raman experiments, the state of polarization is as well of relevance
+Additonally, this is limited for incident, detection and sample normal
+to be in one plane. This does not have to be the case for Raman scattering
+experiments. Therefore, this is not general enough and may be moved to
+NXellipsometry.
+This information may be as well stored in an incident and detection beam-->
+            <!--beam properties-->
+            <group name="beam_TYPE" type="NXbeam" minOccurs="0" maxOccurs="unbounded">
+                <doc>
+                     Beam characteristics between two beam_devices.
+                     
+                     It is recommended, to at least define one incident and one detection beam.
+                     If this beam is directly connected to an source, chose here the same
+                     name appendix as for the NXsource (e.g. TYPE=532nm)
+                </doc>
+                <field name="incident_wavelength" type="NX_FLOAT" units="NX_WAVELENGTH"/>
+                <field name="incident_wavelength_spread" type="NX_NUMBER" recommended="true" units="NX_WAVELENGTH"/>
+                <field name="incident_polarization" type="NX_NUMBER" recommended="true" units="NX_ANY"/>
+                <field name="extent" type="NX_FLOAT" recommended="true"/>
+                <field name="associated_source" type="NX_CHAR" recommended="true">
+                    <doc>
+                         The path to a the source, which emitted this beam.
+                         Should be named with the same appendix as the source, e.g.,
+                         for TYPE=532nmlaser, there should as well be
+                         a NXsource named "source_532nmlaser" aside of this Beam
+                         instance named "beam_532nmlaser"
+                         
+                         Example: /entry/instrument/source_532nmlaser
+                    </doc>
+                </field>
+                <!--The two polarization descriptions may be completely replaced by
+incident_polarization-->
+                <field name="beam_polarization_type" optional="true">
+                    <enumeration>
+                        <item value="linear"/>
+                        <item value="circular"/>
+                        <item value="ellipically"/>
+                        <item value="unpolarized"/>
+                    </enumeration>
+                </field>
+                <field name="linear_beam_sample_polarization" type="NX_NUMBER" optional="true" units="NX_ANGLE">
+                    <doc>
+                         Description of the light polarization of the respective beam and the beam-sample-normal.
+                         This is only well defined, if the beam direclty hits the sample (either indicent
+                         beam or detection beam) and if the samples needs to have a clearly
+                         defined sample surface. The beam-sample-normal plane is spanned by
+                         the beam and the samples surface normal.
+                         
+                         If the electric field in in this plane, this value is 0° (P-pol)
+                         If the electric field is perpendicular to this plane, this value is 90° (S-pol)
+                         If the surface normal is parallel to the beam direction, then only the
+                         relation between different polarizations has to be consistent 
+                         (i.e. parallel polarized 0° and cross polarized 90°)
+                    </doc>
                 </field>
             </group>
-            <group type="NXbeam_path">
-                <doc>
-                     Describes an arrangement of optical or other elements, e.g. the beam
-                     path between the light source and the sample, or between the sample
-                     and the detector unit (including the sources and detectors
-                     themselves).
-                     
-                     If a beam splitter (i.e. a device that splits the incoming beam into
-                     two or more beams) is part of the beam path, two or more NXbeam_path
-                     fields may be needed to fully describe the beam paths and the correct
-                     sequence of the beam path elements.
-                     Use as many beam paths as needed to describe the setup.
-                </doc>
-            </group>
-            <field name="angle_of_incidence" type="NX_NUMBER" units="NX_ANGLE">
+            <!--Discussion with florian:
+The user wants to use simple parameters, which they are used to.
+Though, via NXtransformations in principle maximum flexibility can be provided,
+even for unusual and complex experimental setups.
+The solution from mpes was: simple "front end" by only stating one angle
+with the "backend" to be customizable via NXtransformations.
+
+fundamental orientation of incident and detection beam-->
+            <!--
+relation beam directions (incident and detection) with sample orientation
+these angles are quite simple. They might be extended similar to
+NXmpes_liquid with leaf_normal to allow arbitrary description.
+this might require a different reference frame.
+-->
+            <field name="angle_of_incidence" type="NX_NUMBER" optional="true" units="NX_ANGLE">
                 <doc>
                      Angle(s) of the incident beam vs. the normal of the bottom reflective
-                     (substrate) surface in the sample.
+                     (substrate) surface in the sample. These two directions span the plane
+                     of incidence.
                 </doc>
                 <dimensions rank="1">
                     <dim index="1" value="N_incident_angles"/>
                 </dimensions>
                 <attribute name="units"/>
             </field>
-            <field name="detection_angle" type="NX_NUMBER" optional="true" units="NX_ANGLE">
+            <field name="angle_of_detection" type="NX_NUMBER" optional="true" units="NX_ANGLE">
                 <doc>
                      Detection angle(s) of the beam reflected or scattered off the sample
                      vs. the normal of the bottom reflective (substrate) surface in the
                      sample if not equal to the angle(s) of incidence.
+                     These two directions span the plane of detection.
                 </doc>
                 <dimensions rank="1">
                     <dim index="1" value="N_detection_angles"/>
                 </dimensions>
             </field>
-            <group name="sample_stage" type="NXsubentry">
+            <field name="angle_of_incident_and_detection_beam" type="NX_NUMBER" optional="true" units="NX_ANGLE">
                 <doc>
-                     Sample stage, holding the sample at a specific position in X,Y,Z
-                     (Cartesian) coordinate system and at an orientation defined
-                     by three Euler angles (alpha, beta, gamma).
+                     Angle between the incident and detection beam.
+                     If angle_of_detection + angle_of_incidence = angle_of_incident_and_detection_beam,
+                     then the setup is a reflection setup.
+                     If angle_of_detection + angle_of_incidence != angle_of_incident_and_detection_beam
+                     then the setup may be a light scattering setup.
+                     (i.e. 90° + 90° != 90°, i.e. incident and detection beam in the sample surface, but
+                     the angle source-sample-detector is 90°)
                 </doc>
-                <field name="stage_type">
+                <dimensions rank="1">
+                    <dim index="1" value="XX"/>
+                </dimensions>
+                <attribute name="units"/>
+            </field>
+            <field name="angle_of_in_plane_sample_rotation" type="NX_NUMBER" optional="true" units="NX_ANGLE">
+                <doc>
+                     Angle of the inplane orientation of the sample. This might be an arbitrary,
+                     angle without specific relation to the sample symmetry,
+                     of the angle to a specific sample property (i.e. crystallographic axis or sample
+                     shape such as wafer flat)
+                </doc>
+                <dimensions rank="1">
+                    <dim index="1" value="XX"/>
+                </dimensions>
+            </field>
+            <field name="lateral_focal_point_offset" type="NX_NUMBER" optional="true" units="NX_LENGTH">
+                <doc>
+                     Specify if there is a lateral offset on the sample surface, between the focal 
+                     points of the incident beam and the detection beam.
+                </doc>
+            </field>
+            <!--beam path elements-->
+            <group name="source_TYPE" type="NXsource" minOccurs="1" maxOccurs="unbounded">
+                <field name="type" recommended="true">
+                    <enumeration>
+                        <item value="laser"/>
+                        <item value="dye-laser"/>
+                        <item value="broadband tunable light source"/>
+                        <item value="X-ray Source"/>
+                        <item value="other"/>
+                    </enumeration>
+                </field>
+                <field name="type_other" optional="true">
+                    <doc>
+                         Specification of type, may also go to name.
+                    </doc>
+                </field>
+                <field name="name" recommended="true"/>
+                <field name="source_polarization" recommended="true">
+                    <doc>
+                         The type of light polarization produced by the source.
+                    </doc>
+                    <enumeration>
+                        <item value="linear"/>
+                        <item value="unpolarized"/>
+                        <item value="circular"/>
+                        <item value="elliptically"/>
+                        <item value="other"/>
+                    </enumeration>
+                </field>
+                <group name="device_information" type="NXfabrication">
+                    <doc>
+                         Details about the device information.
+                    </doc>
+                </group>
+                <field name="associated_beam" type="NX_CHAR">
+                    <doc>
+                         The path to a beam emitted by this source.
+                         Should be named with the same appendix, e.g.,
+                         for TYPE=532nmlaser, there should as well be
+                         a NXbeam named "beam_532nmlaser" aside of this source
+                         instance named "source_532nmlaser"
+                         
+                         Example: /entry/instrument/beam_532nmlaser
+                    </doc>
+                </field>
+                <group name="device_characteristics" type="NXdata"/>
+            </group>
+            <group name="detector_TYPE" type="NXdetector" minOccurs="1" maxOccurs="unbounded">
+                <field name="detector_channel_type" recommended="true">
+                    <enumeration>
+                        <item value="single-channel"/>
+                        <item value="multichannel"/>
+                    </enumeration>
+                </field>
+                <field name="detector_type" recommended="true">
+                    <doc>
+                         Description of the detector type.
+                    </doc>
+                    <enumeration>
+                        <item value="CCD"/>
+                        <item value="Photomultiplier"/>
+                        <item value="Photodiode"/>
+                        <item value="Avalanche-Photodiode"/>
+                        <item value="Bolometer"/>
+                        <item value="Golay Detectors"/>
+                        <item value="Pyroelectric Detector"/>
+                    </enumeration>
+                </field>
+                <group name="device_characteristics" type="NXdata"/>
+                <group name="device_information" type="NXfabrication" recommended="true">
+                    <field name="vendor" recommended="true"/>
+                    <field name="model" recommended="true"/>
+                    <field name="identifier" recommended="true"/>
+                </group>
+                <group name="raw_data" type="NXdata" recommended="true">
+                    <doc>
+                         Contains the raw data collected by the detector before calibration.
+                         The data which is considered raw might change from experiment to experiment
+                         due to hardware pre-processing of the data.
+                         This field ideally collects the data with the lowest level of processing
+                         possible.
+                    </doc>
+                    <!--Define a similar convention for NXopt? Or only for NXraman, NXellipsometry and NXphotoluminescence?
+ Fields should be named according to new following convention:
+
+ - **pixel_x**: Detector pixel in x direction.
+ - **pixel_y**: Detector pixel in y direction.
+ - **energy**: (Un)calibrated energy (kinetic or binding energy). Unit category: NX_ENERGY (e.g., eV).
+ - **kx**: (Un)calibrated x axis in k-space. Unit category: NX_ANY (e.g., 1/Angström).
+ - **ky**: (Un)calibrated y axis in k-space. Unit category: NX_ANY (1/Angström).
+ - **kz**: (Un)calibrated z axis in k-space. Unit category: NX_ANY (1/Angström).
+ - **angular0**: Fast-axis angular coordinate (or second slow axis if angularly integrated).
+   Unit category: NX_ANGLE
+ - **angular1**: Slow-axis angular coordinate (or second fast axis if simultaneously dispersed in 2 dimensions)
+   Unit category: NX_ANGLE
+ - **spatial0**: Fast-axis spatial coordinate (or second slow axis if spatially integrated)
+   Unit category: NX_LENGTH
+ - **spatial1**: Slow-axis spatial coordinate (or second fast axis if simultaneously dispersed in 2 dimensions)
+   Unit category: NX_LENGTH
+ - **delay**: Calibrated delay time. Unit category: NX_TIME (s).
+ - **polarization_angle**: Linear polarization angle of the incoming or
+   outgoing beam.
+   Unit category: NX_ANGLE (° or rad)
+ - **ellipticity**: Ellipticity of the incoming or outgoing beam.
+   Unit category: NX_ANGLE (° or rad)
+ - **time_of_flight**: Total time of flight. Unit category: NX_TIME_OF_FLIGHT
+ - **time_of_flight_adc**: Time-of-flight values, analog-to-digital converted.
+ - **external_AXIS**: Describes an axis which is coming from outside the detectors scope.-->
+                    <attribute name="signal">
+                        <enumeration>
+                            <item value="raw"/>
+                        </enumeration>
+                    </attribute>
+                    <field name="raw" type="NX_NUMBER">
+                        <doc>
+                             Raw data before calibration.
+                        </doc>
+                    </field>
+                </group>
+            </group>
+            <group type="NXmonochromator" optional="true">
+                <group name="device_characteristics" type="NXdata"/>
+            </group>
+            <group type="NXlens_opt" optional="true">
+                <group name="device_characteristics" type="NXdata"/>
+            </group>
+            <group type="NXwaveplate" optional="true">
+                <group name="device_characteristics" type="NXdata"/>
+            </group>
+            <group name="WINDOW" type="NXaperture" optional="true">
+                <doc>
+                     For environmental measurements, the environment (liquid, vapor
+                     etc.) is enclosed in a cell, which has windows both in the
+                     direction of the source (entry window) and the detector (exit
+                     window) (looking from the sample). In case that the entry and exit
+                     windows are not the same type and do not have the same properties,
+                     use a second 'WINDOW(MXaperture)' field.
+                     
+                     The windows also add a phase shift to the light altering the
+                     measured signal. This shift has to be corrected based on measuring
+                     a known sample (reference sample) or the actual sample of interest
+                     in the environmental cell. State if a window correction has been
+                     performed in 'window_effects_corrected'. Reference data should be
+                     considered as a separate experiment, and a link to the NeXus file
+                     should be added in reference_data_link in measured_data.
+                     
+                     The window is considered to be a part of the sample stage but also
+                     beam path. Hence, its position within the beam path should be
+                     defined by the 'depends_on' field.
+                </doc>
+                <field name="window_effects_corrected" type="NX_BOOLEAN">
+                    <doc>
+                         Was a window correction performed? If 'True' describe the window
+                         correction procedure in 'window_correction/procedure'.
+                    </doc>
+                </field>
+                <group name="window_correction" type="NXprocess" optional="true">
+                    <doc>
+                         Was a window correction performed? If 'True' describe the
+                         window correction procedure in ''
+                    </doc>
+                    <field name="procedure">
+                        <doc>
+                             Describe when (before or after the main measurement + time
+                             stamp in 'date') and how the window effects have been
+                             corrected, i.e. either mathematically or by performing a
+                             reference measurement. In the latter case, provide the link to
+                             to the reference data in 'reference_data_link'.
+                        </doc>
+                    </field>
+                    <field name="reference_data_link" optional="true">
+                        <doc>
+                             Link to the NeXus file which describes the reference data if a
+                             reference measurement for window correction was performed.
+                             Ideally, the reference measurement was performed on a reference
+                             sample and on the same sample, and using the same conditions as
+                             for the actual measurement with and without windows. It should
+                             have been conducted as close in time to the actual measurement
+                             as possible.
+                        </doc>
+                    </field>
+                </group>
+                <field name="material" type="NX_CHAR">
+                    <doc>
+                         The material of the window.
+                    </doc>
+                    <enumeration>
+                        <item value="quartz"/>
+                        <item value="diamond"/>
+                        <item value="calcium fluoride"/>
+                        <item value="zinc selenide"/>
+                        <item value="thallium bromoiodide"/>
+                        <item value="alkali halide compound"/>
+                        <item value="Mylar"/>
+                        <item value="other"/>
+                    </enumeration>
+                </field>
+                <field name="material_other" type="NX_CHAR" optional="true">
+                    <doc>
+                         If you specified 'other' as material, decsribe here what it is.
+                    </doc>
+                </field>
+                <field name="thickness" type="NX_FLOAT" units="NX_LENGTH">
+                    <doc>
+                         Thickness of the window.
+                    </doc>
+                </field>
+                <field name="orientation_angle" type="NX_FLOAT" units="NX_ANGLE">
+                    <doc>
+                         Angle of the window normal (outer) vs. the substrate normal
+                         (similar to the angle of incidence).
+                    </doc>
+                </field>
+            </group>
+            <field name="sample_medium_refractive_indices" type="NX_FLOAT" optional="true" units="NX_UNITLESS">
+                <doc>
+                     Array of pairs of complex refractive indices n + ik of the medium
+                     for every measured spectral point/wavelength/energy.
+                     Only necessary if the measurement was performed not in air, or
+                     something very well known, e.g. high purity water.
+                </doc>
+                <dimensions rank="2">
+                    <dim index="1" value="2"/>
+                    <dim index="2" value="N_spectrum"/>
+                </dimensions>
+            </field>
+            <!--beam devices for beam path description-->
+            <group type="NXbeam_device" minOccurs="0" maxOccurs="unbounded">
+                <doc>
+                     Describes the order of respective beam devices in the optical beam
+                     path.
+                     
+                     Everything object which interacts or modifies optical beam properties,
+                     may be an beam device, e.g. Filter, Window, Beamsplitter, Photon Source,
+                     Detector, etc,
+                     
+                     It is intended, to include this functionality later to "older" beam
+                     components, such as NXsource, NXdetector, NXlens, etc.
+                     Until this is possbible, auxillary beam devices have to be created,
+                     for each "older" beam component instead, to allow a beam path description.
+                     To link the auxillary beam device to the real device properties, the
+                     attribute \@device should be used.
+                </doc>
+                <attribute name="device" recommended="true">
+                    <doc>
+                         Reference to beam device, which is described by a NeXus concept
+                         (e.g. for NXsource, entry/instrument/source_TYPE).
+                    </doc>
+                </attribute>
+                <field name="previous_device" recommended="true">
+                    <doc>
+                         Reference to the previous beam device, from which the photon beam came
+                         to reach this beam device. A photon source is related as origin by ".".
+                         This enables a logical order description of the optical setup.
+                    </doc>
+                </field>
+            </group>
+            <!--non-beam path elements-->
+            <group name="sample_stage" type="NXmanipulator" optional="true">
+                <doc>
+                     Sample stage (or manipulator) for positioning of the sample. This should
+                     only contain the spatial orientation of movement.
+                </doc>
+                <field name="stage_type" optional="true">
                     <doc>
                          Specify the type of the sample stage.
                     </doc>
@@ -327,237 +805,93 @@ optical spectroscopy experiments-->
                         <item value="liquid stage"/>
                         <item value="gas cell"/>
                         <item value="cryostat"/>
+                        <item value="heater"/>
+                        <item value="other"/>
                     </enumeration>
                 </field>
-                <field name="alternative" optional="true">
+                <field name="stage_type_other" optional="true">
                     <doc>
-                         If there is no motorized stage, we should at least qualify where
-                         the beam hits the sample and in what direction the sample stands
-                         in a free-text description, e.g. 'center of sample, long edge
-                         parallel to the plane of incidence'.
+                         If "other" was chosen in stage_type, enter here a free text description
+                         of the stage type.
                     </doc>
                 </field>
-                <group name="environment_conditions" type="NXenvironment">
+                <field name="reference_frame" optional="true">
                     <doc>
-                         Specify external parameters that have influenced the sample, such
-                         as the surrounding medium, and varied parameters e.g. temperature,
-                         pressure, pH value, optical excitation etc.
+                         This is a placeholder, to describe the relation between the samples
+                         coordinate system, laboratory coordinate system and the stage coordinate
+                         system. Up to now, use the "beam_sample_relation" to give supporting
+                         information.
                     </doc>
-                    <field name="medium">
-                        <doc>
-                             Describe what was the medium above or around the sample. The
-                             common model is built up from the substrate to the medium on the
-                             other side. Both boundaries are assumed infinite in the model.
-                             Here, define the name of the medium (e.g. water, air, UHV, etc.).
-                        </doc>
-                    </field>
-                    <field name="medium_refractive_indices" type="NX_FLOAT" optional="true" units="NX_UNITLESS">
-                        <doc>
-                             Array of pairs of complex refractive indices n + ik of the medium
-                             for every measured spectral point/wavelength/energy.
-                             Only necessary if the measurement was performed not in air, or
-                             something very well known, e.g. high purity water.
-                        </doc>
-                        <dimensions rank="2">
-                            <dim index="1" value="2"/>
-                            <dim index="2" value="N_spectrum"/>
-                        </dimensions>
-                    </field>
-                    <group name="PARAMETER" type="NXsensor" optional="true">
-                        <doc>
-                             A sensor used to monitor an external condition influencing the
-                             sample, such as temperature or pressure. It is suggested to
-                             replace 'PARAMETER' by the type of the varied parameter defined
-                             in 'parameter_type'.
-                             The measured parameter values should be provided in 'values'.
-                             For each parameter, a 'PARAMETER(NXsensor)' field needs to exist.
-                             In other words, there are N_sensors 'PARAMETER(NXsensor)' fields.
-                        </doc>
-                        <field name="parameter_type">
-                            <doc>
-                                 Indicates which parameter was changed. Its definition must exist
-                                 below. The specified variable has to be N_measurements long,
-                                 providing the parameters for each data set. If you vary more than
-                                 one parameter simultaneously.
-                                 If the measured parameter is not contained in the list `other`
-                                 should be specified and the `parameter_type_name` should be provided.
-                            </doc>
-                            <enumeration>
-                                <item value="conductivity"/>
-                                <item value="detection_angle"/>
-                                <item value="electric_field"/>
-                                <item value="flow"/>
-                                <item value="incident_angle"/>
-                                <item value="magnetic_field"/>
-                                <item value="optical_excitation"/>
-                                <item value="pH"/>
-                                <item value="pressure"/>
-                                <item value="resistance"/>
-                                <item value="shear"/>
-                                <item value="stage_positions"/>
-                                <item value="strain"/>
-                                <item value="stress"/>
-                                <item value="surface_pressure"/>
-                                <item value="temperature"/>
-                                <item value="voltage"/>
-                                <item value="other"/>
-                            </enumeration>
-                        </field>
-                        <field name="parameter_type_name" optional="true">
-                            <doc>
-                                 If the parameter_type is `other` a name should be specified here.
-                            </doc>
-                        </field>
-                        <field name="number_of_parameters" type="NX_POSINT" units="NX_UNITLESS">
-                            <doc>
-                                 Number of different parameter values at which the measurement
-                                 was performed. For example, if the measurement was performed at
-                                 temperatures of 4, 77 and 300 K, then number_of_parameters = 3.
-                            </doc>
-                        </field>
-                        <field name="values" type="NX_FLOAT" units="NX_ANY">
-                            <doc>
-                                 Vector containing the values of the varied parameter. Its
-                                 length is equal to N_measurements. The order of the values
-                                 should be as follows:
-                                 
-                                 * Order the sensors according to number_of_parameters starting
-                                   with the lowest number. If number_of_parameters is equal for
-                                   two sensors order them alphabetically (sensor/parameter name).
-                                 * The first sensor's j parameters should be ordered in the
-                                   following way. The first N_measurements/number_of_parameters
-                                   entries of the vector contain the first parameter (a1), the
-                                   second N_measurements/number_of_parameters contain the second
-                                   parameter (a2) etc., so the vector looks like:
-                                   [
-                                   a1,a1,...,a1,
-                                   a2,a2,...,a2,
-                                   ...
-                                   aj,aj,...aj
-                                   ]
-                                 * The kth sensor's m parameters should be ordered in the
-                                   following way:
-                                   [
-                                   p1,...p1,p2,...,p2,...pm,...,pm,
-                                   p1,...p1,p2,...,p2,...pm,...,pm,
-                                   ...
-                                   p1,...p1,p2,...,p2,...pm,...,pm
-                                   ]
-                                 * The last sensor's n parameters should be ordered in the
-                                   following way:
-                                   [
-                                   z1,z2,...,zn,
-                                   z1,z2,...,zn,
-                                   ...
-                                   z1,z2,...,zn]
-                                 
-                                 For example, if the experiment was performed at three different
-                                 temperatures (T1, T2, T3), two different pressures (p1, p2) and
-                                 two different angles of incidence (a1, a2), then
-                                 N_measurements = 12 and the order of the values for the various
-                                 parameter vectors is:
-                                 
-                                 * angle_of_incidence: [a1,a1,a1,a1,a1,a1,a2,a2,a2,a2,a2,a2]
-                                 * pressure: [p1,p1,p1,p2,p2,p2,p1,p1,p1,p2,p2,p2]
-                                 * temperature: [T1,T2,T3,T1,T2,T3,T1,T2,T3,T1,T2,T3]
-                            </doc>
-                            <dimensions rank="1">
-                                <dim index="1" value="N_measurements"/>
-                            </dimensions>
-                        </field>
-                    </group>
-                </group>
-                <group name="WINDOW" type="NXaperture" optional="true">
+                </field>
+                <field name="beam_sample_relation" optional="true">
                     <doc>
-                         For environmental measurements, the environment (liquid, vapor
-                         etc.) is enclosed in a cell, which has windows both in the
-                         direction of the source (entry window) and the detector (exit
-                         window) (looking from the sample). In case that the entry and exit
-                         windows are not the same type and do not have the same properties,
-                         use a second 'WINDOW(MXaperture)' field.
-                         
-                         The windows also add a phase shift to the light altering the
-                         measured signal. This shift has to be corrected based on measuring
-                         a known sample (reference sample) or the actual sample of interest
-                         in the environmental cell. State if a window correction has been
-                         performed in 'window_effects_corrected'. Reference data should be
-                         considered as a separate experiment, and a link to the NeXus file
-                         should be added in reference_data_link in measured_data.
-                         
-                         The window is considered to be a part of the sample stage but also
-                         beam path. Hence, its position within the beam path should be
-                         defined by the 'depends_on' field.
+                         Description of relation of the beam with the sample. How dit the
+                         sample hit the beam, e.g. 'center of sample, long edge parallel
+                         to the plane of incidence'.
                     </doc>
-                    <field name="depends_on" recommended="true">
-                        <doc>
-                             Specify the position of the window in the beam path by pointing
-                             to the preceding element in the sequence of beam path elements.
-                        </doc>
-                    </field>
-                    <field name="window_effects_corrected" type="NX_BOOLEAN">
-                        <doc>
-                             Was a window correction performed? If 'True' describe the window
-                             correction procedure in 'window_correction/procedure'.
-                        </doc>
-                    </field>
-                    <group name="window_correction" type="NXprocess" optional="true">
-                        <doc>
-                             Was a window correction performed? If 'True' describe the
-                             window correction procedure in ''
-                        </doc>
-                        <field name="procedure">
-                            <doc>
-                                 Describe when (before or after the main measurement + time
-                                 stamp in 'date') and how the window effects have been
-                                 corrected, i.e. either mathematically or by performing a
-                                 reference measurement. In the latter case, provide the link to
-                                 to the reference data in 'reference_data_link'.
-                            </doc>
-                        </field>
-                        <field name="reference_data_link" optional="true">
-                            <doc>
-                                 Link to the NeXus file which describes the reference data if a
-                                 reference measurement for window correction was performed.
-                                 Ideally, the reference measurement was performed on a reference
-                                 sample and on the same sample, and using the same conditions as
-                                 for the actual measurement with and without windows. It should
-                                 have been conducted as close in time to the actual measurement
-                                 as possible.
-                            </doc>
-                        </field>
-                    </group>
-                    <field name="material" type="NX_CHAR">
-                        <doc>
-                             The material of the window.
-                        </doc>
-                        <enumeration>
-                            <item value="quartz"/>
-                            <item value="diamond"/>
-                            <item value="calcium fluoride"/>
-                            <item value="zinc selenide"/>
-                            <item value="thallium bromoiodide"/>
-                            <item value="alkali halide compound"/>
-                            <item value="Mylar"/>
-                            <item value="other"/>
-                        </enumeration>
-                    </field>
-                    <field name="other_material" type="NX_CHAR" optional="true">
-                        <doc>
-                             If you specified 'other' as material, decsribe here what it is.
-                        </doc>
-                    </field>
-                    <field name="thickness" type="NX_FLOAT" units="NX_LENGTH">
-                        <doc>
-                             Thickness of the window.
-                        </doc>
-                    </field>
-                    <field name="orientation_angle" type="NX_FLOAT" units="NX_ANGLE">
-                        <doc>
-                             Angle of the window normal (outer) vs. the substrate normal
-                             (similar to the angle of incidence).
-                        </doc>
-                    </field>
+                </field>
+                <group name="device_information" type="NXfabrication"/>
+            </group>
+            <group name="temperature_sensor" type="NXsensor" recommended="true">
+                <field name="name" recommended="true"/>
+                <field name="measurement">
+                    <enumeration>
+                        <item value="temperature"/>
+                    </enumeration>
+                </field>
+                <field name="type" optional="true"/>
+                <field name="value" type="NX_FLOAT"/>
+                <group name="device_information" type="NXfabrication"/>
+            </group>
+            <group name="temp_control_TYPE" type="NXactuator" optional="true">
+                <doc>
+                     Type of control for the sample temperature. Replace TYPE by "cryostat" or
+                     "heater" to specify it.
+                </doc>
+                <field name="name" recommended="true"/>
+                <field name="physical_quantity">
+                    <enumeration>
+                        <item value="temperature"/>
+                    </enumeration>
+                </field>
+                <field name="cryo_or_heater" recommended="true">
+                    <enumeration>
+                        <item value="cryostat"/>
+                        <item value="heater"/>
+                    </enumeration>
+                </field>
+                <field name="type" optional="true">
+                    <doc>
+                         Hardware used for actuation, i.e. laser, gas lamp, filament, resistive
+                    </doc>
+                </field>
+                <group type="NXpid">
+                    <field name="setpoint" type="NX_FLOAT" recommended="true"/>
                 </group>
+                <group name="device_information" type="NXfabrication"/>
+            </group>
+            <group name="PARAMETER_SENSOR" type="NXsensor" recommended="true">
+                <field name="name" recommended="true"/>
+                <field name="measurement"/>
+                <field name="type" optional="true"/>
+                <field name="value" type="NX_FLOAT"/>
+                <group name="device_information" type="NXfabrication"/>
+            </group>
+            <group name="PARAMETER_ACTUATOR" type="NXactuator" optional="true">
+                <doc>
+                     Control of arbitrary parameter - compare to temperature above.
+                </doc>
+                <field name="name" recommended="true"/>
+                <field name="physical_quantity"/>
+                <field name="type" optional="true">
+                    <doc>
+                         Hardware used for actuation
+                    </doc>
+                </field>
+                <group type="NXpid">
+                    <field name="setpoint" type="NX_FLOAT" recommended="true"/>
+                </group>
+                <group name="device_information" type="NXfabrication"/>
             </group>
         </group>
         <group type="NXsample">
@@ -569,30 +903,40 @@ optical spectroscopy experiments-->
             </doc>
             <field name="sample_name">
                 <doc>
-                     Descriptive name of the sample
+                     Name of the sample, which is uaually pleases human readability.
+                     This may be, but does not have to be identical to the sample_id.
                 </doc>
             </field>
-            <field name="sample_type">
+            <field name="sample_id" recommended="true">
                 <doc>
-                     Specify the type of sample, e.g. thin film, single crystal etc.
+                     Uniquely identifying name of the sample.
                 </doc>
+            </field>
+            <field name="physical_form" recommended="true">
+                <doc>
+                     State the form of the sample, examples are:
+                     thin film, single crystal, poly crystal, amorphous, single layer,
+                     multi layer, liquid, gas, pellet, powder.
+                </doc>
+            </field>
+            <field name="description" optional="true">
+                <doc>
+                     Free text description of the sample.
+                </doc>
+            </field>
+            <field name="situation" recommended="true">
                 <enumeration>
-                    <item value="thin film"/>
-                    <item value="single crystal"/>
-                    <item value="poly crystal"/>
-                    <item value="single layer"/>
-                    <item value="multi layer"/>
+                    <item value="air"/>
+                    <item value="vacuum"/>
+                    <item value="inert atmosphere"/>
+                    <item value="oxidising atmosphere"/>
+                    <item value="reducing atmosphere"/>
+                    <item value="sealed can"/>
+                    <item value="water"/>
+                    <item value="other"/>
                 </enumeration>
             </field>
-            <field name="layer_structure">
-                <doc>
-                     Qualitative description of the layer structure for the sample,
-                     starting with the top layer (i.e. the one on the front surface, on
-                     which the light incident), e.g. native oxide/bulk substrate, or
-                     Si/native oxide/thermal oxide/polymer/peptide.
-                </doc>
-            </field>
-            <field name="chemical_formula">
+            <field name="chemical_formula" recommended="true">
                 <doc>
                      Chemical formula of the sample. Use the Hill system (explained here:
                      https://en.wikipedia.org/wiki/Chemical_formula#Hill_system) to write
@@ -603,7 +947,7 @@ optical spectroscopy experiments-->
                      The order must be consistent with layer_structure
                 </doc>
             </field>
-            <field name="atom_types">
+            <field name="atom_types" optional="true">
                 <doc>
                      List of comma-separated elements from the periodic table that are
                      contained in the sample. If the sample substance has multiple
@@ -611,185 +955,134 @@ optical spectroscopy experiments-->
                      'atom_types'.
                 </doc>
             </field>
-            <field name="sample_history">
-                <doc>
-                     Ideally, a reference to the location or a unique (globally
-                     persistent) identifier (e.g.) of e.g. another file which gives
-                     as many as possible details of the material, its microstructure,
-                     and its thermo-chemo-mechanical processing/preparation history.
-                     In the case that such a detailed history of the sample is not
-                     available, use this field as a free-text description to specify
-                     details of the sample and its preparation.
-                </doc>
-            </field>
             <field name="preparation_date" type="NX_DATE_TIME" recommended="true">
                 <doc>
-                     ISO8601 date with time zone (UTC offset) specified.
+                     ISO 8601 time code with local time zone offset to UTC information
+                     when the specimen was prepared.
+                     
+                     Ideally, report the end of the preparation, i.e. the last known timestamp when
+                     the measured specimen surface was actively prepared.
                 </doc>
             </field>
-            <field name="substrate" recommended="true">
+            <group name="history" type="NXhistory" recommended="true">
                 <doc>
-                     Description of the substrate.
+                     A set of activities that occurred to the sample prior to/during the experiment.
+                </doc>
+                <group name="history_id" type="NXidentifier">
+                    <doc>
+                         A reference to the location or a unique (globally
+                         persistent) identifier (e.g.) of e.g. another file which gives
+                         as many as possible details of the material, its microstructure,
+                         and its thermo-chemo-mechanical processing/preparation history.
+                    </doc>
+                </group>
+            </group>
+            <group name="temperature" type="NXenvironment" recommended="true">
+                <doc>
+                     Sample temperature (either controlled or just measured).
+                </doc>
+                <group name="temperature_sensor" type="NXsensor">
+                    <doc>
+                         Temperature sensor measuring the sample temperature.
+                         This should be a link to /entry/instrument/manipulator/temperature_sensor.
+                    </doc>
+                </group>
+                <group name="sample_heater" type="NXactuator" optional="true">
+                    <doc>
+                         Device to heat the sample.
+                         This should be a link to /entry/instrument/manipulator/sample_heater.
+                    </doc>
+                </group>
+                <group name="cryostat" type="NXactuator" optional="true">
+                    <doc>
+                         Cryostat for cooling the sample.
+                         This should be a link to /entry/instrument/manipulator/cryostat.
+                    </doc>
+                </group>
+            </group>
+            <group type="NXenvironment" optional="true">
+                <doc>
+                     Arbirary sample property which may be varied during the experiment
+                     and controlled by a device. Examples are pressure, voltage, magnetic field etc.
+                     Similar to the temperautre description of the sample.
+                </doc>
+                <group type="NXsensor" optional="true"/>
+                <group type="NXactuator" optional="true"/>
+            </group>
+            <field name="thickness" type="NX_NUMBER" optional="true" units="NX_LENGTH">
+                <doc>
+                     (Measured) sample thickness.
+                     
+                     The information is recorded to qualify if the light used was likely
+                     able to shine through the sample. 
+                     
+                     In this case the value should be set to the actual thickness of
+                     the specimen viewed for an illumination situation where the nominal
+                     surface normal of the specimen is parallel to the optical axis.
+                </doc>
+            </field>
+            <field name="thickness_determination" optional="true">
+                <doc>
+                     If a thickness if given, please specify how this thickness was estimated or
+                     determined.
+                </doc>
+            </field>
+            <field name="layer_structure" optional="true">
+                <doc>
+                     Qualitative description of the layer structure for the sample,
+                     starting with the top layer (i.e. the one on the front surface, on
+                     which the light incident), e.g. native oxide/bulk substrate, or
+                     Si/native oxide/thermal oxide/polymer/peptide.
                 </doc>
             </field>
             <field name="sample_orientation" optional="true">
                 <doc>
-                     Specify the sample orientation.
+                     Specify the sample orientation, how is its sample normal oriented
+                     relative in the laboratory reference frame, incident beam reference
+                     frame.
+                </doc>
+            </field>
+            <field name="substrate" recommended="true">
+                <doc>
+                     If the sample is grown or fixed on a substrate, specify this here by
+                     a free text description.
                 </doc>
             </field>
         </group>
-        <group name="data_collection" type="NXprocess">
+        <group type="NXdata">
             <doc>
-                 Measured data, data errors, and varied parameters. If reference data
-                 were measured they should be considered a separate experiment and a
-                 link to its NeXus file should be added in reference_data_link.
+                 A default view of the data provided in ENTRY/data_collection/measured_data. This
+                 should be the part of the data set which provides the most suitable
+                 representation of the data.
+                 
+                 You may provide multiple instances of NXdata
             </doc>
-            <field name="data_identifier" type="NX_NUMBER">
+            <attribute name="axes">
                 <doc>
-                     An identifier to correlate data to the experimental conditions,
-                     if several were used in this measurement; typically an index of 0-N.
+                     Spectrum, i.e. x-axis of the data (e.g. wavelength, energy etc.)
                 </doc>
-            </field>
-            <field name="data_type">
+            </attribute>
+            <attribute name="signal">
                 <doc>
-                     Select which type of data was recorded, for example intensity,
-                     reflectivity, transmittance, Psi and Delta etc.
-                     It is possible to have multiple selections. The enumeration list
-                     depends on the type of experiment and may differ for different
-                     application definitions.
+                     Spectrum, i.e. y-axis of the data (e.g. counts, intensity)
                 </doc>
-                <enumeration>
-                    <item value="intensity"/>
-                    <item value="reflectivity"/>
-                    <item value="transmittance"/>
-                    <item value="Psi/Delta"/>
-                    <item value="tan(Psi)/cos(Delta)"/>
-                    <item value="Mueller matrix"/>
-                    <item value="Jones matrix"/>
-                    <item value="N/C/S"/>
-                    <item value="raw data"/>
-                </enumeration>
-            </field>
-            <!--This should be a required field, but is set to 'optional' for the moment-->
-            <field name="NAME_spectrum" type="NX_FLOAT" optional="true" units="NX_ANY">
-                <doc>
-                     Spectral values (e.g. wavelength or energy) used for the measurement.
-                     An array of 1 or more elements. Length defines N_spectrum. Replace
-                     'SPECTRUM' by the physical quantity that is used, e.g. wavelength.
-                </doc>
-                <dimensions rank="1">
-                    <dim index="1" value="N_spectrum"/>
-                </dimensions>
-                <attribute name="units" optional="true">
+            </attribute>
+        </group>
+        <group name="measurement_data_calibration" type="NXprocess">
+            <group name="wavelength_calibration" type="NXcalibration" optional="true">
+                <field name="calibrated_axis" type="NX_FLOAT" recommended="true">
                     <doc>
-                         If applicable, change 'unit: NX_ANY' to the appropriate NXDL unit.
-                         If the unit of the measured data is not covered by NXDL units state
-                         here which unit was used.
-                    </doc>
-                </attribute>
-            </field>
-            <field name="measured_data" type="NX_FLOAT" units="NX_ANY">
-                <doc>
-                     Resulting data from the measurement, described by 'data_type'.
-                     
-                     The first dimension is defined by the number of measurements taken,
-                     (N_measurements). The instructions on how to order the values
-                     contained in the parameter vectors given in the doc string of
-                     INSTRUMENT/sample_stage/environment_conditions/PARAMETER/values,
-                     define the N_measurements parameter sets. For example, if the
-                     experiment was performed at three different temperatures
-                     (T1, T2, T3), two different pressures (p1, p2) and two different
-                     angles of incidence (a1, a2), the first measurement was taken at the
-                     parameters {a1,p1,T1}, the second measurement at {a1,p1,T2} etc.
-                </doc>
-                <dimensions rank="3">
-                    <dim index="1" value="N_measurements"/>
-                    <dim index="2" value="N_observables"/>
-                    <dim index="3" value="N_spectrum"/>
-                </dimensions>
-                <attribute name="units" optional="true">
-                    <doc>
-                         If applicable, change 'unit: NX_ANY' to the appropriate NXDL unit.
-                         If the unit of the measured data is not covered by NXDL units state
-                         here which unit was used.
-                    </doc>
-                </attribute>
-            </field>
-            <field name="measured_data_errors" type="NX_FLOAT" optional="true" units="NX_ANY">
-                <doc>
-                     Specified uncertainties (errors) of the data described by 'data_type'
-                     and provided in 'measured_data'.
-                </doc>
-                <dimensions rank="3">
-                    <dim index="1" value="N_measurements"/>
-                    <dim index="2" value="N_observables"/>
-                    <dim index="3" value="N_spectrum"/>
-                </dimensions>
-                <attribute name="units" optional="true">
-                    <doc>
-                         If applicable, change 'unit: NX_ANY' to the appropriate NXDL unit.
-                         If the unit of the measured data is not covered by NXDL units state
-                         here which unit was used.
-                    </doc>
-                </attribute>
-            </field>
-            <field name="varied_parameter_link" optional="true">
-                <doc>
-                     List of links to the values of the sensors. Add a link for each
-                     varied parameter (i.e. for each sensor).
-                </doc>
-                <dimensions rank="1">
-                    <dim index="1" value="N_sensors"/>
-                </dimensions>
-            </field>
-            <field name="reference_data_link" optional="true">
-                <doc>
-                     Link to the NeXus file which describes the reference data if a
-                     reference measurement was performed. Ideally, the reference
-                     measurement was performed using the same conditions as the actual
-                     measurement and should be as close in time to the actual measurement
-                     as possible.
-                </doc>
-            </field>
-            <group name="data_software" type="NXprocess" optional="true">
-                <field name="program">
-                    <doc>
-                         Commercial or otherwise defined given name of the program that was
-                         used to generate the result file(s) with measured data and/or
-                         metadata (in most cases, this is the same as INSTRUMENT/software).
-                         If home written, one can provide the actual steps in the NOTE
-                         subfield here.
+                         Location to save the calibrated wavelength data.
                     </doc>
                 </field>
-                <field name="version">
-                    <doc>
-                         Either version with build number, commit hash, or description of a
-                         (online) repository where the source code of the program and build
-                         instructions can be found so that the program can be configured in
-                         such a way that result files can be created ideally in a
-                         deterministic manner.
-                    </doc>
-                </field>
-                <attribute name="url" optional="true">
-                    <doc>
-                         Website of the software.
-                    </doc>
-                </attribute>
-            </group>
-            <group type="NXdata" optional="true">
-                <doc>
-                     A plot of the multi-dimensional data array provided in
-                     ENTRY/data/measured_data.
-                </doc>
-                <attribute name="axes">
-                    <doc>
-                         Spectrum, i.e. x-axis of the data (e.g. wavelength, energy etc.)
-                    </doc>
-                </attribute>
             </group>
         </group>
+        <!--The old "data_collection(NXprocess)" is now replaced by more flexbile
+NXdata. A detailed rework of this has to be done after the NXopt workshop-->
         <group name="derived_parameters" type="NXprocess" optional="true">
             <doc>
+                 &gt;&gt;&gt;This section is transfered from the first NXopt version and might
+                 require a reqwork.&lt;&lt;&lt;
                  Parameters that are derived from the measured data.
             </doc>
             <field name="depolarization" type="NX_NUMBER" optional="true" units="NX_UNITLESS">
@@ -851,18 +1144,6 @@ optical spectroscopy experiments-->
                     </doc>
                 </field>
             </group>
-        </group>
-        <group name="plot" type="NXdata">
-            <doc>
-                 A default view of the data provided in ENTRY/data_collection/measured_data. This
-                 should be the part of the data set which provides the most suitable
-                 representation of the data.
-            </doc>
-            <attribute name="axes">
-                <doc>
-                     Spectrum, i.e. x-axis of the data (e.g. wavelength, energy etc.)
-                </doc>
-            </attribute>
         </group>
     </group>
 </definition>

--- a/contributed_definitions/NXopt_window.nxdl.xml
+++ b/contributed_definitions/NXopt_window.nxdl.xml
@@ -1,0 +1,117 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+<!--
+# NeXus - Neutron and X-ray Common Data Format
+#
+# Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# For further information, see http://www.nexusformat.org
+-->
+<!--
+A draft of a new base class to describe a window in a optical setup or device-->
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXopt_window" extends="NXaperture" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+    <doc>
+         A window of a cryostat, heater, vacuum chamber or a simple glass slide.
+         
+         This first verion originates from NXopt to describe cryostate windows
+         and possible influences for ellipsometry measurements.
+         
+         For environmental measurements, the environment (liquid, vapor
+         etc.) is enclosed in a cell, which has windows both in the
+         direction of the source (entry window) and the detector (exit
+         window) (looking from the sample). In case that the entry and exit
+         windows are not the same type and do not have the same properties,
+         use a second 'WINDOW(NXaperture)' field.
+         
+         The windows also add a phase shift to the light altering the
+         measured signal. This shift has to be corrected based on measuring
+         a known sample (reference sample) or the actual sample of interest
+         in the environmental cell. State if a window correction has been
+         performed in 'window_effects_corrected'. Reference data should be
+         considered as a separate experiment, and a link to the NeXus file
+         should be added in reference_data_link in measured_data.
+         
+         The window is considered to be a part of the sample stage but also
+         beam path. Hence, its position within the beam path should be
+         defined by the 'depends_on' field.
+    </doc>
+    <group type="NXentry">
+        <field name="window_effects_corrected" type="NX_BOOLEAN">
+            <doc>
+                 Was a window correction performed? If 'True' describe the window
+                 correction procedure in 'window_correction/procedure'.
+            </doc>
+        </field>
+        <group name="window_correction" type="NXprocess">
+            <doc>
+                 Was a window correction performed? If 'True' describe the
+                 window correction procedure in ''
+            </doc>
+            <field name="procedure">
+                <doc>
+                     Describe when (before or after the main measurement + time
+                     stamp in 'date') and how the window effects have been
+                     corrected, i.e. either mathematically or by performing a
+                     reference measurement. In the latter case, provide the link to
+                     to the reference data in 'reference_data_link'.
+                </doc>
+            </field>
+            <field name="reference_data_link">
+                <doc>
+                     Link to the NeXus file which describes the reference data if a
+                     reference measurement for window correction was performed.
+                     Ideally, the reference measurement was performed on a reference
+                     sample and on the same sample, and using the same conditions as
+                     for the actual measurement with and without windows. It should
+                     have been conducted as close in time to the actual measurement
+                     as possible.
+                </doc>
+            </field>
+        </group>
+        <field name="material" type="NX_CHAR">
+            <doc>
+                 The material of the window.
+            </doc>
+            <enumeration>
+                <item value="quartz"/>
+                <item value="diamond"/>
+                <item value="calcium fluoride"/>
+                <item value="zinc selenide"/>
+                <item value="thallium bromoiodide"/>
+                <item value="alkali halide compound"/>
+                <item value="Mylar"/>
+                <item value="other"/>
+            </enumeration>
+        </field>
+        <field name="material_other" type="NX_CHAR">
+            <doc>
+                 If you specified 'other' as material, decsribe here what it is.
+            </doc>
+        </field>
+        <field name="thickness" type="NX_FLOAT" units="NX_LENGTH">
+            <doc>
+                 Thickness of the window.
+            </doc>
+        </field>
+        <field name="orientation_angle" type="NX_FLOAT" units="NX_ANGLE">
+            <doc>
+                 Angle of the window normal (outer) vs. the substrate normal
+                 (similar to the angle of incidence).
+            </doc>
+        </field>
+    </group>
+</definition>

--- a/contributed_definitions/NXraman.nxdl.xml
+++ b/contributed_definitions/NXraman.nxdl.xml
@@ -1,0 +1,247 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+<!--
+# NeXus - Neutron and X-ray Common Data Format
+#
+# Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# For further information, see http://www.nexusformat.org
+-->
+<!--
+N_incident_wavelengths: |
+ Number of the incident wavelen
+N_incident_beams: |
+ to be done....-->
+<!--
+04/2024
+A draft version of a NeXus application definition for Raman spectroscopy.-->
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXraman" extends="NXopt" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+    <symbols>
+        <doc>
+             Variables used throughout the document, e.g. dimensions or parameters.
+        </doc>
+        <symbol name="N_spectrum">
+            <doc>
+                 Length of the spectrum array (e.g. wavelength or energy) of the measured
+                 data.
+            </doc>
+        </symbol>
+        <symbol name="N_measurements">
+            <doc>
+                 Number of measurements (1st dimension of measured_data array). This is
+                 equal to the number of parameters scanned. For example, if the experiment
+                 was performed at three different temperatures and two different pressures
+                 N_measurements = 2*3 = 6.
+            </doc>
+        </symbol>
+        <symbol name="N_detection_angles">
+            <doc>
+                 Number of detection angles of the beam reflected or scattered off the
+                 sample.
+            </doc>
+        </symbol>
+        <symbol name="N_incident_angles">
+            <doc>
+                 Number of angles of incidence of the incident beam.
+            </doc>
+        </symbol>
+        <symbol name="N_scattering_configurations">
+            <doc>
+                 Number of scattering configurations used in the measurement.
+                 It is 1 for only parallel polarization meausement, 2 for parallel and cross 
+                 polarization measurement or larger, if i.e. the incident and scattered photon
+                 direction is varied.
+            </doc>
+        </symbol>
+    </symbols>
+    <doc>
+         An application definition for Raman spectrocopy experiments.
+         
+         Such experiments may be as simple a single Raman spectrum from spontanous
+         Raman scattering and range to Raman imaging Raman spectrometer,
+         surface- and tip-enhanced Raman techniques, x-Ray Raman scattering, as well
+         as resonant Raman scattering phenomena or multidimenional Raman spectra (i.e.
+         varying temperature, pressure, electric field, ....)
+         
+         The application definition contains two things:
+         1. The structures in the application definition of NXopt:
+         * Instrument and data calibrations
+         * Sensors for sample or beam conditions
+           
+         AND
+         
+         2. The strucutres specified and extended in NXraman:
+         * description of the experiment type
+         * descroption of the setup's meta data and optical elements (source, monochromator, detector, waveplate, lens, etc.)
+         * description of beam properties and their relations to the sample
+         * sample information
+         
+         Information on Raman spectroscopy are provided in:
+         
+         General
+         
+         * Lewis, Ian R.; Edwards, Howell G. M.
+           Handbook of Raman Spectroscopy
+           ISBN 0-8247-0557-2
+         
+         Raman scattering selection rules
+         
+         * Dresselhaus, M. S.; Dresselhaus, G.; Jorio, A.
+           Group Theory - Application to the Physics ofCondensed Matter
+           ISBN 3540328971
+         
+         Semiconductors
+         
+         * Manuel Cardona
+           Light Scattering in Solids I
+           eBook ISBN: 978-3-540-37568-5
+           DOI: https://doi.org/10.1007/978-3-540-37568-5
+         
+         * Manuel Cardona, Gernot Güntherodt
+           Light Scattering in Solids II
+           eBook ISBN:  978-3-540-39075-6
+           DOI: https://doi.org/10.1007/3-540-11380-0
+         
+         * See as well other Books from the "Light Scattering in Solids" series:
+           III: Recent Results
+           IV: Electronic Scattering, Spin Effects, SERS, and Morphic Effects
+           V: Superlattices and Other Microstructures
+           VI: Recent Results, Including High-Tc Superconductivity
+           VII: Crystal-Field and Magnetic Excitations
+           VIII: Fullerenes, Semiconductor Surfaces, Coherent Phonons
+           IX: Novel Materials and Techniques
+         
+         Glasses, Liquids, Gasses, ...
+         
+         Review articles:
+         Stimulated Raman scattering, Coherent anti-Stokes Raman scattering,
+         Surface-enhanced Raman scattering, Tip-enhanced Raman scattering
+         * https://doi.org/10.1186/s11671-019-3039-2
+    </doc>
+    <group type="NXentry">
+        <field name="definition">
+            <doc>
+                 An application definition for Raman spectrsocopy.
+            </doc>
+            <attribute name="version">
+                <doc>
+                     Version number to identify which definition of this application
+                     definition was used for this entry/data.
+                </doc>
+            </attribute>
+            <attribute name="url">
+                <doc>
+                     URL where to find further material (documentation, examples) relevant
+                     to the application definition.
+                </doc>
+            </attribute>
+            <enumeration>
+                <item value="NXraman"/>
+            </enumeration>
+        </field>
+        <field name="title"/>
+        <field name="experiment_type">
+            <doc>
+                 Specify the type of the optical experiment.
+                 
+                 You may specify fundamental characteristics or properties in the experimental sub-type.
+            </doc>
+            <enumeration>
+                <item value="Raman spectroscopy"/>
+            </enumeration>
+        </field>
+        <field name="raman_experiment_type">
+            <doc>
+                 Specify the type of Raman experiment.
+            </doc>
+            <enumeration>
+                <item value="in situ Raman spectroscopy"/>
+                <item value="resonant Raman spectroscopy"/>
+                <item value="non-resonant Raman spectroscopy"/>
+                <item value="Raman imaging"/>
+                <item value="Tip-enhanced Raman spectroscopy (TERS)"/>
+                <item value="Surface-enhanced Raman spectroscopy (SERS)"/>
+                <item value="Surface plasmon polariton enhanced Raman scattering (SPPERS)"/>
+                <item value="Hyper Raman spectroscopy (HRS)"/>
+                <item value="Stimulated Raman spectroscopy (SRS)"/>
+                <item value="Inverse Raman spectroscopy (IRS)"/>
+                <item value="Coherent anti-Stokes Raman spectroscopy (CARS)"/>
+                <item value="other"/>
+            </enumeration>
+        </field>
+        <field name="raman_experiment_type_other" optional="true">
+            <doc>
+                 If the raman_experiment_type is `other`, a name should be specified here.
+            </doc>
+        </field>
+        <group type="NXinstrument">
+            <doc>
+                 Metadata of the setup, its optical elements and physical properites which
+                 defines the Raman measurement.
+            </doc>
+            <field name="scattering_configuration" type="NX_CHAR">
+                <doc>
+                     Scattering configuration as defined by the porto notation by three
+                     states, which are othogonal to each other. Example: z(xx)z for
+                     parallel polarized backscattering configuration.
+                     
+                     See:
+                     https://www.cryst.ehu.es/cgi-bin/cryst/programs/nph-doc-raman
+                     
+                     A(BC)D
+                     
+                     A = The propagation direction of the incident light (k_i)
+                     B = The polarization direction of the incident light (E_i)
+                     C = The polarization direction of the scattered light (E_s)
+                     D = The propagation direction of the scattered light (k_s)
+                     
+                     An orthogonal base is assumed.
+                     Linear polarized light is displayed by e.g. "x","y" or "z"
+                     Unpolarized light is displayed by "."
+                     For non-orthogonal vectors, use the attribute porto_notation_vectors.
+                </doc>
+                <attribute name="porto_notation_vectors" type="NX_NUMBER">
+                    <!--
+unit: NX_LENGTH
+-->
+                    <doc>
+                         Scattering configuration as defined by the porto notation given by
+                         respective vectors.
+                         
+                         Vectors in the porto notation are defined as for A, B, C, D above.
+                         Linear light polarization is assumed.
+                    </doc>
+                    <dimensions rank="3">
+                        <doc>
+                             3 x 4 Matrix, which lists the porto notation vectors A, B, C, D.
+                             A has to be perpendicular to B and C perpendicular to D.
+                        </doc>
+                        <dim index="1" value="4"/>
+                        <dim index="2" value="3"/>
+                        <dim index="3" value="N_scattering_configurations"/>
+                    </dimensions>
+                </attribute>
+            </field>
+            <group name="beam_incident" type="NXbeam">
+                <doc>
+                     Beam which is incident to the sample.
+                </doc>
+                <field name="wavelength" type="NX_NUMBER"/>
+            </group>
+        </group>
+    </group>
+</definition>

--- a/contributed_definitions/nyaml/NXellipsometry.yaml
+++ b/contributed_definitions/nyaml/NXellipsometry.yaml
@@ -1,7 +1,15 @@
 category: application
+
 doc: |
-  Ellipsometry, complex systems, up to variable angle spectroscopy.
+  This is the application definition describing ellipsometry experiments.
   
+  Such experiments may be as simple as identifying how a reflected
+  beam of light with a single wavelength changes its polarization state,
+  to a variable angle spectroscopic ellipsometry experiment.
+  
+  The application definition specifies optical spectroscopy (NXopt), by extending
+  the terms and setting specific requirements.
+
   Information on ellipsometry is provided, e.g. in:
   
   * H. Fujiwara, Spectroscopic ellipsometry: principles and applications,
@@ -35,20 +43,12 @@ doc: |
     Adv. Opt. Techn., (2022),
     https://doi.org/10.1515/aot-2022-0016
 
-# N_p1:
-# "Number of sample parameters scanned, if you varied any of the parameters
-# such as temperature, pressure, or pH, the maximal length of the arrays
-# specified by NXsample/environment_conditions/SENSOR/value if it exists."
-# N_time: "Number of time points measured, the length of NXsample/time_points"
 symbols:
   doc: |
     Variables used throughout the document, e.g. dimensions or parameters.
   N_spectrum: |
     Length of the spectrum array (e.g. wavelength or energy) of the measured
     data.
-  N_sensors: |
-    Number of sensors used to measure parameters that influence the sample,
-    such as temperature or pressure.
   N_measurements: |
     Number of measurements (1st dimension of measured_data array). This is
     equal to the number of parameters scanned. For example, if the experiment
@@ -59,48 +59,13 @@ symbols:
     sample.
   N_incident_angles: |
     Number of angles of incidence of the incident beam.
-  N_observables: |
-    Number of observables that are saved in a measurement. e.g. one for
-    intensity, reflectivity or transmittance, two for Psi and Delta etc. This
-    is equal to the second dimension of the data array 'measured_data' and the
-    number of column names.
-  N_time: |
-    Number of time points measured, the length of NXsample/time_points
 
-# 06/2022
-# A draft version of a NeXus application definition for ellipsometry.
+# 04/2024
+# A rework of the draft version(06/2022) of a NeXus application definition for ellipsometry.
 
-# The document has the following main elements:
-# - Instrument used and is characteristics
-# - Sample: Properties of the sample
-# - Data: measured data, data errors
-# - Derived parameters: e.g. extra parameters derived in the measurement software
 type: group
 NXellipsometry(NXopt):
-  
-  # symbols:
-  # doc: "Variables used throughout the document, e.g. dimensions and important parameters"
-  # N_wavelength: "Size of the energy or wavelength vector used, the length of
-  # NXinstrument/spectrometer/wavelength array"
-  # N_variables: "How many variables are saved in a measurement. e.g. 2 for Psi
-  # and Delta, 16 for Mueller matrix elements, 15 for normalized
-  # Mueller matrix, 3 for NCS, the length of NXsample/column_names"
-  # N_angles: "Number of incident angles used, the length of
-  # NXinstrument/angle_of_incidence array"
   (NXentry):
-    doc: |
-      This is the application definition describing ellipsometry experiments.
-      
-      Such experiments may be as simple as identifying how a reflected
-      beam of light with a single wavelength changes its polarization state,
-      to a variable angle spectroscopic ellipsometry experiment.
-      
-      The application definition defines:
-      
-      * elements of the experimental instrument
-      * calibration information if available
-      * parameters used to tune the state of the sample
-      * sample description
     definition:
       doc: |
         An application definition for ellipsometry.
@@ -113,37 +78,24 @@ NXellipsometry(NXopt):
           URL where to find further material (documentation, examples) relevant
           to the application definition.
       enumeration: [NXellipsometry]
-    experiment_description:
-      doc: |
-        An optional free-text description of the experiment.
-        
-        However, details of the experiment should be defined in the specific
-        fields of this application definition rather than in this experiment
-        description.
+    title:
     experiment_type:
       doc: |
+        Specify the type of the optical experiment.
+        
+        You may specify fundamental characteristics or properties in the experimental sub-type.
+      enumeration: [ellipsometry]
+    ellipsometry_experiment_type:
+      doc: |
         Specify the type of ellipsometry.
-      enumeration: [in situ spectroscopic ellipsometry, THz spectroscopic ellipsometry, infrared spectroscopic ellipsometry, ultraviolet spectroscopic ellipsometry, uv-vis spectroscopic ellipsometry, NIR-Vis-UV spectroscopic ellipsometry, imaging ellipsometry]
+      enumeration: [in situ spectroscopic ellipsometry, THz spectroscopic ellipsometry, infrared spectroscopic ellipsometry, ultraviolet spectroscopic ellipsometry, uv-vis spectroscopic ellipsometry, NIR-Vis-UV spectroscopic ellipsometry, other]
+    ellipsometry_experiment_type_other:
+      exists: optional
+      doc: |
+        If the ellipsometry_experiment_type is `other`, a name should be specified here.
     (NXinstrument):
       doc: |
         Properties of the ellipsometry equipment.
-      company:
-        exists: optional
-        doc: |
-          Name of the company which build the instrument.
-      construction_year(NX_DATE_TIME):
-        exists: optional
-        doc: |
-          ISO8601 date when the instrument was constructed.
-          UTC offset should be specified.
-      software(NXprocess):
-        program:
-          doc: |
-            Commercial or otherwise defined given name of the program that was
-            used to generate the result file(s) with measured data and metadata.
-            This program converts the measured signals to ellipsometry data. If
-            home written, one can provide the actual steps in the NOTE subfield
-            here.
       ellipsometer_type:
         doc: |
           What type of ellipsometry was used? See Fujiwara Table 4.2.
@@ -153,16 +105,17 @@ NXellipsometry(NXopt):
           Define which element rotates, e.g. polarizer or analyzer.
         enumeration: [polarizer (source side), analyzer (detector side), compensator (source side), compensator (detector side)]
       (NXbeam_path):
-        light_source(NXsource):
-          doc: |
-            Specify the used light source. Multiple selection possible.
-          source_type:
-            enumeration: [arc lamp, halogen lamp, LED, other]
+        #light_source(NXsource):
+        #  doc: |
+        #    Specify the used light source. Multiple selection possible.
+        #  source_type:
+        #    enumeration: [arc lamp, halogen lamp, LED, other]
         focussing_probes(NXlens_opt):
           exists: optional
           doc: |
             If focussing probes (lenses) were used, please state if the data
             were corrected for the window effects.
+          # This as well can be stated in window/aperture 
           data_correction(NX_BOOLEAN):
             doc: |
               Were the recorded data corrected by the window effects of the
@@ -172,10 +125,6 @@ NXellipsometry(NXopt):
             unit: NX_ANGLE
             doc: |
               Specify the angular spread caused by the focussing probes.
-        (NXdetector):
-          doc: |
-            Properties of the detector used. Integration time is the count time
-            field, or the real time field. See their definition.
         rotating_element(NXwaveplate):
           exists: optional
           doc: |
@@ -201,39 +150,25 @@ NXellipsometry(NXopt):
             doc: |
               Specify the maximum value of revolutions of the rotating element
               for each measurement.
-        spectrometer(NXmonochromator):
-          exists: optional
-          doc: |
-            The spectroscope element of the ellipsometer before the detector,
-            but often integrated to form one closed unit. Information on the
-            dispersive element can be specified in the subfield GRATING. Note
-            that different gratings might be used for different wavelength
-            ranges. The dispersion of the grating for each wavelength range can
-            be stored in grating_dispersion.
     (NXsample):
       backside_roughness(NX_BOOLEAN):
+        exists: recommended
         doc: |
           Was the backside of the sample roughened? Relevant for infrared
           ellipsometry.
-    data_collection(NXprocess):
+    (NXdata):
       data_type:
         doc: |
           Select which type of data was recorded, for example Psi and Delta
           (see: https://en.wikipedia.org/wiki/Ellipsometry#Data_acquisition).
           It is possible to have multiple selections. Data types may also be
           converted to each other, e.g. a Mueller matrix contains N,C,S data
-          as well. This selection defines how many columns (N_observables) are
-          stored in the data array.
+          as well.
         enumeration: [Psi/Delta, tan(Psi)/cos(Delta), Mueller matrix, Jones matrix, N/C/S, raw data]
   
-  # column_names:
-  # doc: |
-  # Please list in this array the column names used in your actual data.
-  # That is ['Psi', 'Delta'] or ['MM1', 'MM2', 'MM3', ..., 'MM16] for
-  # a full Mueller matrix, etc.
-  # dimensions:
-  # rank: 1
-  # dim: [[1, N_observables]]
+
+
+
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
 # e5c086ad7e50f420614c5465adc29a57a2b25cc1be09659435b3f1592c0f941a

--- a/contributed_definitions/nyaml/NXellipsometry.yaml
+++ b/contributed_definitions/nyaml/NXellipsometry.yaml
@@ -104,67 +104,175 @@ NXellipsometry(NXopt):
         doc: |
           Define which element rotates, e.g. polarizer or analyzer.
         enumeration: [polarizer (source side), analyzer (detector side), compensator (source side), compensator (detector side)]
-      (NXbeam_path):
-        #light_source(NXsource):
-        #  doc: |
-        #    Specify the used light source. Multiple selection possible.
-        #  source_type:
-        #    enumeration: [arc lamp, halogen lamp, LED, other]
-        focussing_probes(NXlens_opt):
-          exists: optional
+      focussing_probes(NXlens_opt):
+        exists: optional
+        doc: |
+          If focussing probes (lenses) were used, please state if the data
+          were corrected for the window effects.
+        # This as well can be stated in window/aperture
+        data_correction(NX_BOOLEAN):
           doc: |
-            If focussing probes (lenses) were used, please state if the data
-            were corrected for the window effects.
-          # This as well can be stated in window/aperture 
-          data_correction(NX_BOOLEAN):
-            doc: |
-              Were the recorded data corrected by the window effects of the
-              focussing probes (lenses)?
-          angular_spread(NX_NUMBER):
-            exists: recommended
-            unit: NX_ANGLE
-            doc: |
-              Specify the angular spread caused by the focussing probes.
-        rotating_element(NXwaveplate):
-          exists: optional
+            Were the recorded data corrected by the window effects of the
+            focussing probes (lenses)?
+        angular_spread(NX_NUMBER):
+          exists: recommended
+          unit: NX_ANGLE
           doc: |
-            Properties of the rotating element defined in
-            'instrument/rotating_element_type'.
-          revolutions(NX_NUMBER):
-            exists: optional
-            unit: NX_COUNT
-            doc: |
-              Define how many revolutions of the rotating element were averaged
-              for each measurement. If the number of revolutions was fixed to a
-              certain value use the field 'fixed_revolutions' instead.
-          fixed_revolutions(NX_NUMBER):
-            exists: optional
-            unit: NX_COUNT
-            doc: |
-              Define how many revolutions of the rotating element were taken
-              into account for each measurement (if number of revolutions was
-              fixed to a certain value, i.e. not averaged).
-          max_revolutions(NX_NUMBER):
-            exists: optional
-            unit: NX_COUNT
-            doc: |
-              Specify the maximum value of revolutions of the rotating element
-              for each measurement.
+            Specify the angular spread caused by the focussing probes.
+      rotating_element(NXwaveplate):
+        exists: optional
+        doc: |
+          Properties of the rotating element defined in
+          'instrument/rotating_element_type'.
+        revolutions(NX_NUMBER):
+          exists: optional
+          unit: NX_COUNT
+          doc: |
+            Define how many revolutions of the rotating element were averaged
+            for each measurement. If the number of revolutions was fixed to a
+            certain value use the field 'fixed_revolutions' instead.
+        fixed_revolutions(NX_NUMBER):
+          exists: optional
+          unit: NX_COUNT
+          doc: |
+            Define how many revolutions of the rotating element were taken
+            into account for each measurement (if number of revolutions was
+            fixed to a certain value, i.e. not averaged).
+        max_revolutions(NX_NUMBER):
+          exists: optional
+          unit: NX_COUNT
+          doc: |
+            Specify the maximum value of revolutions of the rotating element
+            for each measurement.
     (NXsample):
       backside_roughness(NX_BOOLEAN):
-        exists: recommended
+        exists: optional
         doc: |
           Was the backside of the sample roughened? Relevant for infrared
           ellipsometry.
-    (NXdata):
+    # The following NXdata setction called data_collection, is specialization
+    # from the old (NXopt and NXellipsometry) for the new NXellipometry.
+    # The generic description of the data collection will in future be
+    # included in the generic NXopt, but is now keept limited to
+    # NXellipsometry.
+    data_collection(NXdata):
+      doc: |
+        Measured data, data errors, and varied parameters. This may be used to describe
+        indirectly derived data or data transformed between different descriptions,
+        such as:
+        Raw Data --> Psi
+        Delta Psi, Delta --> N,C,S
+        Mueller matrix --> N,C,S
+        Mueller matrix --> Psi, Delta
+        etc.
+
+        Other types of data, such as temperature or sample location, may be saved
+        in a generic (NXdata) concept from NXopt, or better directly in the
+        location of the sample positioner or temperature sensor.
+      data_identifier(NX_NUMBER):
+        doc: |
+          An identifier to correlate data to the experimental conditions,
+          if several were used in this measurement; typically an index of 0-N.
       data_type:
         doc: |
-          Select which type of data was recorded, for example Psi and Delta
-          (see: https://en.wikipedia.org/wiki/Ellipsometry#Data_acquisition).
-          It is possible to have multiple selections. Data types may also be
-          converted to each other, e.g. a Mueller matrix contains N,C,S data
-          as well.
-        enumeration: [Psi/Delta, tan(Psi)/cos(Delta), Mueller matrix, Jones matrix, N/C/S, raw data]
+          Select which type of data was recorded, for example intensity,
+          reflectivity, transmittance, Psi and Delta etc.
+          It is possible to have multiple selections. The enumeration list
+          depends on the type of experiment and may differ for different
+          application definitions.
+        enumeration: [intensity, reflectivity, transmittance, Psi/Delta, tan(Psi)/cos(Delta), Mueller matrix, Jones matrix, N/C/S, raw data]
+
+      NAME_spectrum(NX_FLOAT):
+        exists: optional
+        unit: NX_ANY
+        doc: |
+          Spectral values (e.g. wavelength or energy) used for the measurement.
+          An array of 1 or more elements. Length defines N_spectrum. Replace
+          'SPECTRUM' by the physical quantity that is used, e.g. wavelength.
+        dimensions:
+          rank: 1
+          dim: [[1, N_spectrum]]
+        \@units:
+          exists: optional
+          doc: |
+            If applicable, change 'unit: NX_ANY' to the appropriate NXDL unit.
+            If the unit of the measured data is not covered by NXDL units state
+            here which unit was used.
+      measured_data(NX_FLOAT):
+        unit: NX_ANY
+        doc: |
+          Resulting data from the measurement, described by 'data_type'.
+
+          The first dimension is defined by the number of measurements taken,
+          (N_measurements). The instructions on how to order the values
+          contained in the parameter vectors given in the doc string of
+          INSTRUMENT/sample_stage/environment_conditions/PARAMETER/values,
+          define the N_measurements parameter sets. For example, if the
+          experiment was performed at three different temperatures
+          (T1, T2, T3), two different pressures (p1, p2) and two different
+          angles of incidence (a1, a2), the first measurement was taken at the
+          parameters {a1,p1,T1}, the second measurement at {a1,p1,T2} etc.
+        dimensions:
+          rank: 3
+          dim: [[1, N_measurements], [2, N_observables], [3, N_spectrum]]
+        \@units:
+          exists: optional
+          doc: |
+            If applicable, change 'unit: NX_ANY' to the appropriate NXDL unit.
+            If the unit of the measured data is not covered by NXDL units state
+            here which unit was used.
+      measured_data_errors(NX_FLOAT):
+        exists: optional
+        unit: NX_ANY
+        doc: |
+          Specified uncertainties (errors) of the data described by 'data_type'
+          and provided in 'measured_data'.
+        dimensions:
+          rank: 3
+          dim: [[1, N_measurements], [2, N_observables], [3, N_spectrum]]
+        \@units:
+          exists: optional
+          doc: |
+            If applicable, change 'unit: NX_ANY' to the appropriate NXDL unit.
+            If the unit of the measured data is not covered by NXDL units state
+            here which unit was used.
+      varied_parameter_link:
+        exists: optional
+        doc: |
+          List of links to the values of the sensors. Add a link for each
+          varied parameter (i.e. for each sensor).
+        dimensions:
+          rank: 1
+          dim: [[1, N_sensors]]
+      reference_data_link:
+        exists: optional
+        doc: |
+          Link to the NeXus file which describes the reference data if a
+          reference measurement was performed. Ideally, the reference
+          measurement was performed using the same conditions as the actual
+          measurement and should be as close in time to the actual measurement
+          as possible.
+      data_software(NXprogram):
+        exists: optional
+        program:
+          doc: |
+            Commercial or otherwise defined given name of the program that was
+            used to generate the result file(s) with measured data and/or
+            metadata (in most cases, this is the same as INSTRUMENT/software).
+            If home written, one can provide the actual steps in the NOTE
+            subfield here.
+        version:
+          doc: |
+            Either version with build number, commit hash, or description of a
+            (online) repository where the source code of the program and build
+            instructions can be found so that the program can be configured in
+            such a way that result files can be created ideally in a
+            deterministic manner.
+        \@url:
+          exists: optional
+          doc: |
+            Website of the software.
+
   
 
 

--- a/contributed_definitions/nyaml/NXfabrication.yaml
+++ b/contributed_definitions/nyaml/NXfabrication.yaml
@@ -13,7 +13,15 @@ NXfabrication(NXobject):
     doc: |
       Ideally, (globally) unique persistent identifier, i.e.
       a serial number or hash identifier of the component.
+  construction_year(NX_DATE_TIME):
+    doc: |
+      Datetime of components initial construction. This refers to the date of
+      first measurement after new construction or to the relocation date,
+      if it describes a multicomponent/custom-build setup.
+      Should be a ISO8601 date/time stamp. It is recommended to add an explicit time zone,
+      otherwise the local time zone is assumed per ISO8601.
   capability(NX_CHAR):
     doc: |
       Free-text list with eventually multiple terms of
       functionalities which the component offers.
+

--- a/contributed_definitions/nyaml/NXfabrication.yaml
+++ b/contributed_definitions/nyaml/NXfabrication.yaml
@@ -12,7 +12,8 @@ NXfabrication(NXobject):
     \@version:
       type: NX_CHAR
       doc: |
-        If different versions exist are possible, the value in this field should be made specific enough to resolve the version.
+        If different versions exist are possible, the value in this field should be made
+        specific enough to resolve the version.
   identifier(NX_CHAR):
     doc: |
       Ideally, (globally) unique persistent identifier, i.e.
@@ -30,7 +31,7 @@ NXfabrication(NXobject):
       functionalities which the component offers.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 6b41658298bdab15f08057e91686e6853e1c1adf0460309bc82194cf30151ac1
+# 1bd65ca97f104626d51743277a21d0f909b560fd3fbdbc8e4f46f5d1fba3dc5c
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -65,12 +66,12 @@ NXfabrication(NXobject):
 #     </field>
 #     <field name="model" type="NX_CHAR">
 #         <doc>
-#              Version or model of the component named by the manufacturer. 
+#              Version or model of the component named by the manufacturer.
 #         </doc>
 #         <attribute name="version" type="NX_CHAR">
 #             <doc>
-#                 If different versions exist are possible, the value in this field should be made specific enough to resolve the version.
-# 
+#                  If different versions exist are possible, the value in this field should be made
+#                  specific enough to resolve the version.
 #             </doc>
 #         </attribute>
 #     </field>
@@ -78,6 +79,15 @@ NXfabrication(NXobject):
 #         <doc>
 #              Ideally, (globally) unique persistent identifier, i.e.
 #              a serial number or hash identifier of the component.
+#         </doc>
+#     </field>
+#     <field name="construction_year" type="NX_DATE_TIME">
+#         <doc>
+#              Datetime of components initial construction. This refers to the date of
+#              first measurement after new construction or to the relocation date,
+#              if it describes a multicomponent/custom-build setup.
+#              Should be a ISO8601 date/time stamp. It is recommended to add an explicit time zone,
+#              otherwise the local time zone is assumed per ISO8601.
 #         </doc>
 #     </field>
 #     <field name="capability" type="NX_CHAR">

--- a/contributed_definitions/nyaml/NXhistory.yaml
+++ b/contributed_definitions/nyaml/NXhistory.yaml
@@ -26,6 +26,12 @@ NXhistory(NXobject):
       Any chemical process that was performed on the physical entity prior or during the
       experiment.
   
+  (NXidentifier):
+    doc: |
+      An ID or reference to the location or a unique (globally
+      persistent) identifier of e.g. another file which gives
+      as many as possible details of the history event.
+
   # There should be more activities here, like measurement.
   notes(NXnote):
     doc: |

--- a/contributed_definitions/nyaml/NXopt.yaml
+++ b/contributed_definitions/nyaml/NXopt.yaml
@@ -28,6 +28,18 @@ symbols:
 # 04/2024
 # Extension of the Draft Version (05/2023) of a NeXus application definition which
 # serves as a template for various optical spectroscopy experiments
+#
+# TODO:
+# - Merge reference_frames with angle_reference_frame
+# - Rework instrument_calibration_DEVICE - use NXcalibration?
+# - Beam polarizations: Own Polarization concept with angle or from NXbeam via beam coordinates? (solve reference frame problem first)
+# - Describe angle_of_detection by NXtransformations
+# - remove NXmonchromator? as it is already in NXinstrument
+# - Add NXlens_opt and NXwaveplate to NXinstrument?
+# - Make sample stage_stage(NXmanipulator)/reference_frame via NXtransformations
+# - Add properties from NXlens_opt from NXopt to NXlens_opt base class
+# - Make polfilter_TYPE(NXbeam_device) own base class --> rework NXpolarizer_opt. and add them to NXinstrument.
+# - Make spectralfilter_TYPE(NXbeam_device) own base class --> extend NXfilter?  and add them to NXinstrument.
 type: group
 NXopt(NXobject):
   (NXentry):
@@ -63,8 +75,11 @@ NXopt(NXobject):
         principal investigator.
         (ii) The identifier enables to link experiments to e.g. proposals.
       service(NX_CHAR):
+        exists: optional
       identifier(NX_CHAR):
+        exists: recommended
       is_persistent(NX_BOOLEAN):
+        exists: optional
     experiment_description:
       exists: optional
       doc: |
@@ -81,10 +96,11 @@ NXopt(NXobject):
       doc: |
         Specify the type of the optical experiment.
         
-        Chose other if non of these methods are suitable. You may specify
+        Chose other if none of these methods are suitable. You may specify
         fundamental characteristics or properties in the experimental sub-type.
       enumeration: [ellipsometry, Raman spectroscopy, photoluminescence, transmission spectroscopy, reflection spectroscopy, other]
     experiment_sub_type:
+      exists: optional
       doc: |
         Specify a special property or characteristic of the experiment, which specifies
         the generic experiment type.
@@ -94,60 +110,30 @@ NXopt(NXobject):
     # The above listed things are related to beam properties? This is different
     # compared to temperature or pressure. Is this a useful distinction?
     experiment_type_other:
+      exists: optional
       doc: |
-        If "other" was selected in "experiment_type", specify the experiment here
-        with a free text name, which is knwon in the respective community of interest.
+        If "other" was selected in "experiment_type" and/or in "experiment_sub_type",
+        specify the experiment here with a free text name, which is knwon in the
+        respective community of interest.
+    reference_frames(NXcoordinate_system_set):
+      # This should be extended later and hopefully replace angle_reference_frame
+      # and sample_normal_direction.
+      # Required reference frames:
+      # Sample normal, beam_z_axis, sample_stage
+      exists: optional
+      doc: |
+        Description of one or more coordinate systems that are specific to the
+        experiment.
     (NXuser):
       exists: [min, 0, max, infty]
       doc: |
         Contact information and eventually details of at persons who
         performed the measurements. This can be for example the principal
-        investigator or student.
+        investigator or student. Examples are: name, affiliation, address, telephone
+        number, email, role as well as identifiers such as orcid or similar. 
         It is recommended to add multiple users if relevant.
 
         Due to data privacy concerns, there is no minimum requirement.
-      name(NX_CHAR):
-        exists: recommended
-        doc: |
-          Given (first) name and surname of the user.
-      affiliation(NX_CHAR):
-        exists: optional
-        doc: |
-          Name of the affiliation of the user at the point in time
-          when the experiment was performed.
-      address(NX_CHAR):
-        exists: optional
-        doc: |
-          Postal address of the user's affiliation.
-      email(NX_CHAR):
-        exists: optional
-        doc: |
-          Email address of the user at the point in time when the experiment
-          was performed. Writing the most permanently used email is recommended.
-      orcid(NX_CHAR):
-        exists: recommended
-        doc: |
-          Author ID defined by https://orcid.org/.
-      telephone_number(NX_CHAR):
-        exists: optional
-        doc: |
-          (Business) (tele)phone number of the user at the point
-          in time when the experiment was performed.
-      role(NX_CHAR):
-        exists: optional
-        doc: |
-          Which role does the user have in the place and at the point
-          in time when the experiment was performed? Technician operating
-          the setup, student, PhD-student, postdoc, principle investigator, or guest
-          are common examples.
-      identifier(NXidentifier):
-        exists: recommended
-        doc: |
-          Service as another mean of identification of a user other than by its name.
-          Examples could be an ORCID or social media account of the user.
-        service(NX_CHAR):
-        identifier(NX_CHAR):
-        is_persistent(NX_BOOLEAN):
     (NXinstrument):
       doc: |
         Devices or elements of the optical spectroscopy setup described with its
@@ -176,12 +162,7 @@ NXopt(NXobject):
         identifier:
           exists: recommended
         construction_year(NX_DATE_TIME):
-          exists: recommended
-          doc: |
-            Datetime of setup's initial construction. This refers to the date of
-            first measurement after new construction  or relocation of the setup.
-            Should be a ISO8601 date/time stamp. It is recommended to add an explicit time zone,
-            otherwise the local time zone is assumed per ISO8601.
+          exists: optional
       software_TYPE(NXprogram):
         exists: recommended
         program:
@@ -192,6 +173,7 @@ NXopt(NXobject):
             "software_detector" or "software_stage" to specify the respective
             program or software components.
           \@version:
+            exists: recommended
             doc: |
               Either version with build number, commit hash, or description of a
               (online) repository where the source code of the program and build
@@ -203,16 +185,9 @@ NXopt(NXobject):
             doc: |
               Description of the software by persistent resource, where the program,
               code, script etc. can be found.
-      # general properties and reference frames
-      reference_frames(NXcoordinate_system_set):
-        # This should be extended later and hopefully replace angle_reference_frame
-        # and sample_normal_direction.
-        # Required reference frames:
-        # Sample normal, beam_z_axis, sample_stage
-        exists: optional
-        doc: |
-          Description of one or more coordinate systems that are specific to the
-          experiment.
+      # The angle_reference_frame will be connected later to general reference frames
+      # For this this solution enables the description of the beam relations for
+      # different optical spectroscopy methods in the reference frame they are used to
       angle_reference_frame:
         doc: |
           Defines the reference frame which is used to describe the sample orientation
@@ -264,7 +239,9 @@ NXopt(NXobject):
         exists: recommended
         doc: |
           Pre-calibration of an arbitrary device of the instrumental setup, which
-          has the name DEVICE. You can specify here at which point
+          has the name DEVICE. You can specify here how, at which time by which method
+          the calibration was done. As well the accuracy and a link to the calibration
+          dataset.
         device_path:
           exists: recommended
           doc: |
@@ -317,31 +294,31 @@ NXopt(NXobject):
         doc: |
           Beam characteristics between two beam_devices.
 
-          It is recommended, to at least define one incident and one detection beam.
-          If this beam is directly connected to an source, chose here the same
+          It is recommended to at least define one incident and one detection beam.
+          If this beam is directly connected to a source, chose here the same
           name appendix as for the NXsource (e.g. TYPE=532nm)
-        incident_wavelength(NX_FLOAT):
-          unit: NX_WAVELENGTH
+        incident_wavelength(NX_NUMBER):
+          exists: recommended
         incident_wavelength_spread(NX_NUMBER):
           exists: recommended
-          unit: NX_WAVELENGTH
         incident_polarization(NX_NUMBER):
           exists: recommended
-          unit: NX_ANY
         extent(NX_FLOAT):
           exists: recommended
         associated_source(NX_CHAR):
-          exists: recommended
+          exists: optional
           doc: |
-            The path to a the source, which emitted this beam.
-            Should be named with the same appendix as the source, e.g.,
-            for TYPE=532nmlaser, there should as well be
-            a NXsource named "source_532nmlaser" aside of this Beam
-            instance named "beam_532nmlaser"
+            The path to the source which emitted this beam.
+
+            Is recommended, if the previous optical element is a photon source.
+            In this way, the properties of the laser or light souce can be described
+            and associated.
+            The beam should be named with the same appendix as the source, e.g.,
+            for TYPE=532nmlaser, there should be both a NXsource named
+            "source_532nmlaser" and a NXbeam named "beam_532nmlaser".
             
             Example: /entry/instrument/source_532nmlaser
-        # The two polarization descriptions may be completely replaced by
-        # incident_polarization
+        # The two polarization descriptions may be completely replaced by polarization
         beam_polarization_type:
           exists: optional
           enumeration: [linear, circular, ellipically, unpolarized]
@@ -360,12 +337,8 @@ NXopt(NXobject):
             relation between different polarizations has to be consistent 
             (i.e. parallel polarized 0° and cross polarized 90°)
           unit: NX_ANGLE
-      # Discussion with florian:
-      # The user wants to use simple parameters, which they are used to.
-      # Though, via NXtransformations in principle maximum flexibility can be provided,
-      # even for unusual and complex experimental setups.
-      # The solution from mpes was: simple "front end" by only stating one angle
-      # with the "backend" to be customizable via NXtransformations.
+      # The given angles may be extended similar to NXmpes, to allow a simple
+      # as well as an arbitrary description via NXtransformations
       #
       # fundamental orientation of incident and detection beam
       angle_of_incidence(NX_NUMBER):
@@ -432,18 +405,13 @@ NXopt(NXobject):
         exists: [min, 1, max, infty]
         type:
           exists: recommended
-          enumeration: [laser, dye-laser, broadband tunable light source, X-ray Source, other]
+          enumeration: [laser, dye-laser, broadband tunable light source, X-ray Source, arc lamp, halogen lamp, LED, other]
         type_other:
           exists: optional
           doc: |
             Specification of type, may also go to name.
         name:
           exists: recommended
-        source_polarization:
-          exists: recommended
-          doc: |
-            The type of light polarization produced by the source.
-          enumeration: [linear, unpolarized, circular, elliptically, other]
         device_information(NXfabrication):
           doc: |
             Details about the device information.
@@ -452,11 +420,16 @@ NXopt(NXobject):
             The path to a beam emitted by this source.
             Should be named with the same appendix, e.g.,
             for TYPE=532nmlaser, there should as well be
-            a NXbeam named "beam_532nmlaser" aside of this source
+            a NXbeam named "beam_532nmlaser" together with this source
             instance named "source_532nmlaser"
             
             Example: /entry/instrument/beam_532nmlaser
         device_characteristics(NXdata):
+          exists: optional
+          doc: |
+            You may add here data which characterises the source in more detail,
+            such as spectral power density, power dependency on line width, line-shape
+            of the laser line, etc.
       detector_TYPE(NXdetector):
         exists: [min, 1, max, infty]
         detector_channel_type:
@@ -466,8 +439,17 @@ NXopt(NXobject):
           exists: recommended
           doc: |
             Description of the detector type.
-          enumeration: [CCD, Photomultiplier, Photodiode, Avalanche-Photodiode, Bolometer, Golay Detectors, Pyroelectric Detector]
+          enumeration: [CCD, Photomultiplier, Photodiode, Avalanche-Photodiode, Bolometer, Golay Detectors, Pyroelectric Detector, other]
+        detector_type_other:
+          exists: optional
+          doc: |
+            Type of detector, if "other" was selected in "detector_type".
         device_characteristics(NXdata):
+          exists: optional
+          doc: |
+            You may add here data which characterizes the detector, such as quantum
+            efficiency as function of wavelength or angular dependency of intenty.
+
         device_information(NXfabrication):
           exists: recommended
           vendor:
@@ -519,76 +501,42 @@ NXopt(NXobject):
       (NXmonochromator):
         exists: optional
         device_characteristics(NXdata):
+          exists: optional
+          doc: |
+            Characteristics of the monochromator as diffraction efficiency as 
+            wavelength and polarization dependence
+        device_information(NXfabrication):
+          exists: recommended
+          vendor:
+            exists: recommended
+          model:
+            exists: recommended
+          identifier:
+            exists: recommended
       (NXlens_opt):
         exists: optional
+        doc: |
+          This is the optical element used to focus or collect light. This may
+          be a genereic lens or microcope objectives which are used for the
+          Raman scattering process.
+        type:
+          enumeration: [objective, lens, glass fiber, none, other]
+        numerical_aperture(NX_NUMBER):
+          doc: |
+            The numerical aperture of the used incident light optics.
+        magnification(NX_FLOAT):
+          doc: |
+            Magnification of the lens.
+        device_information(NXfabrication):
+          exists: recommended
+          doc: |
+            Details about the optical component, if available. 
         device_characteristics(NXdata):
       (NXwaveplate):
         exists: optional
         device_characteristics(NXdata):
-      WINDOW(NXaperture):
-        exists: optional
-        doc: |
-          For environmental measurements, the environment (liquid, vapor
-          etc.) is enclosed in a cell, which has windows both in the
-          direction of the source (entry window) and the detector (exit
-          window) (looking from the sample). In case that the entry and exit
-          windows are not the same type and do not have the same properties,
-          use a second 'WINDOW(MXaperture)' field.
-          
-          The windows also add a phase shift to the light altering the
-          measured signal. This shift has to be corrected based on measuring
-          a known sample (reference sample) or the actual sample of interest
-          in the environmental cell. State if a window correction has been
-          performed in 'window_effects_corrected'. Reference data should be
-          considered as a separate experiment, and a link to the NeXus file
-          should be added in reference_data_link in measured_data.
-          
-          The window is considered to be a part of the sample stage but also
-          beam path. Hence, its position within the beam path should be
-          defined by the 'depends_on' field.
-        window_effects_corrected(NX_BOOLEAN):
-          doc: |
-            Was a window correction performed? If 'True' describe the window
-            correction procedure in 'window_correction/procedure'.
-        window_correction(NXprocess):
-          exists: optional
-          doc: |
-            Was a window correction performed? If 'True' describe the
-            window correction procedure in ''
-          procedure:
-            doc: |
-              Describe when (before or after the main measurement + time
-              stamp in 'date') and how the window effects have been
-              corrected, i.e. either mathematically or by performing a
-              reference measurement. In the latter case, provide the link to
-              to the reference data in 'reference_data_link'.
-          reference_data_link:
-            exists: optional
-            doc: |
-              Link to the NeXus file which describes the reference data if a
-              reference measurement for window correction was performed.
-              Ideally, the reference measurement was performed on a reference
-              sample and on the same sample, and using the same conditions as
-              for the actual measurement with and without windows. It should
-              have been conducted as close in time to the actual measurement
-              as possible.
-        material(NX_CHAR):
-          doc: |
-            The material of the window.
-          enumeration: [quartz, diamond, calcium fluoride, zinc selenide, thallium bromoiodide, alkali halide compound, Mylar, other]
-        material_other(NX_CHAR):
-          exists: optional
-          doc: |
-            If you specified 'other' as material, decsribe here what it is.
-        thickness(NX_FLOAT):
-          unit: NX_LENGTH
-          doc: |
-            Thickness of the window.
-        orientation_angle(NX_FLOAT):
-          unit: NX_ANGLE
-          doc: |
-            Angle of the window normal (outer) vs. the substrate normal
-            (similar to the angle of incidence).
+      (NXopt_window):
+
       sample_medium_refractive_indices(NX_FLOAT):
         exists: optional
         unit: NX_UNITLESS
@@ -600,6 +548,66 @@ NXopt(NXobject):
         dimensions:
           rank: 2
           dim: [[1, 2], [2, N_spectrum]]
+      
+      polfilter_TYPE(NXbeam_device):
+        exists: optional
+        doc: |
+          polarization filter to prepare light to be measured or to be incident 
+          on the sample.
+          Genereric polarization filter porperties may be implemented via NXfilter_pol
+          at a later stage.
+        filter_mechanism(NX_CHAR):
+          exists: optional
+          doc: |
+            Physical principle of the polarization filter used to create a
+            defined incident or scattered light state.
+          enumeration: [Polarization by Fresnel reflection, Birefringent polarizers, Thin film polarizers, Wire-grid polarizers, other]
+        specific_polarization_filter_type(NX_CHAR):
+          exists: optional
+          doc: |
+            Specific name or type of the polarizer used.
+            
+            Free text, for example: Glan-Thompson, Glan-Taylor, Rochon Prism, Wollaston
+            Polarizer...      
+        device_information(NXfabrication):
+      spectralfilter_TYPE(NXbeam_device):
+        exists: optional
+        doc: |
+          Spectral filter used to modify properties of the scattered or incident light.
+          Genereric spectral filter porperties may be implemented via NXfilter_spec
+          at a later stage.
+        filter_type:
+          exists: optional
+          doc: |
+            Type of laserline filter used to supress the laser, if measurements
+            close to the laserline are performed.
+          enumeration: [long-pass filter, short-pass filter, Notch filter, reflection filter, neutral density filter, other]
+        intended_use:
+          exists: optional
+          doc: |
+            Type of laserline filter used to supress the laser, if measurements
+            close to the laserline are performed.
+          enumeration: [laser line cleanup, raylight line removal, spectral filtering, intensity manipulation, other]
+        filter_characteristics(NXdata):
+          exists: optional
+          doc: |
+            Properties of the spectral filter such as wavelength dependent Transmission
+            or reflectivity.
+          \@characteristics_type:
+            exists: optional
+            doc: |
+              Which property is used to form the spectral properties of light,
+              i.e. transmission or reflection properties.
+            enumeration: [transmission, reflection]
+        device_information(NXfabrication):
+
+    
+    # In the following - Auxillary NXbeam_devices are defined, to enable a 
+    # beam path description of the setup, while using the up now available
+    # Nexus definitions for source, detector, monochromator, ... 
+
+      
+      
       # beam devices for beam path description
       (NXbeam_device):
         exists: [min, 0, max, infty]
@@ -644,6 +652,7 @@ NXopt(NXobject):
           doc: |
             If "other" was chosen in stage_type, enter here a free text description
             of the stage type.
+        # This is for now a placeholder and should be specified with NXtransformation
         reference_frame:
           exists: optional
           doc: |
@@ -677,9 +686,9 @@ NXopt(NXobject):
           exists: recommended
         physical_quantity:
           enumeration: [temperature]
-        cryo_or_heater:
+        cooler_or_heater:
           exists: recommended
-          enumeration: [cryostat, heater]
+          enumeration: [cooler, heater]
         type:
           exists: optional
           doc: |
@@ -688,30 +697,6 @@ NXopt(NXobject):
           setpoint(NX_FLOAT):
             exists: recommended
         device_information(NXfabrication):    
-      PARAMETER_SENSOR(NXsensor):
-        exists: recommended
-        name:
-          exists: recommended
-        measurement:
-        type:
-          exists: optional
-        value(NX_FLOAT):
-        device_information(NXfabrication):
-      PARAMETER_ACTUATOR(NXactuator):
-        doc: 
-          Control of arbitrary parameter - compare to temperature above.
-        exists: optional
-        name:
-          exists: recommended
-        physical_quantity:
-        type:
-          exists: optional
-          doc: |
-            Hardware used for actuation
-        (NXpid):
-          setpoint(NX_FLOAT):
-            exists: recommended
-        device_information(NXfabrication):
     (NXsample):
       doc: |
         Properties of the sample, such as sample type, layer structure,
@@ -725,7 +710,7 @@ NXopt(NXobject):
       sample_id:
         exists: recommended
         doc: |
-          Uniquely identifying name of the sample.
+          Uniquely identifying ID of the sample.
       physical_form:
         exists: recommended
         doc: |
@@ -736,9 +721,6 @@ NXopt(NXobject):
         exists: optional
         doc: |
           Free text description of the sample.
-      situation:
-        exists: recommended
-        enumeration: [air, vacuum, inert atmosphere, oxidising atmosphere, reducing atmosphere, sealed can, water, other]
       chemical_formula:
         exists: recommended
         doc: |
@@ -768,12 +750,6 @@ NXopt(NXobject):
         exists: recommended
         doc: |
           A set of activities that occurred to the sample prior to/during the experiment.
-        history_id(NXidentifier):
-          doc: |
-            A reference to the location or a unique (globally
-            persistent) identifier (e.g.) of e.g. another file which gives
-            as many as possible details of the material, its microstructure,
-            and its thermo-chemo-mechanical processing/preparation history.
       temperature(NXenvironment):
         exists: recommended
         doc: |
@@ -787,10 +763,10 @@ NXopt(NXobject):
           doc: |
             Device to heat the sample.
             This should be a link to /entry/instrument/manipulator/sample_heater.
-        cryostat(NXactuator):
+        sample_cooler(NXactuator):
           exists: optional
           doc: |
-            Cryostat for cooling the sample.
+            Device for cooling the sample (Cryostat, Airflow cooler, etc.).
             This should be a link to /entry/instrument/manipulator/cryostat.
       (NXenvironment):
         exists: optional
@@ -798,10 +774,9 @@ NXopt(NXobject):
           Arbirary sample property which may be varied during the experiment
           and controlled by a device. Examples are pressure, voltage, magnetic field etc.
           Similar to the temperautre description of the sample.
-        (NXsensor):
-          exists: optional
-        (NXactuator):
-          exists: optional
+        sample_medium:
+          exists: recommended
+          enumeration: [air, vacuum, inert atmosphere, oxidising atmosphere, reducing atmosphere, sealed can, water, other]
       thickness(NX_NUMBER):
         exists: optional
         doc: |

--- a/contributed_definitions/nyaml/NXopt.yaml
+++ b/contributed_definitions/nyaml/NXopt.yaml
@@ -1,15 +1,19 @@
 category: application
 doc: |
-  An application definition for optical spectroscopy experiments.
+  A general application definition of optical spectroscopy elements, which may 
+  be used as a template to derive specialized optical spectroscopy experiments.
+  
+  Possible specializations are ellipsometry, Raman spectroscopy, photoluminescence,
+  reflectivity/transmission spectroscopy.
+
+  A general optical experiment consists of (i) a light/photon source, (ii) a sample,
+  (iii) a detector.
 symbols:
   doc: |
     Variables used throughout the document, e.g. dimensions or parameters.
   N_spectrum: |
     Length of the spectrum array (e.g. wavelength or energy) of the measured
     data.
-  N_sensors: |
-    Number of sensors used to measure parameters that influence the sample,
-    such as temperature or pressure.
   N_measurements: |
     Number of measurements (1st dimension of measured_data array). This is
     equal to the number of parameters scanned. For example, if the experiment
@@ -20,30 +24,13 @@ symbols:
     sample.
   N_incident_angles: |
     Number of angles of incidence of the incident beam.
-  N_observables: |
-    Number of observables that are saved in a measurement. e.g. one for
-    intensity, reflectivity or transmittance, two for Psi and Delta etc. This
-    is equal to the second dimension of the data array 'measured_data' and the
-    number of column names.
 
-# 05/2023
-# Draft of a NeXus application definition which serves as a template for various
-# optical spectroscopy experiments
-
-# To do:
-# [ ] Check base classes (NXbeam_path + base classes used by it)
-# [ ] Harmonize NXopt and NXellipsometry
-# [ ] Fix dimensions and ranks
+# 04/2024
+# Extension of the Draft Version (05/2023) of a NeXus application definition which
+# serves as a template for various optical spectroscopy experiments
 type: group
 NXopt(NXobject):
   (NXentry):
-    doc: |
-      An application definition template for optical spectroscopy experiments.
-      
-      A general optical experiment consists of a light or excitation source, a
-      beam path, a sample + its stage + its environment, and a detection unit.
-      Examples are reflection or transmission measurements, photoluminescence,
-      Raman spectroscopy, ellipsometry etc.
     definition:
       doc: |
         An application definition describing a general optical experiment.
@@ -56,348 +43,675 @@ NXopt(NXobject):
           URL where to find further material (documentation, examples) relevant
           to the application definition.
       enumeration: [NXopt]
-    experiment_identifier:
+    title:
+    start_time(NX_DATE_TIME):
+      doc: |
+        Datetime of the start of the measurement.
+        Should be a ISO8601 date/time stamp. It is recommended to add an explicit time zone,
+        otherwise, the local time zone is assumed per ISO8601.
+    end_time(NX_DATE_TIME):
+      exists: recommended
+      doc: |
+        Datetime of the end of the measurement.
+        Should be a ISO8601 date/time stamp. It is recommended to add an explicit time zone,
+        otherwise the local time zone is assumed per ISO8601.
+    experiment_identifier(NXidentifier):
+      exists: recommended
       doc: |
         A (globally persistent) unique identifier of the experiment.
-        (i) The identifier is usually defined by the facility or principle
-        investigator.
+        (i) The identifier is usually defined by the facility, laboratory or
+        principal investigator.
         (ii) The identifier enables to link experiments to e.g. proposals.
+      service(NX_CHAR):
+      identifier(NX_CHAR):
+      is_persistent(NX_BOOLEAN):
     experiment_description:
       exists: optional
       doc: |
         An optional free-text description of the experiment.
         
-        However, details of the experiment should be defined in the specific
-        fields of this application definition rather than in this experiment
-        description.
+        Users are strongly advised to parameterize the description of their experiment
+        by using respective groups and fields and base classes instead of writing prose
+        into this field.
+
+        The reason is that such a free-text field is difficult to machine-interpret.
+        The motivation behind keeping this field for now is to learn how far the
+        current base classes need extension based on user feedback.
     experiment_type:
       doc: |
         Specify the type of the optical experiment.
-    start_time(NX_DATE_TIME):
+        
+        Chose other if non of these methods are suitable. You may specify
+        fundamental characteristics or properties in the experimental sub-type.
+      enumeration: [ellipsometry, Raman spectroscopy, photoluminescence, transmission spectroscopy, reflection spectroscopy, other]
+    experiment_sub_type:
       doc: |
-        Start time of the experiment. UTC offset should be specified.
+        Specify a special property or characteristic of the experiment, which specifies
+        the generic experiment type.
+      enumeration: [time resolved, imaging, pump-probe, other]
+    # Replace maybe sub_type with exp_technique?
+    #experimental technique --> pump-probe, parameters seperated (i.e. time, space)?
+    # The above listed things are related to beam properties? This is different
+    # compared to temperature or pressure. Is this a useful distinction?
+    experiment_type_other:
+      doc: |
+        If "other" was selected in "experiment_type", specify the experiment here
+        with a free text name, which is knwon in the respective community of interest.
     (NXuser):
+      exists: [min, 0, max, infty]
       doc: |
-        Contact information of at least the user of the instrument or the
-        investigator who performed this experiment.
-        Adding multiple users, if relevant, is recommended.
+        Contact information and eventually details of at persons who
+        performed the measurements. This can be for example the principal
+        investigator or student.
+        It is recommended to add multiple users if relevant.
+
+        Due to data privacy concerns, there is no minimum requirement.
       name(NX_CHAR):
+        exists: recommended
         doc: |
-          Name of the user.
+          Given (first) name and surname of the user.
       affiliation(NX_CHAR):
-        exists: recommended
+        exists: optional
         doc: |
-          Name of the affiliation of the user at the point in time when the
-          experiment was performed.
+          Name of the affiliation of the user at the point in time
+          when the experiment was performed.
       address(NX_CHAR):
-        exists: recommended
+        exists: optional
         doc: |
-          Street address of the user's affiliation.
+          Postal address of the user's affiliation.
       email(NX_CHAR):
+        exists: optional
         doc: |
-          Email address of the user.
+          Email address of the user at the point in time when the experiment
+          was performed. Writing the most permanently used email is recommended.
       orcid(NX_CHAR):
         exists: recommended
         doc: |
           Author ID defined by https://orcid.org/.
       telephone_number(NX_CHAR):
+        exists: optional
+        doc: |
+          (Business) (tele)phone number of the user at the point
+          in time when the experiment was performed.
+      role(NX_CHAR):
+        exists: optional
+        doc: |
+          Which role does the user have in the place and at the point
+          in time when the experiment was performed? Technician operating
+          the setup, student, PhD-student, postdoc, principle investigator, or guest
+          are common examples.
+      identifier(NXidentifier):
         exists: recommended
         doc: |
-          Telephone number of the user.
+          Service as another mean of identification of a user other than by its name.
+          Examples could be an ORCID or social media account of the user.
+        service(NX_CHAR):
+        identifier(NX_CHAR):
+        is_persistent(NX_BOOLEAN):
     (NXinstrument):
       doc: |
-        Properties of the experimental setup. This includes general information
-        about the instrument (such as model, company etc.), information about
-        the calibration of the instrument, elements of the beam path including
-        the excitation or light source and the detector unit, the sample stage
-        (plus the sample environment, which also includes sensors used to
-        monitor external conditions) and elements of the beam path.
+        Devices or elements of the optical spectroscopy setup described with its
+        properties and general information.
         
-        Meta data describing the sample should be specified in ENTRY/SAMPLE
-        outside of ENTRY/INSTRUMENT.
-      model:
+        This includes for example:
+        - The beam device's or instrument's model, company, serial number, construction year, etc.
+        - Used software or code
+        - Experiment descriptive parameters as reference frames, resolution, calibration
+        - Photon beams with their respective properties such as angles and polarization
+        - Various optical beam path devices, which interact, manipulate or measure optical beams
+        - Characteristics of the medium surrounding the sample
+        - "Beam devices" for a beam path description
+        - Stages(NXmanipulator)
+        - Sensors and actuators to control or measure sample or beam properties
+      device_information(NXfabrication):
         doc: |
-          The name of the instrument.
-        \@version:
+          General device information of the optical spectroscopy setup, if
+          suitable (e.g. for a tabletop spectrometer or other non-custom build setups).
+          For custom build setups, this may be limited to the construction year.
+        exists: recommended
+        vendor:
+          exists: recommended
+        model:
+          exists: recommended
+        identifier:
+          exists: recommended
+        construction_year(NX_DATE_TIME):
+          exists: recommended
           doc: |
-            The used version of the hardware if available. If not a commercial
-            instrument use date of completion of the hardware.
-      company:
-        exists: optional
-        doc: |
-          Name of the company which build the instrument.
-      construction_year(NX_DATE_TIME):
-        exists: optional
-        doc: |
-          ISO8601 date when the instrument was constructed.
-          UTC offset should be specified.
-      software(NXprocess):
+            Datetime of setup's initial construction. This refers to the date of
+            first measurement after new construction  or relocation of the setup.
+            Should be a ISO8601 date/time stamp. It is recommended to add an explicit time zone,
+            otherwise the local time zone is assumed per ISO8601.
+      software_TYPE(NXprogram):
+        exists: recommended
         program:
           doc: |
             Commercial or otherwise defined given name of the program that was
-            used to measure the data, i.e. the software used to start and
-            record the measured data and/or metadata.
-            If home written, one can provide the actual steps in the NOTE
-            subfield here.
-        version:
+            used to control any parts of the optical spectroscopy setup.
+            The uppercase TYPE should be replaced by a specification name, i.e.
+            "software_detector" or "software_stage" to specify the respective
+            program or software components.
+          \@version:
+            doc: |
+              Either version with build number, commit hash, or description of a
+              (online) repository where the source code of the program and build
+              instructions can be found so that the program can be configured in
+              such a way that result files can be created ideally in a
+              deterministic manner.
+          \@url:
+            exists: optional
+            doc: |
+              Description of the software by persistent resource, where the program,
+              code, script etc. can be found.
+      # general properties and reference frames
+      reference_frames(NXcoordinate_system_set):
+        # This should be extended later and hopefully replace angle_reference_frame
+        # and sample_normal_direction.
+        # Required reference frames:
+        # Sample normal, beam_z_axis, sample_stage
+        exists: optional
+        doc: |
+          Description of one or more coordinate systems that are specific to the
+          experiment.
+      angle_reference_frame:
+        doc: |
+          Defines the reference frame which is used to describe the sample orientation
+          with respect to the beam directions.
+
+          A beam centered description is the default and uses 4 angles(similar to XRD):
+            - Omega (angle between sample surface and incident beam)
+            - 2Theta (angle between the transmitted beam and the detection beam)
+            - Chi (sample tilt angle, angle between plane#1 and the surface normal,
+                  plane#1 = spanned by incidence beam and detection
+                  and detection. If Chi=0°, then plane#1 is the plane of
+                  incidence in reflection setups)
+            - Phi (inplane rotation of sample, rotation axis is the samples 
+                  surface normal)
+
+
+          A sample normal centered description is as well possible(similar to XX):
+            - angle of incidence (angle between incident beam and sample surface)
+            - angle of detection (angle between detection beam and sample surface)
+            - angle of incident and detection beam (angle between the incident and scattering beam)
+            - angle of in-plane sample rotation (direction along the sample's surface normal)
+       
+        # For the sample centered approach, it has to be avoided, that the detection beam,
+        # incident beam or surface normal beam are parallel to each other
+        # (Is this a problem for Raman backscattering?)
+        # For beam centered approach (as done for beamlines), the grativation and beam direction are used to define
+        # the coordinate system. As beamlines are usually built flat - there is no case
+        # in which these two vectors can be parallel to each other
+        # This is different with the surface normal. Aside of the surface normal,
+        # at least one further additional natural direction is required.
+        # This could be the magnetic/geographic north pole
+        # magnetic north pole: easy to determine, but time depenent (long term)
+        # geographic north pole: harder to determine? (What about GPS?), but constant with time
+        
+        enumeration: [beam centered, sample normal centered]
+      wavelength_resolution(NXresolution):
+        exists: optional
+        doc: |
+          The overall resolution of the optical instrument.
+        physical_quantity:
+          enumeration: [wavelength]
+        type:
+          exists: recommended
+        resolution(NX_FLOAT):
+          unit: NX_WAVELENGTH
           doc: |
-            Either version with build number, commit hash, or description of a
-            (online) repository where the source code of the program and build
-            instructions can be found so that the program can be configured in
-            such a way that result files can be created ideally in a
-            deterministic manner.
-        \@url:
-          exists: optional
-          doc: |
-            Website of the software.
-      firmware(NXprogram):
+            Minimum distinguishable wavelength separation of peaks in spectra.
+      instrument_calibration_DEVICE(NXsubentry):
         exists: recommended
         doc: |
-          Commercial or otherwise defined name of the firmware that was used
-          for the measurement - if available.
-        \@version:
+          Pre-calibration of an arbitrary device of the instrumental setup, which
+          has the name DEVICE. You can specify here at which point
+        device_path:
+          exists: recommended
           doc: |
-            Version and build number or commit hash of the software source code.
-        \@url:
+            Path to the device, which was calibrated.
+            Example: entry/instrument/DEVICE
+        calibration_method:
+          exists: optional
+          doc: 
+            Describe here the approach or method, used to perform the calibration,
+            by a free text.
+        calibration_accuracy(NXdata):
           exists: optional
           doc: |
-            Website of the software.
-      calibration_status(NX_CHAR):
-        doc: |
-          Was a calibration performed? If yes, when was it done? If the
-          calibration time is provided, it should be specified in
-          ENTRY/INSTRUMENT/calibration/calibration_time.
-        enumeration: [calibration time provided, no calibration, within 1 hour, within 1 day, within 1 week]
-      calibration(NXsubentry):
-        exists: recommended
-        doc: |
-          The calibration data and metadata should be described in a separate NeXus file
-          with the link provided in 'calibration_link'.
+            Provide data about the determined accuracy of the device, this may
+            may be a single value or a dataset like wavelength error vs. wavelength etc.
+        calibration_status(NX_CHAR):
+          exists: recommended
+          doc: |
+            Was a calibration performed? If yes, when was it done? If the
+            calibration time is provided, it should be specified in
+            ENTRY/INSTRUMENT/calibration/calibration_time.
+          enumeration: [calibration time provided, no calibration, within 1 hour, within 1 day, within 1 week]
         calibration_time(NX_DATE_TIME):
           exists: optional
           doc: |
             If calibtration status is 'calibration time provided', specify the
             ISO8601 date when calibration was last performed before this
             measurement. UTC offset should be specified.
-        calibration_data_link:
+        calibration_data_link(NXidentifier):
+          exists: recommended
           doc: |
             Link to the NeXus file containing the calibration data and metadata.
-      (NXbeam_path):
+      # Discussion
+      # ##########
+      # The basic idea was: You have always an incident source and a detector.
+      # Therefore, you always have an incident beam and a "detection beam".
+      # These beams can be assigned clear incident and detection angles.
+      #
+      # This information is always of relevance for ellipsometry,
+      # but for Raman experiments, the state of polarization is as well of relevance
+      # Additonally, this is limited for incident, detection and sample normal
+      # to be in one plane. This does not have to be the case for Raman scattering
+      # experiments. Therefore, this is not general enough and may be moved to
+      # NXellipsometry. 
+      # This information may be as well stored in an incident and detection beam
+
+      # beam properties
+      beam_TYPE(NXbeam):
+        exists: [min, 0, max, infty]
         doc: |
-          Describes an arrangement of optical or other elements, e.g. the beam
-          path between the light source and the sample, or between the sample
-          and the detector unit (including the sources and detectors
-          themselves).
-          
-          If a beam splitter (i.e. a device that splits the incoming beam into
-          two or more beams) is part of the beam path, two or more NXbeam_path
-          fields may be needed to fully describe the beam paths and the correct
-          sequence of the beam path elements.
-          Use as many beam paths as needed to describe the setup.
+          Beam characteristics between two beam_devices.
+
+          It is recommended, to at least define one incident and one detection beam.
+          If this beam is directly connected to an source, chose here the same
+          name appendix as for the NXsource (e.g. TYPE=532nm)
+        incident_wavelength(NX_FLOAT):
+          unit: NX_WAVELENGTH
+        incident_wavelength_spread(NX_NUMBER):
+          exists: recommended
+          unit: NX_WAVELENGTH
+        incident_polarization(NX_NUMBER):
+          exists: recommended
+          unit: NX_ANY
+        extent(NX_FLOAT):
+          exists: recommended
+        associated_source(NX_CHAR):
+          exists: recommended
+          doc: |
+            The path to a the source, which emitted this beam.
+            Should be named with the same appendix as the source, e.g.,
+            for TYPE=532nmlaser, there should as well be
+            a NXsource named "source_532nmlaser" aside of this Beam
+            instance named "beam_532nmlaser"
+            
+            Example: /entry/instrument/source_532nmlaser
+        # The two polarization descriptions may be completely replaced by
+        # incident_polarization
+        beam_polarization_type:
+          exists: optional
+          enumeration: [linear, circular, ellipically, unpolarized]
+        linear_beam_sample_polarization(NX_NUMBER):
+          exists: optional
+          doc: |
+            Description of the light polarization of the respective beam and the beam-sample-normal.
+            This is only well defined, if the beam direclty hits the sample (either indicent
+            beam or detection beam) and if the samples needs to have a clearly
+            defined sample surface. The beam-sample-normal plane is spanned by
+            the beam and the samples surface normal.
+
+            If the electric field in in this plane, this value is 0° (P-pol)
+            If the electric field is perpendicular to this plane, this value is 90° (S-pol)
+            If the surface normal is parallel to the beam direction, then only the
+            relation between different polarizations has to be consistent 
+            (i.e. parallel polarized 0° and cross polarized 90°)
+          unit: NX_ANGLE
+      # Discussion with florian:
+      # The user wants to use simple parameters, which they are used to.
+      # Though, via NXtransformations in principle maximum flexibility can be provided,
+      # even for unusual and complex experimental setups.
+      # The solution from mpes was: simple "front end" by only stating one angle
+      # with the "backend" to be customizable via NXtransformations.
+      #
+      # fundamental orientation of incident and detection beam
       angle_of_incidence(NX_NUMBER):
+      # relation beam directions (incident and detection) with sample orientation
+      # these angles are quite simple. They might be extended similar to
+      # NXmpes_liquid with leaf_normal to allow arbitrary description.
+      # this might require a different reference frame.
+        exists: optional
         unit: NX_ANGLE
         doc: |
           Angle(s) of the incident beam vs. the normal of the bottom reflective
-          (substrate) surface in the sample.
+          (substrate) surface in the sample. These two directions span the plane
+          of incidence.
         dimensions:
           rank: 1
           dim: [[1, N_incident_angles]]
         \@units:
-      detection_angle(NX_NUMBER):
+      angle_of_detection(NX_NUMBER):
         exists: optional
         unit: NX_ANGLE
         doc: |
           Detection angle(s) of the beam reflected or scattered off the sample
           vs. the normal of the bottom reflective (substrate) surface in the
           sample if not equal to the angle(s) of incidence.
+          These two directions span the plane of detection.
         dimensions:
           rank: 1
           dim: [[1, N_detection_angles]]
-      sample_stage(NXsubentry):
+      angle_of_incident_and_detection_beam(NX_NUMBER):
+        exists: optional
+        unit: NX_ANGLE
         doc: |
-          Sample stage, holding the sample at a specific position in X,Y,Z
-          (Cartesian) coordinate system and at an orientation defined
-          by three Euler angles (alpha, beta, gamma).
+          Angle between the incident and detection beam.
+          If angle_of_detection + angle_of_incidence = angle_of_incident_and_detection_beam,
+          then the setup is a reflection setup.
+          If angle_of_detection + angle_of_incidence != angle_of_incident_and_detection_beam
+          then the setup may be a light scattering setup.
+          (i.e. 90° + 90° != 90°, i.e. incident and detection beam in the sample surface, but
+          the angle source-sample-detector is 90°)
+
+        dimensions:
+          rank: 1
+          dim: [[1, XX]]
+        \@units:
+      angle_of_in_plane_sample_rotation(NX_NUMBER):
+        exists: optional
+        unit: NX_ANGLE
+        doc: |
+          Angle of the inplane orientation of the sample. This might be an arbitrary,
+          angle without specific relation to the sample symmetry,
+          of the angle to a specific sample property (i.e. crystallographic axis or sample
+          shape such as wafer flat)
+        dimensions:
+          rank: 1
+          dim: [[1, XX]]
+      lateral_focal_point_offset(NX_NUMBER):
+        exists: optional
+        unit: NX_LENGTH
+        doc: |
+          Specify if there is a lateral offset on the sample surface, between the focal 
+          points of the incident beam and the detection beam.
+      # beam path elements
+      source_TYPE(NXsource):
+        exists: [min, 1, max, infty]
+        type:
+          exists: recommended
+          enumeration: [laser, dye-laser, broadband tunable light source, X-ray Source, other]
+        type_other:
+          exists: optional
+          doc: |
+            Specification of type, may also go to name.
+        name:
+          exists: recommended
+        source_polarization:
+          exists: recommended
+          doc: |
+            The type of light polarization produced by the source.
+          enumeration: [linear, unpolarized, circular, elliptically, other]
+        device_information(NXfabrication):
+          doc: |
+            Details about the device information.
+        associated_beam(NX_CHAR):
+          doc: |
+            The path to a beam emitted by this source.
+            Should be named with the same appendix, e.g.,
+            for TYPE=532nmlaser, there should as well be
+            a NXbeam named "beam_532nmlaser" aside of this source
+            instance named "source_532nmlaser"
+            
+            Example: /entry/instrument/beam_532nmlaser
+        device_characteristics(NXdata):
+      detector_TYPE(NXdetector):
+        exists: [min, 1, max, infty]
+        detector_channel_type:
+          exists: recommended
+          enumeration: [single-channel, multichannel]
+        detector_type:
+          exists: recommended
+          doc: |
+            Description of the detector type.
+          enumeration: [CCD, Photomultiplier, Photodiode, Avalanche-Photodiode, Bolometer, Golay Detectors, Pyroelectric Detector]
+        device_characteristics(NXdata):
+        device_information(NXfabrication):
+          exists: recommended
+          vendor:
+            exists: recommended
+          model:
+            exists: recommended
+          identifier:
+            exists: recommended
+        raw_data(NXdata):
+          exists: recommended
+          doc: |
+            Contains the raw data collected by the detector before calibration.
+            The data which is considered raw might change from experiment to experiment
+            due to hardware pre-processing of the data.
+            This field ideally collects the data with the lowest level of processing
+            possible.
+
+          # Define a similar convention for NXopt? Or only for NXraman, NXellipsometry and NXphotoluminescence?  
+          #  Fields should be named according to new following convention:
+          #  
+          #  - **pixel_x**: Detector pixel in x direction.
+          #  - **pixel_y**: Detector pixel in y direction.
+          #  - **energy**: (Un)calibrated energy (kinetic or binding energy). Unit category: NX_ENERGY (e.g., eV).
+          #  - **kx**: (Un)calibrated x axis in k-space. Unit category: NX_ANY (e.g., 1/Angström).
+          #  - **ky**: (Un)calibrated y axis in k-space. Unit category: NX_ANY (1/Angström).
+          #  - **kz**: (Un)calibrated z axis in k-space. Unit category: NX_ANY (1/Angström).
+          #  - **angular0**: Fast-axis angular coordinate (or second slow axis if angularly integrated).
+          #    Unit category: NX_ANGLE
+          #  - **angular1**: Slow-axis angular coordinate (or second fast axis if simultaneously dispersed in 2 dimensions)
+          #    Unit category: NX_ANGLE
+          #  - **spatial0**: Fast-axis spatial coordinate (or second slow axis if spatially integrated)
+          #    Unit category: NX_LENGTH
+          #  - **spatial1**: Slow-axis spatial coordinate (or second fast axis if simultaneously dispersed in 2 dimensions)
+          #    Unit category: NX_LENGTH
+          #  - **delay**: Calibrated delay time. Unit category: NX_TIME (s).
+          #  - **polarization_angle**: Linear polarization angle of the incoming or
+          #    outgoing beam.
+          #    Unit category: NX_ANGLE (° or rad)
+          #  - **ellipticity**: Ellipticity of the incoming or outgoing beam.
+          #    Unit category: NX_ANGLE (° or rad)
+          #  - **time_of_flight**: Total time of flight. Unit category: NX_TIME_OF_FLIGHT
+          #  - **time_of_flight_adc**: Time-of-flight values, analog-to-digital converted.
+          #  - **external_AXIS**: Describes an axis which is coming from outside the detectors scope.
+          \@signal:
+            enumeration: [raw]
+          raw(NX_NUMBER):
+            doc: |
+              Raw data before calibration.
+      (NXmonochromator):
+        exists: optional
+        device_characteristics(NXdata):
+      (NXlens_opt):
+        exists: optional
+        device_characteristics(NXdata):
+      (NXwaveplate):
+        exists: optional
+        device_characteristics(NXdata):
+      WINDOW(NXaperture):
+        exists: optional
+        doc: |
+          For environmental measurements, the environment (liquid, vapor
+          etc.) is enclosed in a cell, which has windows both in the
+          direction of the source (entry window) and the detector (exit
+          window) (looking from the sample). In case that the entry and exit
+          windows are not the same type and do not have the same properties,
+          use a second 'WINDOW(MXaperture)' field.
+          
+          The windows also add a phase shift to the light altering the
+          measured signal. This shift has to be corrected based on measuring
+          a known sample (reference sample) or the actual sample of interest
+          in the environmental cell. State if a window correction has been
+          performed in 'window_effects_corrected'. Reference data should be
+          considered as a separate experiment, and a link to the NeXus file
+          should be added in reference_data_link in measured_data.
+          
+          The window is considered to be a part of the sample stage but also
+          beam path. Hence, its position within the beam path should be
+          defined by the 'depends_on' field.
+        window_effects_corrected(NX_BOOLEAN):
+          doc: |
+            Was a window correction performed? If 'True' describe the window
+            correction procedure in 'window_correction/procedure'.
+        window_correction(NXprocess):
+          exists: optional
+          doc: |
+            Was a window correction performed? If 'True' describe the
+            window correction procedure in ''
+          procedure:
+            doc: |
+              Describe when (before or after the main measurement + time
+              stamp in 'date') and how the window effects have been
+              corrected, i.e. either mathematically or by performing a
+              reference measurement. In the latter case, provide the link to
+              to the reference data in 'reference_data_link'.
+          reference_data_link:
+            exists: optional
+            doc: |
+              Link to the NeXus file which describes the reference data if a
+              reference measurement for window correction was performed.
+              Ideally, the reference measurement was performed on a reference
+              sample and on the same sample, and using the same conditions as
+              for the actual measurement with and without windows. It should
+              have been conducted as close in time to the actual measurement
+              as possible.
+        material(NX_CHAR):
+          doc: |
+            The material of the window.
+          enumeration: [quartz, diamond, calcium fluoride, zinc selenide, thallium bromoiodide, alkali halide compound, Mylar, other]
+        material_other(NX_CHAR):
+          exists: optional
+          doc: |
+            If you specified 'other' as material, decsribe here what it is.
+        thickness(NX_FLOAT):
+          unit: NX_LENGTH
+          doc: |
+            Thickness of the window.
+        orientation_angle(NX_FLOAT):
+          unit: NX_ANGLE
+          doc: |
+            Angle of the window normal (outer) vs. the substrate normal
+            (similar to the angle of incidence).
+      sample_medium_refractive_indices(NX_FLOAT):
+        exists: optional
+        unit: NX_UNITLESS
+        doc: |
+          Array of pairs of complex refractive indices n + ik of the medium
+          for every measured spectral point/wavelength/energy.
+          Only necessary if the measurement was performed not in air, or
+          something very well known, e.g. high purity water.
+        dimensions:
+          rank: 2
+          dim: [[1, 2], [2, N_spectrum]]
+      # beam devices for beam path description
+      (NXbeam_device):
+        exists: [min, 0, max, infty]
+        doc: |
+          Describes the order of respective beam devices in the optical beam
+          path.
+          
+          Everything object which interacts or modifies optical beam properties,
+          may be an beam device, e.g. Filter, Window, Beamsplitter, Photon Source,
+          Detector, etc,
+
+          It is intended, to include this functionality later to "older" beam
+          components, such as NXsource, NXdetector, NXlens, etc.
+          Until this is possbible, auxillary beam devices have to be created,
+          for each "older" beam component instead, to allow a beam path description.
+          To link the auxillary beam device to the real device properties, the
+          attribute \@device should be used.
+        \@device:
+          exists: recommended
+          doc: |
+            Reference to beam device, which is described by a NeXus concept
+            (e.g. for NXsource, entry/instrument/source_TYPE).
+        previous_device:
+          exists: recommended
+          doc: |
+            Reference to the previous beam device, from which the photon beam came
+            to reach this beam device. A photon source is related as origin by ".".
+            This enables a logical order description of the optical setup.
+      # non-beam path elements
+      sample_stage(NXmanipulator):
+        exists: optional
+        doc: |
+          Sample stage (or manipulator) for positioning of the sample. This should
+          only contain the spatial orientation of movement. 
         stage_type:
+          exists: optional
           doc: |
             Specify the type of the sample stage.
-          enumeration: [manual stage, scanning stage, liquid stage, gas cell, cryostat]
-        alternative:
+          enumeration: [manual stage, scanning stage, liquid stage, gas cell, cryostat, heater, other]
+        stage_type_other:
           exists: optional
           doc: |
-            If there is no motorized stage, we should at least qualify where
-            the beam hits the sample and in what direction the sample stands
-            in a free-text description, e.g. 'center of sample, long edge
-            parallel to the plane of incidence'.
-        environment_conditions(NXenvironment):
-          doc: |
-            Specify external parameters that have influenced the sample, such
-            as the surrounding medium, and varied parameters e.g. temperature,
-            pressure, pH value, optical excitation etc.
-          medium:
-            doc: |
-              Describe what was the medium above or around the sample. The
-              common model is built up from the substrate to the medium on the
-              other side. Both boundaries are assumed infinite in the model.
-              Here, define the name of the medium (e.g. water, air, UHV, etc.).
-          medium_refractive_indices(NX_FLOAT):
-            exists: optional
-            unit: NX_UNITLESS
-            doc: |
-              Array of pairs of complex refractive indices n + ik of the medium
-              for every measured spectral point/wavelength/energy.
-              Only necessary if the measurement was performed not in air, or
-              something very well known, e.g. high purity water.
-            dimensions:
-              rank: 2
-              dim: [[1, 2], [2, N_spectrum]]
-          PARAMETER(NXsensor):
-            exists: optional
-            doc: |
-              A sensor used to monitor an external condition influencing the
-              sample, such as temperature or pressure. It is suggested to
-              replace 'PARAMETER' by the type of the varied parameter defined
-              in 'parameter_type'.
-              The measured parameter values should be provided in 'values'.
-              For each parameter, a 'PARAMETER(NXsensor)' field needs to exist.
-              In other words, there are N_sensors 'PARAMETER(NXsensor)' fields.
-            parameter_type:
-              doc: |
-                Indicates which parameter was changed. Its definition must exist
-                below. The specified variable has to be N_measurements long,
-                providing the parameters for each data set. If you vary more than
-                one parameter simultaneously.
-                If the measured parameter is not contained in the list `other`
-                should be specified and the `parameter_type_name` should be provided.
-              enumeration: [conductivity, detection_angle, electric_field, flow, incident_angle, magnetic_field, optical_excitation, pH, pressure, resistance, shear, stage_positions, strain, stress, surface_pressure, temperature, voltage, other]
-            parameter_type_name:
-              exists: optional
-              doc: |
-                If the parameter_type is `other` a name should be specified here.
-            number_of_parameters(NX_POSINT):
-              unit: NX_UNITLESS
-              doc: |
-                Number of different parameter values at which the measurement
-                was performed. For example, if the measurement was performed at
-                temperatures of 4, 77 and 300 K, then number_of_parameters = 3.
-            values(NX_FLOAT):
-              unit: NX_ANY
-              doc: |
-                Vector containing the values of the varied parameter. Its
-                length is equal to N_measurements. The order of the values
-                should be as follows:
-                
-                * Order the sensors according to number_of_parameters starting
-                  with the lowest number. If number_of_parameters is equal for
-                  two sensors order them alphabetically (sensor/parameter name).
-                * The first sensor's j parameters should be ordered in the
-                  following way. The first N_measurements/number_of_parameters
-                  entries of the vector contain the first parameter (a1), the
-                  second N_measurements/number_of_parameters contain the second
-                  parameter (a2) etc., so the vector looks like:
-                  [
-                  a1,a1,...,a1,
-                  a2,a2,...,a2,
-                  ...
-                  aj,aj,...aj
-                  ]
-                * The kth sensor's m parameters should be ordered in the
-                  following way:
-                  [
-                  p1,...p1,p2,...,p2,...pm,...,pm,
-                  p1,...p1,p2,...,p2,...pm,...,pm,
-                  ...
-                  p1,...p1,p2,...,p2,...pm,...,pm
-                  ]
-                * The last sensor's n parameters should be ordered in the
-                  following way:
-                  [
-                  z1,z2,...,zn,
-                  z1,z2,...,zn,
-                  ...
-                  z1,z2,...,zn]
-                
-                For example, if the experiment was performed at three different
-                temperatures (T1, T2, T3), two different pressures (p1, p2) and
-                two different angles of incidence (a1, a2), then
-                N_measurements = 12 and the order of the values for the various
-                parameter vectors is:
-                
-                * angle_of_incidence: [a1,a1,a1,a1,a1,a1,a2,a2,a2,a2,a2,a2]
-                * pressure: [p1,p1,p1,p2,p2,p2,p1,p1,p1,p2,p2,p2]
-                * temperature: [T1,T2,T3,T1,T2,T3,T1,T2,T3,T1,T2,T3]
-              dimensions:
-                rank: 1
-                dim: [[1, N_measurements]]
-        WINDOW(NXaperture):
+            If "other" was chosen in stage_type, enter here a free text description
+            of the stage type.
+        reference_frame:
           exists: optional
           doc: |
-            For environmental measurements, the environment (liquid, vapor
-            etc.) is enclosed in a cell, which has windows both in the
-            direction of the source (entry window) and the detector (exit
-            window) (looking from the sample). In case that the entry and exit
-            windows are not the same type and do not have the same properties,
-            use a second 'WINDOW(MXaperture)' field.
-            
-            The windows also add a phase shift to the light altering the
-            measured signal. This shift has to be corrected based on measuring
-            a known sample (reference sample) or the actual sample of interest
-            in the environmental cell. State if a window correction has been
-            performed in 'window_effects_corrected'. Reference data should be
-            considered as a separate experiment, and a link to the NeXus file
-            should be added in reference_data_link in measured_data.
-            
-            The window is considered to be a part of the sample stage but also
-            beam path. Hence, its position within the beam path should be
-            defined by the 'depends_on' field.
-          depends_on:
+            This is a placeholder, to describe the relation between the samples
+            coordinate system, laboratory coordinate system and the stage coordinate
+            system. Up to now, use the "beam_sample_relation" to give supporting
+            information.
+        beam_sample_relation:
+          exists: optional
+          doc: |
+            Description of relation of the beam with the sample. How dit the
+            sample hit the beam, e.g. 'center of sample, long edge parallel
+            to the plane of incidence'.
+        device_information(NXfabrication):
+      temperature_sensor(NXsensor):
+        exists: recommended
+        name:
+          exists: recommended
+        measurement:
+          enumeration: [temperature]
+        type:
+          exists: optional
+        value(NX_FLOAT):
+        device_information(NXfabrication):
+      temp_control_TYPE(NXactuator):
+        doc: 
+          Type of control for the sample temperature. Replace TYPE by 
+          "cryostat" or "heater" to specify it. 
+        exists: optional
+        name:
+          exists: recommended
+        physical_quantity:
+          enumeration: [temperature]
+        cryo_or_heater:
+          exists: recommended
+          enumeration: [cryostat, heater]
+        type:
+          exists: optional
+          doc: |
+            Hardware used for actuation, i.e. laser, gas lamp, filament, resistive
+        (NXpid):
+          setpoint(NX_FLOAT):
             exists: recommended
-            doc: |
-              Specify the position of the window in the beam path by pointing
-              to the preceding element in the sequence of beam path elements.
-          window_effects_corrected(NX_BOOLEAN):
-            doc: |
-              Was a window correction performed? If 'True' describe the window
-              correction procedure in 'window_correction/procedure'.
-          window_correction(NXprocess):
-            exists: optional
-            doc: |
-              Was a window correction performed? If 'True' describe the
-              window correction procedure in ''
-            procedure:
-              doc: |
-                Describe when (before or after the main measurement + time
-                stamp in 'date') and how the window effects have been
-                corrected, i.e. either mathematically or by performing a
-                reference measurement. In the latter case, provide the link to
-                to the reference data in 'reference_data_link'.
-            reference_data_link:
-              exists: optional
-              doc: |
-                Link to the NeXus file which describes the reference data if a
-                reference measurement for window correction was performed.
-                Ideally, the reference measurement was performed on a reference
-                sample and on the same sample, and using the same conditions as
-                for the actual measurement with and without windows. It should
-                have been conducted as close in time to the actual measurement
-                as possible.
-          material(NX_CHAR):
-            doc: |
-              The material of the window.
-            enumeration: [quartz, diamond, calcium fluoride, zinc selenide, thallium bromoiodide, alkali halide compound, Mylar, other]
-          other_material(NX_CHAR):
-            exists: optional
-            doc: |
-              If you specified 'other' as material, decsribe here what it is.
-          thickness(NX_FLOAT):
-            unit: NX_LENGTH
-            doc: |
-              Thickness of the window.
-          orientation_angle(NX_FLOAT):
-            unit: NX_ANGLE
-            doc: |
-              Angle of the window normal (outer) vs. the substrate normal
-              (similar to the angle of incidence).
+        device_information(NXfabrication):    
+      PARAMETER_SENSOR(NXsensor):
+        exists: recommended
+        name:
+          exists: recommended
+        measurement:
+        type:
+          exists: optional
+        value(NX_FLOAT):
+        device_information(NXfabrication):
+      PARAMETER_ACTUATOR(NXactuator):
+        doc: 
+          Control of arbitrary parameter - compare to temperature above.
+        exists: optional
+        name:
+          exists: recommended
+        physical_quantity:
+        type:
+          exists: optional
+          doc: |
+            Hardware used for actuation
+        (NXpid):
+          setpoint(NX_FLOAT):
+            exists: recommended
+        device_information(NXfabrication):
     (NXsample):
       doc: |
         Properties of the sample, such as sample type, layer structure,
@@ -406,18 +720,27 @@ NXopt(NXobject):
         described in ENTRY/INSTRUMENT/sample_stage.
       sample_name:
         doc: |
-          Descriptive name of the sample
-      sample_type:
+          Name of the sample, which is uaually pleases human readability.
+          This may be, but does not have to be identical to the sample_id.
+      sample_id:
+        exists: recommended
         doc: |
-          Specify the type of sample, e.g. thin film, single crystal etc.
-        enumeration: [thin film, single crystal, poly crystal, single layer, multi layer]
-      layer_structure:
+          Uniquely identifying name of the sample.
+      physical_form:
+        exists: recommended
         doc: |
-          Qualitative description of the layer structure for the sample,
-          starting with the top layer (i.e. the one on the front surface, on
-          which the light incident), e.g. native oxide/bulk substrate, or
-          Si/native oxide/thermal oxide/polymer/peptide.
+          State the form of the sample, examples are:
+          thin film, single crystal, poly crystal, amorphous, single layer,
+          multi layer, liquid, gas, pellet, powder.
+      description:
+        exists: optional
+        doc: |
+          Free text description of the sample.
+      situation:
+        exists: recommended
+        enumeration: [air, vacuum, inert atmosphere, oxidising atmosphere, reducing atmosphere, sealed can, water, other]
       chemical_formula:
+        exists: recommended
         doc: |
           Chemical formula of the sample. Use the Hill system (explained here:
           https://en.wikipedia.org/wiki/Chemical_formula#Hill_system) to write
@@ -427,152 +750,119 @@ NXopt(NXobject):
           layer (the one on the front surface, on which the light incident).
           The order must be consistent with layer_structure
       atom_types:
+        exists: optional
         doc: |
           List of comma-separated elements from the periodic table that are
           contained in the sample. If the sample substance has multiple
           components, all elements from each component must be included in
           'atom_types'.
-      sample_history:
-        doc: |
-          Ideally, a reference to the location or a unique (globally
-          persistent) identifier (e.g.) of e.g. another file which gives
-          as many as possible details of the material, its microstructure,
-          and its thermo-chemo-mechanical processing/preparation history.
-          In the case that such a detailed history of the sample is not
-          available, use this field as a free-text description to specify
-          details of the sample and its preparation.
       preparation_date(NX_DATE_TIME):
         exists: recommended
         doc: |
-          ISO8601 date with time zone (UTC offset) specified.
-      substrate:
+          ISO 8601 time code with local time zone offset to UTC information
+          when the specimen was prepared.
+          
+          Ideally, report the end of the preparation, i.e. the last known timestamp when
+          the measured specimen surface was actively prepared.
+      history(NXhistory):
         exists: recommended
         doc: |
-          Description of the substrate.
+          A set of activities that occurred to the sample prior to/during the experiment.
+        history_id(NXidentifier):
+          doc: |
+            A reference to the location or a unique (globally
+            persistent) identifier (e.g.) of e.g. another file which gives
+            as many as possible details of the material, its microstructure,
+            and its thermo-chemo-mechanical processing/preparation history.
+      temperature(NXenvironment):
+        exists: recommended
+        doc: |
+          Sample temperature (either controlled or just measured).
+        temperature_sensor(NXsensor):
+          doc: |
+            Temperature sensor measuring the sample temperature.
+            This should be a link to /entry/instrument/manipulator/temperature_sensor.
+        sample_heater(NXactuator):
+          exists: optional
+          doc: |
+            Device to heat the sample.
+            This should be a link to /entry/instrument/manipulator/sample_heater.
+        cryostat(NXactuator):
+          exists: optional
+          doc: |
+            Cryostat for cooling the sample.
+            This should be a link to /entry/instrument/manipulator/cryostat.
+      (NXenvironment):
+        exists: optional
+        doc: |
+          Arbirary sample property which may be varied during the experiment
+          and controlled by a device. Examples are pressure, voltage, magnetic field etc.
+          Similar to the temperautre description of the sample.
+        (NXsensor):
+          exists: optional
+        (NXactuator):
+          exists: optional
+      thickness(NX_NUMBER):
+        exists: optional
+        doc: |
+          (Measured) sample thickness.
+          
+          The information is recorded to qualify if the light used was likely
+          able to shine through the sample. 
+          
+          In this case the value should be set to the actual thickness of
+          the specimen viewed for an illumination situation where the nominal
+          surface normal of the specimen is parallel to the optical axis.
+        unit: NX_LENGTH
+      thickness_determination:
+        exists: optional
+        doc: |
+          If a thickness if given, please specify how this thickness was estimated or determined.
+      layer_structure:
+        exists: optional
+        doc: |
+          Qualitative description of the layer structure for the sample,
+          starting with the top layer (i.e. the one on the front surface, on
+          which the light incident), e.g. native oxide/bulk substrate, or
+          Si/native oxide/thermal oxide/polymer/peptide.
       sample_orientation:
         exists: optional
         doc: |
-          Specify the sample orientation.
-    data_collection(NXprocess):
+          Specify the sample orientation, how is its sample normal oriented
+          relative in the laboratory reference frame, incident beam reference
+          frame.
+      substrate:
+        exists: recommended
+        doc: |
+          If the sample is grown or fixed on a substrate, specify this here by
+          a free text description.
+    (NXdata):
       doc: |
-        Measured data, data errors, and varied parameters. If reference data
-        were measured they should be considered a separate experiment and a
-        link to its NeXus file should be added in reference_data_link.
-      data_identifier(NX_NUMBER):
+        A default view of the data provided in ENTRY/data_collection/measured_data. This
+        should be the part of the data set which provides the most suitable
+        representation of the data.
+
+        You may provide multiple instances of NXdata
+      \@axes:
         doc: |
-          An identifier to correlate data to the experimental conditions,
-          if several were used in this measurement; typically an index of 0-N.
-      data_type:
+          Spectrum, i.e. x-axis of the data (e.g. wavelength, energy etc.)
+      \@signal:
         doc: |
-          Select which type of data was recorded, for example intensity,
-          reflectivity, transmittance, Psi and Delta etc.
-          It is possible to have multiple selections. The enumeration list
-          depends on the type of experiment and may differ for different
-          application definitions.
-        enumeration: [intensity, reflectivity, transmittance, Psi/Delta, tan(Psi)/cos(Delta), Mueller matrix, Jones matrix, N/C/S, raw data]
-      
-      # This should be a required field, but is set to 'optional' for the moment
-      NAME_spectrum(NX_FLOAT):
+          Spectrum, i.e. y-axis of the data (e.g. counts, intensity)
+    measurement_data_calibration(NXprocess):
+      wavelength_calibration(NXcalibration):
         exists: optional
-        unit: NX_ANY
-        doc: |
-          Spectral values (e.g. wavelength or energy) used for the measurement.
-          An array of 1 or more elements. Length defines N_spectrum. Replace
-          'SPECTRUM' by the physical quantity that is used, e.g. wavelength.
-        dimensions:
-          rank: 1
-          dim: [[1, N_spectrum]]
-        \@units:
-          exists: optional
+        calibrated_axis(NX_FLOAT):
+          exists: recommended
           doc: |
-            If applicable, change 'unit: NX_ANY' to the appropriate NXDL unit.
-            If the unit of the measured data is not covered by NXDL units state
-            here which unit was used.
-      measured_data(NX_FLOAT):
-        unit: NX_ANY
-        doc: |
-          Resulting data from the measurement, described by 'data_type'.
-          
-          The first dimension is defined by the number of measurements taken,
-          (N_measurements). The instructions on how to order the values
-          contained in the parameter vectors given in the doc string of
-          INSTRUMENT/sample_stage/environment_conditions/PARAMETER/values,
-          define the N_measurements parameter sets. For example, if the
-          experiment was performed at three different temperatures
-          (T1, T2, T3), two different pressures (p1, p2) and two different
-          angles of incidence (a1, a2), the first measurement was taken at the
-          parameters {a1,p1,T1}, the second measurement at {a1,p1,T2} etc.
-        dimensions:
-          rank: 3
-          dim: [[1, N_measurements], [2, N_observables], [3, N_spectrum]]
-        \@units:
-          exists: optional
-          doc: |
-            If applicable, change 'unit: NX_ANY' to the appropriate NXDL unit.
-            If the unit of the measured data is not covered by NXDL units state
-            here which unit was used.
-      measured_data_errors(NX_FLOAT):
-        exists: optional
-        unit: NX_ANY
-        doc: |
-          Specified uncertainties (errors) of the data described by 'data_type'
-          and provided in 'measured_data'.
-        dimensions:
-          rank: 3
-          dim: [[1, N_measurements], [2, N_observables], [3, N_spectrum]]
-        \@units:
-          exists: optional
-          doc: |
-            If applicable, change 'unit: NX_ANY' to the appropriate NXDL unit.
-            If the unit of the measured data is not covered by NXDL units state
-            here which unit was used.
-      varied_parameter_link:
-        exists: optional
-        doc: |
-          List of links to the values of the sensors. Add a link for each
-          varied parameter (i.e. for each sensor).
-        dimensions:
-          rank: 1
-          dim: [[1, N_sensors]]
-      reference_data_link:
-        exists: optional
-        doc: |
-          Link to the NeXus file which describes the reference data if a
-          reference measurement was performed. Ideally, the reference
-          measurement was performed using the same conditions as the actual
-          measurement and should be as close in time to the actual measurement
-          as possible.
-      data_software(NXprocess):
-        exists: optional
-        program:
-          doc: |
-            Commercial or otherwise defined given name of the program that was
-            used to generate the result file(s) with measured data and/or
-            metadata (in most cases, this is the same as INSTRUMENT/software).
-            If home written, one can provide the actual steps in the NOTE
-            subfield here.
-        version:
-          doc: |
-            Either version with build number, commit hash, or description of a
-            (online) repository where the source code of the program and build
-            instructions can be found so that the program can be configured in
-            such a way that result files can be created ideally in a
-            deterministic manner.
-        \@url:
-          exists: optional
-          doc: |
-            Website of the software.
-      (NXdata):
-        exists: optional
-        doc: |
-          A plot of the multi-dimensional data array provided in
-          ENTRY/data/measured_data.
-        \@axes:
-          doc: |
-            Spectrum, i.e. x-axis of the data (e.g. wavelength, energy etc.)
+            Location to save the calibrated wavelength data.
+    # The old "data_collection(NXprocess)" is now replaced by more flexbile
+    # NXdata. A detailed rework of this has to be done after the NXopt workshop
     derived_parameters(NXprocess):
       exists: optional
       doc: |
+        >>>This section is transfered from the first NXopt version and might
+        require a reqwork.<<<
         Parameters that are derived from the measured data.
       depolarization(NX_NUMBER):
         exists: optional
@@ -621,14 +911,6 @@ NXopt(NXobject):
             instructions can be found so that the program can be configured in
             such a way that result files can be created ideally in a
             deterministic manner.
-    plot(NXdata):
-      doc: |
-        A default view of the data provided in ENTRY/data_collection/measured_data. This
-        should be the part of the data set which provides the most suitable
-        representation of the data.
-      \@axes:
-        doc: |
-          Spectrum, i.e. x-axis of the data (e.g. wavelength, energy etc.)
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
 # 7d68d553b6c55f5cdd8fe8d92c325b137c71c875c2bd742f5cf2150df56f4398

--- a/contributed_definitions/nyaml/NXopt.yaml
+++ b/contributed_definitions/nyaml/NXopt.yaml
@@ -778,6 +778,7 @@ NXopt(NXobject):
           exists: recommended
           enumeration: [air, vacuum, inert atmosphere, oxidising atmosphere, reducing atmosphere, sealed can, water, other]
       thickness(NX_NUMBER):
+        # Make something like NXlayer_structure_sample?
         exists: optional
         doc: |
           (Measured) sample thickness.
@@ -794,6 +795,7 @@ NXopt(NXobject):
         doc: |
           If a thickness if given, please specify how this thickness was estimated or determined.
       layer_structure:
+      # Maybe consider here to include NXsample_component_set.
         exists: optional
         doc: |
           Qualitative description of the layer structure for the sample,
@@ -813,9 +815,12 @@ NXopt(NXobject):
           a free text description.
     (NXdata):
       doc: |
-        A default view of the data provided in ENTRY/data_collection/measured_data. This
-        should be the part of the data set which provides the most suitable
-        representation of the data.
+        Here generic types of data may be saved.. This may refer to data derived
+        from single or multiple raw measurements (i.e. several intensities are
+        evaluated for different parameters: ellipsometry -> psi and delta) -
+        i.e. non-raw data. 
+        As well plotable data may be stored/linked here, which provides the most suitable
+        representation of the data (for the respective community).
 
         You may provide multiple instances of NXdata
       \@axes:
@@ -832,7 +837,9 @@ NXopt(NXobject):
           doc: |
             Location to save the calibrated wavelength data.
     # The old "data_collection(NXprocess)" is now replaced by more flexbile
-    # NXdata. A detailed rework of this has to be done after the NXopt workshop
+    # NXdata. The detailed inclusion of a data collection description (i.e.
+    # raw data from ellipsometry as polarization values to the usually used
+    # psi and delta values), will be done later after the NXopt workshop.
     derived_parameters(NXprocess):
       exists: optional
       doc: |
@@ -847,7 +854,7 @@ NXopt(NXobject):
         dimensions:
           rank: 3
           dim: [[1, N_measurements], [2, 1], [3, N_spectrum]]
-      Jones_quality_factor(NX_NUMBER):
+      jones_quality_factor(NX_NUMBER):
         exists: optional
         unit: NX_UNITLESS
         doc: |

--- a/contributed_definitions/nyaml/NXopt_window.yaml
+++ b/contributed_definitions/nyaml/NXopt_window.yaml
@@ -1,0 +1,69 @@
+category: base
+doc: |
+  A window of a cryostat, heater, vacuum chamber or a simple glass slide.
+
+  This first verion originates from NXopt to describe cryostate windows
+  and possible influences for ellipsometry measurements.
+
+  For environmental measurements, the environment (liquid, vapor
+  etc.) is enclosed in a cell, which has windows both in the
+  direction of the source (entry window) and the detector (exit
+  window) (looking from the sample). In case that the entry and exit
+  windows are not the same type and do not have the same properties,
+  use a second 'WINDOW(NXaperture)' field.
+  
+  The windows also add a phase shift to the light altering the
+  measured signal. This shift has to be corrected based on measuring
+  a known sample (reference sample) or the actual sample of interest
+  in the environmental cell. State if a window correction has been
+  performed in 'window_effects_corrected'. Reference data should be
+  considered as a separate experiment, and a link to the NeXus file
+  should be added in reference_data_link in measured_data.
+  
+  The window is considered to be a part of the sample stage but also
+  beam path. Hence, its position within the beam path should be
+  defined by the 'depends_on' field.
+# A draft of a new base class to describe a window in a optical setup or device
+type: group
+NXopt_window(NXaperture):
+  (NXentry):
+    window_effects_corrected(NX_BOOLEAN):
+      doc: |
+        Was a window correction performed? If 'True' describe the window
+        correction procedure in 'window_correction/procedure'.
+    window_correction(NXprocess):
+      doc: |
+        Was a window correction performed? If 'True' describe the
+        window correction procedure in ''
+      procedure:
+        doc: |
+          Describe when (before or after the main measurement + time
+          stamp in 'date') and how the window effects have been
+          corrected, i.e. either mathematically or by performing a
+          reference measurement. In the latter case, provide the link to
+          to the reference data in 'reference_data_link'.
+      reference_data_link:
+        doc: |
+          Link to the NeXus file which describes the reference data if a
+          reference measurement for window correction was performed.
+          Ideally, the reference measurement was performed on a reference
+          sample and on the same sample, and using the same conditions as
+          for the actual measurement with and without windows. It should
+          have been conducted as close in time to the actual measurement
+          as possible.
+    material(NX_CHAR):
+      doc: |
+        The material of the window.
+      enumeration: [quartz, diamond, calcium fluoride, zinc selenide, thallium bromoiodide, alkali halide compound, Mylar, other]
+    material_other(NX_CHAR):
+      doc: |
+        If you specified 'other' as material, decsribe here what it is.
+    thickness(NX_FLOAT):
+      unit: NX_LENGTH
+      doc: |
+        Thickness of the window.
+    orientation_angle(NX_FLOAT):
+      unit: NX_ANGLE
+      doc: |
+        Angle of the window normal (outer) vs. the substrate normal
+        (similar to the angle of incidence).

--- a/contributed_definitions/nyaml/NXraman.yaml
+++ b/contributed_definitions/nyaml/NXraman.yaml
@@ -1,0 +1,592 @@
+category: application
+doc: |
+  An application definition for Raman spectrocopy experiments.
+  
+  Such experiments may be as simple a single Raman spectrum from spontanous
+  Raman scattering and range to Raman imaging Raman spectrometer,
+  surface- and tip-enhanced Raman techniques, x-Ray Raman scattering, as well
+  as resonant Raman scattering phenomena or multidimenional Raman spectra (i.e.
+  varying temperature, pressure, electric field, ....)
+  
+  The application definition contains two things:
+  1. The structures in the application definition of NXopt:
+  * Instrument and data calibrations
+  * Sensors for sample or beam conditions
+    
+  AND
+
+  2. The strucutres specified and extended in NXraman:
+  * description of the experiment type
+  * descroption of the setup's meta data and optical elements (source, monochromator, detector, waveplate, lens, etc.)
+  * description of beam properties and their relations to the sample
+  * sample information
+  
+  Information on Raman spectroscopy are provided in:
+  
+  General
+
+  * Lewis, Ian R.; Edwards, Howell G. M.
+    Handbook of Raman Spectroscopy
+    ISBN 0-8247-0557-2
+  
+  Raman scattering selection rules
+
+  * Dresselhaus, M. S.; Dresselhaus, G.; Jorio, A.
+    Group Theory - Application to the Physics ofCondensed Matter
+    ISBN 3540328971
+  
+  Semiconductors
+  
+  * Manuel Cardona
+    Light Scattering in Solids I
+    eBook ISBN: 978-3-540-37568-5
+    DOI: https://doi.org/10.1007/978-3-540-37568-5
+  
+  * Manuel Cardona, Gernot Güntherodt
+    Light Scattering in Solids II
+    eBook ISBN:  978-3-540-39075-6
+    DOI: https://doi.org/10.1007/3-540-11380-0
+  
+  * See as well other Books from the "Light Scattering in Solids" series:
+    III: Recent Results
+    IV: Electronic Scattering, Spin Effects, SERS, and Morphic Effects
+    V: Superlattices and Other Microstructures
+    VI: Recent Results, Including High-Tc Superconductivity
+    VII: Crystal-Field and Magnetic Excitations
+    VIII: Fullerenes, Semiconductor Surfaces, Coherent Phonons
+    IX: Novel Materials and Techniques
+  
+  Glasses, Liquids, Gasses, ...
+  
+  Review articles:
+  Stimulated Raman scattering, Coherent anti-Stokes Raman scattering,
+  Surface-enhanced Raman scattering, Tip-enhanced Raman scattering
+  * https://doi.org/10.1186/s11671-019-3039-2
+symbols:
+  doc: |
+    Variables used throughout the document, e.g. dimensions or parameters.
+  N_spectrum: |
+    Length of the spectrum array (e.g. wavelength or energy) of the measured
+    data.
+  N_measurements: |
+    Number of measurements (1st dimension of measured_data array). This is
+    equal to the number of parameters scanned. For example, if the experiment
+    was performed at three different temperatures and two different pressures
+    N_measurements = 2*3 = 6.
+  N_detection_angles: |
+    Number of detection angles of the beam reflected or scattered off the
+    sample.
+  N_incident_angles: |
+    Number of angles of incidence of the incident beam.
+  N_scattering_configurations: |
+    Number of scattering configurations used in the measurement.
+    It is 1 for only parallel polarization meausement, 2 for parallel and cross 
+    polarization measurement or larger, if i.e. the incident and scattered photon
+    direction is varied.
+  #N_incident_wavelengths: |
+  #  Number of the incident wavelen
+  #N_incident_beams: |
+  #  to be done....
+
+# 04/2024
+# A draft version of a NeXus application definition for Raman spectroscopy.
+
+type: group
+NXraman(NXopt):
+  (NXentry):
+    definition:
+      doc: |
+        An application definition for Raman spectrsocopy.
+      \@version:
+        doc: |
+          Version number to identify which definition of this application
+          definition was used for this entry/data.
+      \@url:
+        doc: |
+          URL where to find further material (documentation, examples) relevant
+          to the application definition.
+      enumeration: [NXraman]
+    title:
+    experiment_type:
+      doc: |
+        Specify the type of the optical experiment.
+        
+        You may specify fundamental characteristics or properties in the experimental sub-type.
+      enumeration: [Raman spectroscopy]
+    raman_experiment_type:
+      doc: |
+        Specify the type of Raman experiment.
+      enumeration: [in situ Raman spectroscopy, resonant Raman spectroscopy, non-resonant Raman spectroscopy, Raman imaging, Tip-enhanced Raman spectroscopy (TERS), Surface-enhanced Raman spectroscopy (SERS), Surface plasmon polariton enhanced Raman scattering (SPPERS), Hyper Raman spectroscopy (HRS), Stimulated Raman spectroscopy (SRS), Inverse Raman spectroscopy (IRS), Coherent anti-Stokes Raman spectroscopy (CARS), other]
+    raman_experiment_type_other:
+      exists: optional
+      doc: |
+        If the raman_experiment_type is `other`, a name should be specified here.
+    (NXinstrument):
+      doc: |
+         Metadata of the setup, its optical elements and physical properites which
+         defines the Raman measurement.
+      scattering_configuration(NX_CHAR):
+        doc: |
+          Scattering configuration as defined by the porto notation by three
+          states, which are othogonal to each other. Example: z(xx)z for
+          parallel polarized backscattering configuration.
+          
+          See:
+          https://www.cryst.ehu.es/cgi-bin/cryst/programs/nph-doc-raman
+          
+          A(BC)D
+          
+          A = The propagation direction of the incident light (k_i)
+          B = The polarization direction of the incident light (E_i)
+          C = The polarization direction of the scattered light (E_s)
+          D = The propagation direction of the scattered light (k_s)
+          
+          An orthogonal base is assumed.
+          Linear polarized light is displayed by e.g. "x","y" or "z"
+          Unpolarized light is displayed by "."
+          For non-orthogonal vectors, use the attribute porto_notation_vectors.
+        \@porto_notation_vectors(NX_NUMBER):
+          # unit: NX_LENGTH
+          doc: |
+            Scattering configuration as defined by the porto notation given by
+            respective vectors.
+            
+            Vectors in the porto notation are defined as for A, B, C, D above.
+            Linear light polarization is assumed.
+          dimensions:
+            rank: 3
+            doc: |
+              3 x 4 Matrix, which lists the porto notation vectors A, B, C, D.
+              A has to be perpendicular to B and C perpendicular to D.
+            dim: [[1, 4], [2, 3], [3, N_scattering_configurations]]
+      beam_incident(NXbeam):
+        doc: |
+          Beam which is incident to the sample.
+        wavelength(NX_NUMBER):
+
+
+
+# ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
+# 80b03b96b60b3c124d11d834654b3e57e09716088e8dca121f7903148c7b06e3
+# <?xml version='1.0' encoding='UTF-8'?>
+# <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+# <!--
+# # NeXus - Neutron and X-ray Common Data Format
+# #
+# # Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+# #
+# # This library is free software; you can redistribute it and/or
+# # modify it under the terms of the GNU Lesser General Public
+# # License as published by the Free Software Foundation; either
+# # version 3 of the License, or (at your option) any later version.
+# #
+# # This library is distributed in the hope that it will be useful,
+# # but WITHOUT ANY WARRANTY; without even the implied warranty of
+# # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# # Lesser General Public License for more details.
+# #
+# # You should have received a copy of the GNU Lesser General Public
+# # License along with this library; if not, write to the Free Software
+# # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# #
+# # For further information, see http://www.nexusformat.org
+# -->
+# <!--
+# 03/2024
+# A draft version of a NeXus application definition for Raman spectroscopy.-->
+# <!--
+# The document has the following main elements:
+# - Instrument used and is characteristics
+# - Sample: Properties of the sample
+# - Data: measured data, data errors
+# - Derived parameters: e.g. extra parameters derived in the measurement software-->
+# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXraman" extends="NXopt" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+#     <symbols>
+#         <doc>
+#              Variables used throughout the document, e.g. dimensions or parameters.
+#         </doc>
+#     </symbols>
+#     <doc>
+#          An application definition for Raman spectrocopy experiments.
+#          
+#          Information on Raman spectroscopy are provided in:
+#          
+#          General
+#          * Lewis, Ian R.; Edwards, Howell G. M.
+#            Handbook of Raman Spectroscopy
+#            ISBN 0-8247-0557-2
+#          
+#          Raman scattering selection rules
+#          * Dresselhaus, M. S.; Dresselhaus, G.; Jorio, A.
+#            Group Theory - Application to the Physics ofCondensed Matter
+#            ISBN 3540328971
+#          
+#          Semiconductors
+#          * Manuel Cardona
+#            Light Scattering in Solids I
+#            eBook ISBN: 978-3-540-37568-5
+#            DOI: https://doi.org/10.1007/978-3-540-37568-5
+#          
+#          * Manuel Cardona, Gernot Güntherodt
+#            Light Scattering in Solids II
+#            eBook ISBN:  978-3-540-39075-6
+#            DOI: https://doi.org/10.1007/3-540-11380-0
+#          
+#          * See as well other Books from the "Light Scattering in Solids" series:
+#            III: Recent Results
+#            IV: Electronic Scattering, Spin Effects, SERS, and Morphic Effects
+#            V: Superlattices and Other Microstructures 
+#            VI: Recent Results, Including High-Tc Superconductivity
+#            VII: Crystal-Field and Magnetic Excitations
+#            VIII: Fullerenes, Semiconductor Surfaces, Coherent Phonons
+#            IX: Novel Materials and Techniques
+#          
+#          Glasses, Liquids, Gasses, ...
+#          
+#          Review articles:
+#          Stimulated Raman scattering, Coherent anti-Stokes Raman scattering,
+#          Surface-enhanced Raman scattering, Tip-enhanced Raman scattering
+#          * https://doi.org/10.1186/s11671-019-3039-2
+#     </doc>
+#     <group type="NXentry">
+#         <doc>
+#              This is the application definition describing Raman spectroscopy experiments.
+#              
+#              Such experiments may be as simple a single Raman spectrum from spontanous 
+#              Raman scattering and range to Raman imaging Raman spectrometer,
+#              surface- and tip-enhanced Raman techniques, x-Ray Raman scattering, as well
+#              as resonant Raman scattering phenomena or multidimenional Raman spectra (i.e.
+#              varying temperature, pressure, electric field, ....)
+#              
+#              The application definition defines:
+#              
+#              * elements of the experimental instrument
+#              * calibration information if available
+#              * parameters used to tune the state of the sample
+#              * sample description
+#         </doc>
+#         <field name="definition">
+#             <doc>
+#                  An application definition for ellipsometry.
+#             </doc>
+#             <attribute name="version">
+#                 <doc>
+#                      Version number to identify which definition of this application
+#                      definition was used for this entry/data.
+#                 </doc>
+#             </attribute>
+#             <attribute name="url">
+#                 <doc>
+#                      URL where to find further material (documentation, examples) relevant
+#                      to the application definition.
+#                 </doc>
+#             </attribute>
+#             <enumeration>
+#                 <item value="NXraman"/>
+#             </enumeration>
+#         </field>
+#         <field name="experiment_description">
+#             <doc>
+#                  An optional free-text description of the experiment.
+#                  
+#                  However, details of the experiment should be defined in the specific
+#                  fields of this application definition rather than in this experiment
+#                  description.
+#             </doc>
+#         </field>
+#         <field name="experiment_type">
+#             <doc>
+#                  Specify the type of Raman measurement.
+#             </doc>
+#             <enumeration>
+#                 <item value="in situ Raman spectroscopy"/>
+#                 <item value="resonant Raman spectroscopy"/>
+#                 <item value="non-resonant Raman spectroscopy"/>
+#                 <item value="Raman imaging"/>
+#                 <item value="Tip-enhanced Raman spectroscopy (TERS)"/>
+#                 <item value="Surface-enhanced Raman spectroscopy (SERS)"/>
+#                 <item value="Surface plasmon polariton enhanced Raman scattering (SPPERS)"/>
+#                 <item value="Hyper Raman spectroscopy (HRS)"/>
+#                 <item value="Stimulated Raman spectroscopy (SRS)"/>
+#                 <item value="Inverse Raman spectroscopy (IRS)"/>
+#                 <item value="Coherent anti-Stokes Raman spectroscopy (CARS)"/>
+#             </enumeration>
+#         </field>
+#         <!--Spontanous / far Field Raman Techniques-->
+#         <!--Enhanced / near Field Raman Techniques-->
+#         <!--Nonlinear Raman spectroscopy-->
+#         <group type="NXinstrument">
+#             <doc>
+#                  Properties of the Instruments used for Raman instrumeasurements.
+#             </doc>
+#             <field name="company" optional="true">
+#                 <doc>
+#                      Name of the company which build the instrument.
+#                 </doc>
+#             </field>
+#             <field name="construction_year" type="NX_DATE_TIME" optional="true">
+#                 <doc>
+#                      ISO8601 date when the instrument was constructed.
+#                      UTC offset should be specified.
+#                 </doc>
+#             </field>
+#             <group name="software" type="NXprocess">
+#                 <field name="program">
+#                     <doc>
+#                          Commercial or otherwise defined given name of the program that was
+#                          used to generate the result file(s) with measured data and metadata.
+#                          This program converts the measured signals to Raman data. If
+#                          home written, one can provide the actual steps in the NOTE subfield
+#                          here.
+#                     </doc>
+#                 </field>
+#             </group>
+#             <field name="incident_source_wavelength" type="NX_NUMBER" units="NX_LENGTH">
+#                 <doc>
+#                      Which indicent wavelength was used for e.g. a laser source.
+#                      For multiple excitation wavelengths, please state the specific discret
+#                      wavelengths (i.e. for dye laser) or the specific contnious range 
+#                      (i.e for white light laser source)
+#                 </doc>
+#             </field>
+#             <field name="scattering_configuration" type="NX_CHAR">
+#                 <!--
+# unit: NX_LENGTH
+# -->
+#                 <doc>
+#                      Scattering configuration as defined by the porto notation by three 
+#                      states, which are othogonal to each other. Example: z(xx)z for
+#                      parallel polarized backscattering configuration.
+#                      
+#                      See:
+#                      https://www.cryst.ehu.es/cgi-bin/cryst/programs/nph-doc-raman
+#                      
+#                      A(BC)D
+#                      
+#                      A = The propagation direction of the incident light (k_i)
+#                      B = The polarization direction of the incident light (E_i)
+#                      C = The polarization direction of the scattered light (E_s)
+#                      D = The propagation direction of the scattered light (k_s)
+#                      
+#                      An orthogonal base is assumed.
+#                      Linear polarized light is displayed by e.g. "x","y" or "z"
+#                      Unpolarized light is displayed by "."
+#                 </doc>
+#                 <field name="non_orthogonal_base_vectors" type="NX_NUMBER">
+#                     <!--
+# unit: NX_LENGTH
+# -->
+#                     <doc>
+#                          Scattering configuration as defined by the porto notation given by
+#                          respective vectors.
+#                          
+#                          Vectors in the porto notation are defined as for A, B, C, D above.
+#                          Linear light polarization is assumed.
+#                     </doc>
+#                     <dimensions rank="2">
+#                         <doc>
+#                              3 x 4 Matrix, which lists the porto notation vectors A, B, C, D. 
+#                              A has to be perpendicular to B and C perpendicular to D.
+#                         </doc>
+#                         <dim index="1" value="4"/>
+#                         <dim index="2" value="3"/>
+#                     </dimensions>
+#                 </field>
+#             </field>
+#             <group type="NXbeam_path">
+#                 <group name="light_source" type="NXsource">
+#                     <doc>
+#                          Specify the used light source. Multiple selection possible.
+#                     </doc>
+#                     <field name="source_type">
+#                         <enumeration>
+#                             <item value="laser"/>
+#                             <item value="dye-laser"/>
+#                             <item value="broadband tunable light source"/>
+#                             <item value="other"/>
+#                         </enumeration>
+#                     </field>
+#                 </group>
+#                 <group name="incident_light_optics" type="NXlens_opt" recommended="true">
+#                     <doc>
+#                          This is the optical element used for the incident light in the Raman
+#                          scattering process.
+#                          
+#                          This can be for example a simple lens or microscope
+#                          objective.
+#                     </doc>
+#                     <field name="type">
+#                         <enumeration>
+#                             <item value="objective"/>
+#                             <item value="lens"/>
+#                             <item value="glass fiber"/>
+#                             <item value="none"/>
+#                             <item value="other"/>
+#                         </enumeration>
+#                     </field>
+#                     <field name="numerical_aperture" type="NX_NUMBER">
+#                         <doc>
+#                              The numerical aperture of the used incident light optics.
+#                         </doc>
+#                     </field>
+#                 </group>
+#                 <group name="scattered_light_optics" type="NXlens_opt" optional="true">
+#                     <doc>
+#                          This is the optical element used for the incident light in the Raman
+#                          scattering process.
+#                          
+#                          This can be for example a simple lens or microscope
+#                          objective.
+#                     </doc>
+#                     <attribute name="is_same_as_for_incident_light"/>
+#                     <field name="type">
+#                         <enumeration>
+#                             <item value="objective"/>
+#                             <item value="lens"/>
+#                             <item value="glass fiber"/>
+#                             <item value="none"/>
+#                             <item value="other"/>
+#                         </enumeration>
+#                     </field>
+#                     <field name="numerical_aperture" type="NX_NUMBER">
+#                         <doc>
+#                              The numerical aperture of the used incident light optics.
+#                         </doc>
+#                     </field>
+#                 </group>
+#                 <group type="NXdetector">
+#                     <doc>
+#                          Properties of the detector used. Integration time is the count time
+#                          field, or the real time field. See their definition.
+#                     </doc>
+#                 </group>
+#                 <group name="polarization_manipulator_N" type="NXwaveplate" optional="true">
+#                     <doc>
+#                          Device for the manipulation of the state of light which is a half wave
+#                          plate.
+#                     </doc>
+#                     <field name="type">
+#                         <enumeration>
+#                             <item value="objective"/>
+#                             <item value="lens"/>
+#                             <item value="glass fiber"/>
+#                             <item value="none"/>
+#                             <item value="other"/>
+#                         </enumeration>
+#                     </field>
+#                 </group>
+#                 <field name="polarization_filter" optional="true">
+#                     <doc>
+#                          Physical principle of the polarization filter used to create a 
+#                          defined incident or scattered light state.
+#                     </doc>
+#                     <field name="type">
+#                         <enumeration>
+#                             <item value="Polarization by Fresnel reflection"/>
+#                             <item value="Birefringent polarizers"/>
+#                             <item value="Thin film polarizers"/>
+#                             <item value="Wire-grid polarizers"/>
+#                         </enumeration>
+#                     </field>
+#                     <field name="specific_polarizer_type">
+#                         <doc>
+#                              Specific name or type of the polarizer used.
+#                              
+#                              For example: Glan-Thompson, Glan-Taylor, Rochon Prism, Wollaston 
+#                              Polarizer...
+#                         </doc>
+#                     </field>
+#                 </field>
+#                 <field name="laser_line_filter" optional="true">
+#                     <doc>
+#                          Type of laserline filter used to supress the laser, if measurements
+#                          close to the laserline are performed.
+#                     </doc>
+#                     <field name="type">
+#                         <enumeration>
+#                             <item value="Long-pass filter"/>
+#                             <item value="Short-pass filter"/>
+#                             <item value="Notch Filter"/>
+#                         </enumeration>
+#                     </field>
+#                     <field name="filter_design_wavelength" type="NX_NUMBER">
+#                         <doc>
+#                              Design wavelength for the laser line filter.
+#                         </doc>
+#                     </field>
+#                     <field name="filter_spectral_steepness">
+#                         <doc>
+#                              Steepness of the filter by normal incidence of the light as defined
+#                              by 10% - 90% transmittance of the respective filter.
+#                         </doc>
+#                     </field>
+#                     <!--for a notch filter in principle two steepness have to be defined..-->
+#                     <field name="filter_strength" type="NX_float">
+#                         <doc>
+#                              Designed supression strength of the laserline at optimal condition
+#                              given in orders of magnitude.
+#                         </doc>
+#                     </field>
+#                 </field>
+#                 <group name="rotating_element" type="NXwaveplate" optional="true">
+#                     <doc>
+#                          Properties of the rotating element defined in
+#                          'instrument/rotating_element_type'.
+#                     </doc>
+#                     <field name="revolutions" type="NX_NUMBER" optional="true" units="NX_COUNT">
+#                         <doc>
+#                              Define how many revolutions of the rotating element were averaged
+#                              for each measurement. If the number of revolutions was fixed to a
+#                              certain value use the field 'fixed_revolutions' instead.
+#                         </doc>
+#                     </field>
+#                     <field name="fixed_revolutions" type="NX_NUMBER" optional="true" units="NX_COUNT">
+#                         <doc>
+#                              Define how many revolutions of the rotating element were taken
+#                              into account for each measurement (if number of revolutions was
+#                              fixed to a certain value, i.e. not averaged).
+#                         </doc>
+#                     </field>
+#                     <field name="max_revolutions" type="NX_NUMBER" optional="true" units="NX_COUNT">
+#                         <doc>
+#                              Specify the maximum value of revolutions of the rotating element
+#                              for each measurement.
+#                         </doc>
+#                     </field>
+#                 </group>
+#                 <group name="spectrometer" type="NXmonochromator" optional="true">
+#                     <doc>
+#                          The spectroscope element of the ellipsometer before the detector,
+#                          but often integrated to form one closed unit. Information on the
+#                          dispersive element can be specified in the subfield GRATING. Note
+#                          that different gratings might be used for different wavelength
+#                          ranges. The dispersion of the grating for each wavelength range can
+#                          be stored in grating_dispersion.
+#                     </doc>
+#                 </group>
+#             </group>
+#         </group>
+#         <group type="NXsample">
+#             <field name="backside_roughness" type="NX_BOOLEAN">
+#                 <doc>
+#                      Was the backside of the sample roughened? Relevant for infrared
+#                      ellipsometry.
+#                 </doc>
+#             </field>
+#         </group>
+#         <group name="data_collection" type="NXprocess">
+#             <field name="data_type">
+#                 <doc>
+#                      Select which type of data was recorded, for example a simple spectrum
+#                      with intensity vs. Raman shift, CCD image or a set of spectra with
+#                      probe, reference and background signals for pump beam on and off.
+#                 </doc>
+#                 <enumeration>
+#                     <item value="Integrated single spectrum"/>
+#                     <item value="CCD image"/>
+#                     <item value="Probe + Background + Reference for Pump-on and Pump-off (i.e. for FSRS)"/>
+#                 </enumeration>
+#             </field>
+#         </group>
+#     </group>
+# </definition>


### PR DESCRIPTION
This PR is a full rework of the NXopt definition. The for this was used from NXmpes and NXem.

NXopt was first defined from NXellipsometry. Therefore, some concepts are present in the current NXopt form, which makes sense to define NXellipsometry(NXopt), but not for e.g. NXraman(NXopt) or NXpl(NXopt). This rework should generalize NXopt in a first step, before in an upcoming workshop final refinements are done.

Added/Modified Parts:
- General entry information
- Various NXuser fields
- Various instrument Devices
- Reference frames with description (needs to be worked out later in detail)
- Added two additional fundamental angles required for scattering/emission experiments and sample rotation
- moved/added calibration and exp. resolution
- NXbeams with polarization description
- Specified NXsource and NXdetector similar to NXmpes
- Moved sample medium opt. prop. to NXinstrument
- NXmanipulator as stage
- NXsensor and NXactuator with specific examples for temperature
- Sample description was refined
- (NXdata) replaces data_collection(NXprocess)
- simple template for calibration data added similar to NXmpes

tl;dr: Full Overhaul of NXopt to enable the description of a generic optical experiment as well as specialization.