### PR TITLE
Add edge cases to namefit documentation

### DIFF
--- a/dev_tools/tests/test_nxdl_utils.py
+++ b/dev_tools/tests/test_nxdl_utils.py
@@ -173,7 +173,7 @@ def test_namefitting(hdf_name, concept_name, should_fit):
         ("test_other", "test_name", -1),
         ("my_fancy_yet_long_name", "my_SOME_name", 8),
         ("something", "XXXX", 0),
-        ("something", "OTHER", 1)
+        ("something", "OTHER", 1),
     ],
 )
 def test_namefitting_scores(hdf_name, concept_name, score):

--- a/dev_tools/tests/test_nxdl_utils.py
+++ b/dev_tools/tests/test_nxdl_utils.py
@@ -172,6 +172,8 @@ def test_namefitting(hdf_name, concept_name, should_fit):
         ("test_name", "test_name", 18),
         ("test_other", "test_name", -1),
         ("my_fancy_yet_long_name", "my_SOME_name", 8),
+        ("something", "XXXX", 0),
+        ("something", "OTHER", 1)
     ],
 )
 def test_namefitting_scores(hdf_name, concept_name, score):

--- a/dev_tools/utils/nxdl_utils.py
+++ b/dev_tools/utils/nxdl_utils.py
@@ -133,6 +133,8 @@ def get_nx_namefit(hdf_name: str, name: str, name_any: bool = False) -> int:
         * `get_nx_namefit("my_other_name", "TEST_name")` returns 5
         * `get_nx_namefit("test_name", "test_name")` returns 18
         * `get_nx_namefit("test_other", "test_name")` returns -1
+        * `get_nx_namefit("something", "XXXX")` returns 0
+        * `get_nx_namefit("something", "OTHER")` returns 1
 
     Args:
         hdf_name (str): The hdf_name, containing the name of the HDF5 node.


### PR DESCRIPTION
This adds some edge cases to the documentation of the `get_nx_namefit` function for better understanding