### PR TITLE
Add default attribute to MPES-related base classes

### DIFF
--- a/base_classes/NXenvironment.nxdl.xml
+++ b/base_classes/NXenvironment.nxdl.xml
@@ -93,4 +93,17 @@
              defined in an NXinstrument instance.
         </doc>
     </group>
+    <attribute name="default">
+        <doc>
+             .. index:: plotting
+             
+             Declares which child group contains a path leading
+             to a :ref:`NXdata` group.
+             
+             It is recommended (as of NIAC2014) to use this attribute
+             to help define the path to the default dataset to be plotted.
+             See https://www.nexusformat.org/2014_How_to_find_default_data.html
+             for a summary of the discussion.
+        </doc>
+    </attribute>
 </definition>

--- a/base_classes/nyaml/NXenvironment.yaml
+++ b/base_classes/nyaml/NXenvironment.yaml
@@ -50,9 +50,20 @@ NXenvironment(NXobject):
     doc: |
       Any sensor used to monitor the environment. This can be linked to a sensor
       defined in an NXinstrument instance.
+  \@default:
+    doc: |
+      .. index:: plotting
+      
+      Declares which child group contains a path leading
+      to a :ref:`NXdata` group.
+      
+      It is recommended (as of NIAC2014) to use this attribute
+      to help define the path to the default dataset to be plotted.
+      See https://www.nexusformat.org/2014_How_to_find_default_data.html
+      for a summary of the discussion.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# edb4357785f3ad2e7c84849c787be220920b9eef3a18ee1c8d251327873c87b7
+# 4e4bd4fe380d78389677def141557774db0580c77850b6cfe755ba06e7b57cef
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -148,4 +159,17 @@ NXenvironment(NXobject):
 #              defined in an NXinstrument instance.
 #         </doc>
 #     </group>
+#     <attribute name="default">
+#         <doc>
+#              .. index:: plotting
+#              
+#              Declares which child group contains a path leading
+#              to a :ref:`NXdata` group.
+#              
+#              It is recommended (as of NIAC2014) to use this attribute
+#              to help define the path to the default dataset to be plotted.
+#              See https://www.nexusformat.org/2014_How_to_find_default_data.html
+#              for a summary of the discussion.
+#         </doc>
+#     </attribute>
 # </definition>

--- a/contributed_definitions/NXactuator.nxdl.xml
+++ b/contributed_definitions/NXactuator.nxdl.xml
@@ -110,5 +110,18 @@
              other component groups.
         </doc>
     </group>
+    <attribute name="default">
+        <doc>
+             .. index:: plotting
+             
+             Declares which child group contains a path leading
+             to a :ref:`NXdata` group.
+             
+             It is recommended (as of NIAC2014) to use this attribute
+             to help define the path to the default dataset to be plotted.
+             See https://www.nexusformat.org/2014_How_to_find_default_data.html
+             for a summary of the discussion.
+        </doc>
+    </attribute>
     <group type="NXfabrication"/>
 </definition>

--- a/contributed_definitions/NXcalibration.nxdl.xml
+++ b/contributed_definitions/NXcalibration.nxdl.xml
@@ -204,4 +204,17 @@
              NXdata groups can be used for multidimensional data which are relevant to the calibration
         </doc>
     </group>
+    <attribute name="default">
+        <doc>
+             .. index:: plotting
+             
+             Declares which child group contains a path leading
+             to a :ref:`NXdata` group.
+             
+             It is recommended (as of NIAC2014) to use this attribute
+             to help define the path to the default dataset to be plotted.
+             See https://www.nexusformat.org/2014_How_to_find_default_data.html
+             for a summary of the discussion.
+        </doc>
+    </attribute>
 </definition>

--- a/contributed_definitions/NXcollectioncolumn.nxdl.xml
+++ b/contributed_definitions/NXcollectioncolumn.nxdl.xml
@@ -99,6 +99,19 @@
              the reference coordinate system.
         </doc>
     </group>
+    <attribute name="default">
+        <doc>
+             .. index:: plotting
+             
+             Declares which child group contains a path leading
+             to a :ref:`NXdata` group.
+             
+             It is recommended (as of NIAC2014) to use this attribute
+             to help define the path to the default dataset to be plotted.
+             See https://www.nexusformat.org/2014_How_to_find_default_data.html
+             for a summary of the discussion.
+        </doc>
+    </attribute>
     <group type="NXaperture">
         <doc>
              The size and position of an aperture inserted in the column, e.g. field aperture

--- a/contributed_definitions/NXelectronanalyser.nxdl.xml
+++ b/contributed_definitions/NXelectronanalyser.nxdl.xml
@@ -258,6 +258,19 @@
              should relate to the reference coordinate system.
         </doc>
     </group>
+    <attribute name="default">
+        <doc>
+             .. index:: plotting
+             
+             Declares which child group contains a path leading
+             to a :ref:`NXdata` group.
+             
+             It is recommended (as of NIAC2014) to use this attribute
+             to help define the path to the default dataset to be plotted.
+             See https://www.nexusformat.org/2014_How_to_find_default_data.html
+             for a summary of the discussion.
+        </doc>
+    </attribute>
     <group type="NXcollectioncolumn">
         <doc>
              Describes the electron collection (spatial and momentum imaging) column

--- a/contributed_definitions/NXenergydispersion.nxdl.xml
+++ b/contributed_definitions/NXenergydispersion.nxdl.xml
@@ -182,4 +182,17 @@
              the reference coordinate system.
         </doc>
     </group>
+    <attribute name="default">
+        <doc>
+             .. index:: plotting
+             
+             Declares which child group contains a path leading
+             to a :ref:`NXdata` group.
+             
+             It is recommended (as of NIAC2014) to use this attribute
+             to help define the path to the default dataset to be plotted.
+             See https://www.nexusformat.org/2014_How_to_find_default_data.html
+             for a summary of the discussion.
+        </doc>
+    </attribute>
 </definition>

--- a/contributed_definitions/NXmanipulator.nxdl.xml
+++ b/contributed_definitions/NXmanipulator.nxdl.xml
@@ -240,5 +240,18 @@
              the reference coordinate system.
         </doc>
     </group>
+    <attribute name="default">
+        <doc>
+             .. index:: plotting
+             
+             Declares which child group contains a path leading
+             to a :ref:`NXdata` group.
+             
+             It is recommended (as of NIAC2014) to use this attribute
+             to help define the path to the default dataset to be plotted.
+             See https://www.nexusformat.org/2014_How_to_find_default_data.html
+             for a summary of the discussion.
+        </doc>
+    </attribute>
     <group type="NXfabrication"/>
 </definition>

--- a/contributed_definitions/NXpid.nxdl.xml
+++ b/contributed_definitions/NXpid.nxdl.xml
@@ -95,4 +95,17 @@
              time constant are related as follows I = P/T.
         </doc>
     </field>
+    <attribute name="default">
+        <doc>
+             .. index:: plotting
+             
+             Declares which child group contains a path leading
+             to a :ref:`NXdata` group.
+             
+             It is recommended (as of NIAC2014) to use this attribute
+             to help define the path to the default dataset to be plotted.
+             See https://www.nexusformat.org/2014_How_to_find_default_data.html
+             for a summary of the discussion.
+        </doc>
+    </attribute>
 </definition>

--- a/contributed_definitions/NXresolution.nxdl.xml
+++ b/contributed_definitions/NXresolution.nxdl.xml
@@ -104,6 +104,19 @@
              The output unit should match the provided unit of this field.
         </doc>
     </field>
+    <attribute name="default">
+        <doc>
+             .. index:: plotting
+             
+             Declares which child group contains a path leading
+             to a :ref:`NXdata` group.
+             
+             It is recommended (as of NIAC2014) to use this attribute
+             to help define the path to the default dataset to be plotted.
+             See https://www.nexusformat.org/2014_How_to_find_default_data.html
+             for a summary of the discussion.
+        </doc>
+    </attribute>
     <group type="NXcalibration">
         <doc>
              For storing details and data of a calibration to derive a resolution from data.

--- a/contributed_definitions/nyaml/NXactuator.yaml
+++ b/contributed_definitions/nyaml/NXactuator.yaml
@@ -64,10 +64,21 @@ NXactuator(NXobject):
       and rotation operations necessary to position the actuator within
       the instrument. The dependency chain may however traverse similar groups in
       other component groups.
+  \@default:
+    doc: |
+      .. index:: plotting
+      
+      Declares which child group contains a path leading
+      to a :ref:`NXdata` group.
+      
+      It is recommended (as of NIAC2014) to use this attribute
+      to help define the path to the default dataset to be plotted.
+      See https://www.nexusformat.org/2014_How_to_find_default_data.html
+      for a summary of the discussion.
   (NXfabrication):
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# ace4abf5ad9c9c7c3c2127dd7f73de80b4200b40f9a820be62c19c8a0391deb5
+# 9eda87a10fdbfaa3518c014b170c81c03eac50d88643109b20b68ce66e12f1c1
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -180,5 +191,18 @@ NXactuator(NXobject):
 #              other component groups.
 #         </doc>
 #     </group>
+#     <attribute name="default">
+#         <doc>
+#              .. index:: plotting
+#              
+#              Declares which child group contains a path leading
+#              to a :ref:`NXdata` group.
+#              
+#              It is recommended (as of NIAC2014) to use this attribute
+#              to help define the path to the default dataset to be plotted.
+#              See https://www.nexusformat.org/2014_How_to_find_default_data.html
+#              for a summary of the discussion.
+#         </doc>
+#     </attribute>
 #     <group type="NXfabrication"/>
 # </definition>

--- a/contributed_definitions/nyaml/NXcalibration.yaml
+++ b/contributed_definitions/nyaml/NXcalibration.yaml
@@ -136,9 +136,20 @@ NXcalibration(NXobject):
     doc: |
       Any data acquired/used during the calibration that does not fit the `NX_FLOAT` fields above.
       NXdata groups can be used for multidimensional data which are relevant to the calibration
+  \@default:
+    doc: |
+      .. index:: plotting
+      
+      Declares which child group contains a path leading
+      to a :ref:`NXdata` group.
+      
+      It is recommended (as of NIAC2014) to use this attribute
+      to help define the path to the default dataset to be plotted.
+      See https://www.nexusformat.org/2014_How_to_find_default_data.html
+      for a summary of the discussion.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# d3cce510d0f123defa65e89965cce313e56f0e4696d9c28e54a253439539156c
+# 5b3f68876a95d97b868d1689748fea53aa780cddc8c874615e21821ae60d4ccc
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -345,4 +356,17 @@ NXcalibration(NXobject):
 #              NXdata groups can be used for multidimensional data which are relevant to the calibration
 #         </doc>
 #     </group>
+#     <attribute name="default">
+#         <doc>
+#              .. index:: plotting
+#              
+#              Declares which child group contains a path leading
+#              to a :ref:`NXdata` group.
+#              
+#              It is recommended (as of NIAC2014) to use this attribute
+#              to help define the path to the default dataset to be plotted.
+#              See https://www.nexusformat.org/2014_How_to_find_default_data.html
+#              for a summary of the discussion.
+#         </doc>
+#     </attribute>
 # </definition>

--- a/contributed_definitions/nyaml/NXcollectioncolumn.yaml
+++ b/contributed_definitions/nyaml/NXcollectioncolumn.yaml
@@ -60,6 +60,17 @@ NXcollectioncolumn(NXobject):
       relative to the experimental setup. Typically, the components of a system should
       all be related relative to each other and only one component should relate to
       the reference coordinate system.
+  \@default:
+    doc: |
+      .. index:: plotting
+      
+      Declares which child group contains a path leading
+      to a :ref:`NXdata` group.
+      
+      It is recommended (as of NIAC2014) to use this attribute
+      to help define the path to the default dataset to be plotted.
+      See https://www.nexusformat.org/2014_How_to_find_default_data.html
+      for a summary of the discussion.
   (NXaperture):
     doc: |
       The size and position of an aperture inserted in the column, e.g. field aperture
@@ -73,7 +84,7 @@ NXcollectioncolumn(NXobject):
   (NXfabrication):
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# dadb7b6ffb1466761253f335bf00a73741580668da2e77983b4702847426d506
+# c429e3229dddfc0adc13df283624a4392189109f7e69d30e5eb88c49885341ad
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -124,7 +135,7 @@ NXcollectioncolumn(NXobject):
 #              Distance between sample and detector entrance
 #         </doc>
 #     </field>
-#     <field name="mode" type="NX_CHAR">
+#     <field name="lens_mode" type="NX_CHAR">
 #         <doc>
 #              Labelling of the lens setting in use.
 #         </doc>
@@ -175,6 +186,19 @@ NXcollectioncolumn(NXobject):
 #              the reference coordinate system.
 #         </doc>
 #     </group>
+#     <attribute name="default">
+#         <doc>
+#              .. index:: plotting
+#              
+#              Declares which child group contains a path leading
+#              to a :ref:`NXdata` group.
+#              
+#              It is recommended (as of NIAC2014) to use this attribute
+#              to help define the path to the default dataset to be plotted.
+#              See https://www.nexusformat.org/2014_How_to_find_default_data.html
+#              for a summary of the discussion.
+#         </doc>
+#     </attribute>
 #     <group type="NXaperture">
 #         <doc>
 #              The size and position of an aperture inserted in the column, e.g. field aperture

--- a/contributed_definitions/nyaml/NXelectronanalyser.yaml
+++ b/contributed_definitions/nyaml/NXelectronanalyser.yaml
@@ -194,6 +194,17 @@ NXelectronanalyser(NXobject):
       relate it relative to the experimental setup. Typically, the components of a
       system should all be related relative to each other and only one component
       should relate to the reference coordinate system.
+  \@default:
+    doc: |
+      .. index:: plotting
+      
+      Declares which child group contains a path leading
+      to a :ref:`NXdata` group.
+      
+      It is recommended (as of NIAC2014) to use this attribute
+      to help define the path to the default dataset to be plotted.
+      See https://www.nexusformat.org/2014_How_to_find_default_data.html
+      for a summary of the discussion.
   (NXcollectioncolumn):
     doc: |
       Describes the electron collection (spatial and momentum imaging) column
@@ -218,7 +229,7 @@ NXelectronanalyser(NXobject):
       Any other resolution not explicitly named in this base class.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 0295d7c6d933779d8287832fa07998656af165e68555e746bd2d6cae8a41e156
+# 697ed2417255fcb8ac209a81b9833502f0bc72192b8537965d6a48c773572fd6
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -319,10 +330,6 @@ NXelectronanalyser(NXobject):
 #         <doc>
 #              Energy resolution of the analyser with the current setting. May be linked from an
 #              NXcalibration.
-#              
-#              This concept is related to term `10.24`_ of the ISO 18115-1:2023 standard.
-#              
-#              .. _10.24: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:10.24
 #         </doc>
 #         <field name="physical_quantity">
 #             <enumeration>
@@ -344,9 +351,9 @@ NXelectronanalyser(NXobject):
 #                  Ratio of the energy resolution of the electron analyser at a specified energy
 #                  value to that energy value.
 #                  
-#                  This concept is related to term `10.7 ff.`_ of the ISO 18115-1:2023 standard.
+#                  This concept is related to term `10.7`_ of the ISO 18115-1:2023 standard.
 #                  
-#                  .. _10.7 ff.: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:10.7
+#                  .. _10.7: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:10.7
 #             </doc>
 #         </field>
 #     </group>
@@ -378,9 +385,9 @@ NXelectronanalyser(NXobject):
 #         <doc>
 #              Spatial resolution of the electron analyser (Airy disk radius)
 #              
-#              This concept is related to term `10.15 ff.`_ of the ISO 18115-1:2023 standard.
+#              This concept is related to term `10.14`_ of the ISO 18115-1:2023 standard.
 #              
-#              .. _10.15 ff.: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:10.15
+#              .. _10.14: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:10.15
 #         </doc>
 #         <field name="physical_quantity">
 #             <enumeration>
@@ -434,9 +441,9 @@ NXelectronanalyser(NXobject):
 #              operating modes for an instrument would show significant variations in atomic
 #              concentrations.
 #              
-#              This concept is related to term `7.15 ff.`_ of the ISO 18115-1:2023 standard.
+#              This concept is related to term `7.15`_ of the ISO 18115-1:2023 standard.
 #              
-#              .. _7.15 ff.: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:7.15
+#              .. _7.15: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:7.15
 #         </doc>
 #         <attribute name="signal">
 #             <enumeration>
@@ -483,6 +490,19 @@ NXelectronanalyser(NXobject):
 #              should relate to the reference coordinate system.
 #         </doc>
 #     </group>
+#     <attribute name="default">
+#         <doc>
+#              .. index:: plotting
+#              
+#              Declares which child group contains a path leading
+#              to a :ref:`NXdata` group.
+#              
+#              It is recommended (as of NIAC2014) to use this attribute
+#              to help define the path to the default dataset to be plotted.
+#              See https://www.nexusformat.org/2014_How_to_find_default_data.html
+#              for a summary of the discussion.
+#         </doc>
+#     </attribute>
 #     <group type="NXcollectioncolumn">
 #         <doc>
 #              Describes the electron collection (spatial and momentum imaging) column

--- a/contributed_definitions/nyaml/NXenergydispersion.yaml
+++ b/contributed_definitions/nyaml/NXenergydispersion.yaml
@@ -135,9 +135,20 @@ NXenergydispersion(NXobject):
       to relate it relative to the experimental setup. Typically, the components of a system
       should all be related relative to each other and only one component should relate to
       the reference coordinate system.
+  \@default:
+    doc: |
+      .. index:: plotting
+      
+      Declares which child group contains a path leading
+      to a :ref:`NXdata` group.
+      
+      It is recommended (as of NIAC2014) to use this attribute
+      to help define the path to the default dataset to be plotted.
+      See https://www.nexusformat.org/2014_How_to_find_default_data.html
+      for a summary of the discussion.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 731460d96b884c5a34ca39f81fcde2fbde397b23fe36bbbddc1ddf0c051c5fdf
+# e89833fc28b832f73564da2bfcea931ca31dbf1e6723fdadc68eeb38eb667ec8
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -322,4 +333,17 @@ NXenergydispersion(NXobject):
 #              the reference coordinate system.
 #         </doc>
 #     </group>
+#     <attribute name="default">
+#         <doc>
+#              .. index:: plotting
+#              
+#              Declares which child group contains a path leading
+#              to a :ref:`NXdata` group.
+#              
+#              It is recommended (as of NIAC2014) to use this attribute
+#              to help define the path to the default dataset to be plotted.
+#              See https://www.nexusformat.org/2014_How_to_find_default_data.html
+#              for a summary of the discussion.
+#         </doc>
+#     </attribute>
 # </definition>

--- a/contributed_definitions/nyaml/NXmanipulator.yaml
+++ b/contributed_definitions/nyaml/NXmanipulator.yaml
@@ -148,10 +148,21 @@ NXmanipulator(NXobject):
       relative to the experimental setup. Typically, the components of a system should
       all be related relative to each other and only one component should relate to
       the reference coordinate system.
+  \@default:
+    doc: |
+      .. index:: plotting
+      
+      Declares which child group contains a path leading
+      to a :ref:`NXdata` group.
+      
+      It is recommended (as of NIAC2014) to use this attribute
+      to help define the path to the default dataset to be plotted.
+      See https://www.nexusformat.org/2014_How_to_find_default_data.html
+      for a summary of the discussion.
   (NXfabrication):
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 08d47f40a1d7fee3cd364f477c76cb02e60194cdcd1c00ff53d9b4e24d025ebd
+# 1e84ea091f45dce3534d71bb2766b0df2951875fac92d3c255ba90138ece3f05
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -394,5 +405,18 @@ NXmanipulator(NXobject):
 #              the reference coordinate system.
 #         </doc>
 #     </group>
+#     <attribute name="default">
+#         <doc>
+#              .. index:: plotting
+#              
+#              Declares which child group contains a path leading
+#              to a :ref:`NXdata` group.
+#              
+#              It is recommended (as of NIAC2014) to use this attribute
+#              to help define the path to the default dataset to be plotted.
+#              See https://www.nexusformat.org/2014_How_to_find_default_data.html
+#              for a summary of the discussion.
+#         </doc>
+#     </attribute>
 #     <group type="NXfabrication"/>
 # </definition>

--- a/contributed_definitions/nyaml/NXpid.yaml
+++ b/contributed_definitions/nyaml/NXpid.yaml
@@ -56,9 +56,20 @@ NXpid(NXobject):
       gain) and P/T (proportional gain/time constant). The formula for the controller
       in the frequency domain is G(s) = P + I/s = P(1 + 1/(Ts)). The integral gain and
       time constant are related as follows I = P/T.
+  \@default:
+    doc: |
+      .. index:: plotting
+      
+      Declares which child group contains a path leading
+      to a :ref:`NXdata` group.
+      
+      It is recommended (as of NIAC2014) to use this attribute
+      to help define the path to the default dataset to be plotted.
+      See https://www.nexusformat.org/2014_How_to_find_default_data.html
+      for a summary of the discussion.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# aadcc7fe3aacdc2888a03ae22cc82dc7e65996a3dce2e0af4d6bd0a9fcfcecee
+# f7e9d17617b925bb83d4b43f19f7a739ce4023290ecdec013a07c0a3d3d8ac7f
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -156,4 +167,17 @@ NXpid(NXobject):
 #              time constant are related as follows I = P/T.
 #         </doc>
 #     </field>
+#     <attribute name="default">
+#         <doc>
+#              .. index:: plotting
+#              
+#              Declares which child group contains a path leading
+#              to a :ref:`NXdata` group.
+#              
+#              It is recommended (as of NIAC2014) to use this attribute
+#              to help define the path to the default dataset to be plotted.
+#              See https://www.nexusformat.org/2014_How_to_find_default_data.html
+#              for a summary of the discussion.
+#         </doc>
+#     </attribute>
 # </definition>

--- a/contributed_definitions/nyaml/NXresolution.yaml
+++ b/contributed_definitions/nyaml/NXresolution.yaml
@@ -58,12 +58,23 @@ NXresolution(NXobject):
       A resolution formula to determine the resolution from a set of symbols as
       entered by the `formula_...` fields.
       The output unit should match the provided unit of this field.
+  \@default:
+    doc: |
+      .. index:: plotting
+      
+      Declares which child group contains a path leading
+      to a :ref:`NXdata` group.
+      
+      It is recommended (as of NIAC2014) to use this attribute
+      to help define the path to the default dataset to be plotted.
+      See https://www.nexusformat.org/2014_How_to_find_default_data.html
+      for a summary of the discussion.
   (NXcalibration):
     doc: |
       For storing details and data of a calibration to derive a resolution from data.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# e5aafac1e871d8ce6e9713e824e04a5c58057f09048999936ebd9ffac7c1fc4d
+# 354ca53d42e75b920aa0abc13f3156051cf9d0bcfd1a61ff852d0ba6d763da6c
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -170,6 +181,19 @@ NXresolution(NXobject):
 #              The output unit should match the provided unit of this field.
 #         </doc>
 #     </field>
+#     <attribute name="default">
+#         <doc>
+#              .. index:: plotting
+#              
+#              Declares which child group contains a path leading
+#              to a :ref:`NXdata` group.
+#              
+#              It is recommended (as of NIAC2014) to use this attribute
+#              to help define the path to the default dataset to be plotted.
+#              See https://www.nexusformat.org/2014_How_to_find_default_data.html
+#              for a summary of the discussion.
+#         </doc>
+#     </attribute>
 #     <group type="NXcalibration">
 #         <doc>
 #              For storing details and data of a calibration to derive a resolution from data.


### PR DESCRIPTION
This allows for more flexibility when defining the default chain within NXmpes NeXus files.