### PR TITLE
Temporarily use NXdata in NXmpes_arpes

### DIFF
--- a/contributed_definitions/NXmpes_arpes.nxdl.xml
+++ b/contributed_definitions/NXmpes_arpes.nxdl.xml
@@ -21,7 +21,7 @@
 #
 # For further information, see http://www.nexusformat.org
 -->
-<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" name="NXmpes_arpes" extends="NXmpes" type="group" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXmpes_arpes" extends="NXmpes" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
     <!--
 Pincelli, Rettig, Arora at fhi-berlin.mpg.de, Dobener at hu-berlin.de, 06/2022
 Draft version of a NeXus application definition for angle resolved photoemission.
@@ -334,21 +334,28 @@ with higher granularity in the data description.
                 </field>
             </group>
         </group>
-        <group name="data" type="NXdata_mpes">
+        <group name="data" type="NXdata">
             <attribute name="signal">
+                <doc>
+                     There is an object named data that contains the signal.
+                </doc>
                 <enumeration>
                     <item value="data"/>
                 </enumeration>
             </attribute>
             <attribute name="axes">
+                <doc>
+                     There are three dimensions, one energy and two angular coordinates. Any coordinates that do not move,
+                     are represented by one point.
+                </doc>
                 <enumeration>
-                    <item value="[angular0, angular1, energy]"/>
+                    <item value="['angular0', 'angular1', 'energy']"/>
                 </enumeration>
             </attribute>
             <attribute name="energy_indices"/>
             <attribute name="angular0_indices"/>
             <attribute name="angular1_indices"/>
-            <attribute name="angular0_depends" type="NX_CHAR">
+            <attribute name="angular0_depends">
                 <doc>
                      Points to the path to a field defining the axis on which the angular axis depends.
                      For example:
@@ -358,7 +365,7 @@ with higher granularity in the data description.
                      @angular0_depends: '/entry/process/calibration/angular0_calibration/calibrated_axis' for a preprocessed axis.
                 </doc>
             </attribute>
-            <attribute name="angular1_depends" type="NX_CHAR">
+            <attribute name="angular1_depends">
                 <doc>
                      Points to the path to a field defining the axis on which the angular axis depends.
                      For example:
@@ -368,7 +375,7 @@ with higher granularity in the data description.
                      @angular1_depends: '/entry/process/calibration/angular1_calibration/calibrated_axis' for a preprocessed axis.
                 </doc>
             </attribute>
-            <attribute name="energy_depends" type="NX_CHAR">
+            <attribute name="energy_depends">
                 <doc>
                      Points to the path to a field defining the axis on which the energy axis depends.
                      For example:

--- a/contributed_definitions/nyaml/NXmpes_arpes.yaml
+++ b/contributed_definitions/nyaml/NXmpes_arpes.yaml
@@ -1,17 +1,20 @@
-#Pincelli, Rettig, Arora at fhi-berlin.mpg.de, Dobener at hu-berlin.de, 06/2022
-#Draft version of a NeXus application definition for angle resolved photoemission.
-#This appdef aims to describe data produced from hemispherical analysers,
-#with at least an angular coordinate and one energy coordinate.
-#It is designed to be extended by other application definitions
-#with higher granularity in the data description.
-
-doc: This is an general application definition for angle-resolved multidimensional photoelectron spectroscopy.
 category: application
+
+# Pincelli, Rettig, Arora at fhi-berlin.mpg.de, Dobener at hu-berlin.de, 06/2022
+# Draft version of a NeXus application definition for angle resolved photoemission.
+# This appdef aims to describe data produced from hemispherical analysers,
+# with at least an angular coordinate and one energy coordinate.
+# It is designed to be extended by other application definitions
+# with higher granularity in the data description.
+doc: |
+  This is an general application definition for angle-resolved multidimensional
+  photoelectron spectroscopy.
+type: group
 NXmpes_arpes(NXmpes):
   (NXentry):
     definition:
       \@version:
-      enumeration: ["NXmpes_arpes"]
+      enumeration: [NXmpes_arpes]
     geometries(NXcoordinate_system_set):
       arpes_geometry(NXcoordinate_system):
         depends_on(NX_CHAR):
@@ -26,8 +29,7 @@ NXmpes_arpes(NXmpes):
     (NXinstrument):
       angularN_resolution(NXresolution):
         exists: recommended
-        doc:
-        - |
+        doc: |
           Overall angular resolution along the Nth angular axis. Create one such entry per relevant angular axis,
           corresponding to the angular axes in NXdata.
           For hemispherical analyzers, angular0_resolution corresponds to the direction along the analyzer slit,
@@ -41,8 +43,7 @@ NXmpes_arpes(NXmpes):
       (NXelectronanalyser):
         angularN_resolution(NXresolution):
           exists: recommended
-          doc:
-          - |
+          doc: |
             Analyzer angular resolution along the Nth angular axis.
             Create one such entry per relevant angular axis, corresponding to the angular axes in NXdata.
             For hemispherical analyzers, angular0_resolution corresponds to the direction along the analyzer slit,
@@ -62,49 +63,48 @@ NXmpes_arpes(NXmpes):
             Set of transformations, describing the relative orientation of the analyzer
             with respect to the beam coordinate system (.).
           analyzer_rotation(NX_NUMBER):
+            unit: NX_ANGLE
             doc: |
               Rotation about the analyzer lens axis.
               Its zero reference is defined such that the angular0 axis is
               increasing towards the positive y axis (analyzer slit vertical).
-            unit: NX_ANGLE
             \@transformation_type:
-              enumeration: ["rotation"]
+              enumeration: [rotation]
             \@vector:
-              enumeration: ["[0, 0, 1]"]
+              enumeration: [[0, 0, 1]]
             \@depends_on:
               doc: |
-                Path to a transformation that places the analyzer origin system into the arpes_geometry coordinate system.
+                Path to a transformation that places the analyzer origin system into the
+                arpes_geometry coordinate system.
           analyzer_elevation(NX_NUMBER):
-            doc: 
-              Elevation of the effective analyzer acceptance area,
-              e.g. realized by deflectors, or as one angle in a TOF detector.
-              If a resolved angle, place the calibrated axis coordinates here.
             unit: NX_ANGLE
+            doc: |
+              Elevation of the effective analyzer acceptance area, e.g. realized by
+              deflectors, or as one angle in a TOF detector. If a resolved angle, place the
+              calibrated axis coordinates here.
             \@transformation_type:
-              enumeration: ["rotation"]
+              enumeration: [rotation]
             \@vector:
-              enumeration: ["[0, 1, 0]"]
+              enumeration: [[0, 1, 0]]
             \@depends_on:
-              enumeration: ["analyzer_dispersion"]
+              enumeration: [analyzer_dispersion]
           analyzer_dispersion(NX_NUMBER):
+            unit: NX_ANGLE
             doc: |
               In-plane analyzer coordinate along a dispersive direction,
               e.g. along an analyzer slit. If a resolved angle, place the calibrated coordinates here.
-            unit: NX_ANGLE
             \@transformation_type:
-              enumeration: ["rotation"]
+              enumeration: [rotation]
             \@vector:
-              enumeration: ["[1, 0, 0]"]
+              enumeration: [[1, 0, 0]]
             \@depends_on:
-              enumeration: ["analyzer_rotation"]
+              enumeration: [analyzer_rotation]
         (NXcollectioncolumn):
           scheme:
             exists: recommended
-            doc: "Scheme of the electron collection column."
-            enumeration: [
-              "angular dispersive",
-              "non-dispersive",
-            ]
+            doc: |
+              Scheme of the electron collection column.
+            enumeration: [angular dispersive, non-dispersive]
           angular_acceptance(NX_FLOAT):
             exists: recommended
         (NXenergydispersion):
@@ -114,13 +114,10 @@ NXmpes_arpes(NXmpes):
           entrance_slit(NXaperture):
             exists: recommended
             shape:
-              enumeration: [
-                "straight slit",
-                "curved slit",
-              ]
+              enumeration: [straight slit, curved slit]
     (NXsample):
       situation:
-        enumeration: ["vacuum"]
+        enumeration: [vacuum]
       depends_on(NX_CHAR):
         doc: |
           Reference to the end of the transformation chain,
@@ -131,70 +128,81 @@ NXmpes_arpes(NXmpes):
           Set of transformations, describing the relative orientation of the sample
           with respect to the arpes_geometry coordinate system.
         sample_polar(NX_NUMBER):
-          doc: "Rotation about the y axis (typically the long manipulator axis)."
           unit: NX_ANGLE
+          doc: |
+            Rotation about the y axis (typically the long manipulator axis).
           \@transformation_type:
-            enumeration: ["rotation"]
+            enumeration: [rotation]
           \@vector:
-            enumeration: ["[0, 1, 0]"]
+            enumeration: [[0, 1, 0]]
           \@depends_on:
             doc: |
               Path to a transformation that places the sample surface
               into the origin of the arpes_geometry coordinate system.
         offset_polar(NX_NUMBER):
-          doc: "Offset of polar rotation."
           unit: NX_ANGLE
+          doc: |
+            Offset of polar rotation.
           \@transformation_type:
-            enumeration: ["rotation"]
+            enumeration: [rotation]
           \@vector:
-            enumeration: ["[0, 1, 0]"]
+            enumeration: [[0, 1, 0]]
           \@depends_on:
-            enumeration: ["sample_polar"]
+            enumeration: [sample_polar]
         sample_tilt(NX_NUMBER):
-          doc: "Rotation about the x axis (typically a manipulator tilt)."
           unit: NX_ANGLE
+          doc: |
+            Rotation about the x axis (typically a manipulator tilt).
           \@transformation_type:
-            enumeration: ["rotation"]
+            enumeration: [rotation]
           \@vector:
-            enumeration: ["[1, 0, 0]"]
+            enumeration: [[1, 0, 0]]
           \@depends_on:
-            enumeration: ["offset_polar"]
+            enumeration: [offset_polar]
         offset_tilt(NX_NUMBER):
-          doc: "Offset of tilt rotation."
           unit: NX_ANGLE
+          doc: |
+            Offset of tilt rotation.
           \@transformation_type:
-            enumeration: ["rotation"]
+            enumeration: [rotation]
           \@vector:
-            enumeration: ["[1, 0, 0]"]
+            enumeration: [[1, 0, 0]]
           \@depends_on:
-            enumeration: ["sample_tilt"]
+            enumeration: [sample_tilt]
         sample_azimuth(NX_NUMBER):
-          doc: "Rotation about the z axis (azimuthal rotation within the sample plane)."
           unit: NX_ANGLE
+          doc: |
+            Rotation about the z axis (azimuthal rotation within the sample plane).
           \@transformation_type:
-            enumeration: ["rotation"]
+            enumeration: [rotation]
           \@vector:
-            enumeration: ["[0, 0, 1]"]
+            enumeration: [[0, 0, 1]]
           \@depends_on:
-            enumeration: ["offset_tilt"]
+            enumeration: [offset_tilt]
         offset_azimuth(NX_NUMBER):
-          doc: "Offset of azimuthal rotation."
           unit: NX_ANGLE
+          doc: |
+            Offset of azimuthal rotation.
           \@transformation_type:
-            enumeration: ["rotation"]
+            enumeration: [rotation]
           \@vector:
-            enumeration: ["[0, 0, 1]"]
+            enumeration: [[0, 0, 1]]
           \@depends_on:
-            enumeration: ["sample_azimuth"]
-    data(NXdata_mpes):
+            enumeration: [sample_azimuth]
+    data(NXdata):
       \@signal:
-        enumeration: ["data"] # There is an object named data that contains the signal
-      \@axes: # There are three dimensions, one energy & two angular coordinates. Any coordinates that do not move, are represented by one point.
-        enumeration: ["[angular0, angular1, energy]"]
-      \@energy_indices: # energy indices have to be provided
-      \@angular0_indices: # angular0 indices have to be provided
-      \@angular1_indices: # angular1 indices have to be provided
-      \@angular0_depends(NX_CHAR):
+        doc: |
+          There is an object named data that contains the signal.
+        enumeration: [data]
+      \@axes:
+        doc: |
+          There are three dimensions, one energy and two angular coordinates. Any coordinates that do not move,
+          are represented by one point.
+        enumeration: [['angular0', 'angular1', 'energy']]
+      \@energy_indices:
+      \@angular0_indices:
+      \@angular1_indices:
+      \@angular0_depends:
         doc: |
           Points to the path to a field defining the axis on which the angular axis depends.
           For example:
@@ -202,7 +210,7 @@ NXmpes_arpes(NXmpes):
           @angular0_depends: '/entry/instrument/detector/sensor_x' for a 2D detector
           @angular0_depends: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
           @angular0_depends: '/entry/process/calibration/angular0_calibration/calibrated_axis' for a preprocessed axis.
-      \@angular1_depends(NX_CHAR):
+      \@angular1_depends:
         doc: |
           Points to the path to a field defining the axis on which the angular axis depends.
           For example:
@@ -210,7 +218,7 @@ NXmpes_arpes(NXmpes):
           @angular1_depends: '/entry/instrument/detector/sensor_x' for a 2D detector
           @angular1_depends: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
           @angular1_depends: '/entry/process/calibration/angular1_calibration/calibrated_axis' for a preprocessed axis.
-      \@energy_depends(NX_CHAR): # Similarly, energy can be dispersed according to different strategies
+      \@energy_depends:
         doc: |
           Points to the path to a field defining the axis on which the energy axis depends.
           For example:
@@ -218,17 +226,440 @@ NXmpes_arpes(NXmpes):
           @energy_depends: '/entry/instrument/energydispersion/center_kinetic_energy' for a swept scan
           @energy_depends: '/entry/process/calibration/energy_calibration/calibrated_axis' for a preprocessed axis.
       energy(NX_NUMBER):
-        doc: "Trace of the energy axis. Could be linked from the respective 'AXISNAME_depends' field."
         unit: NY_ENERGY
+        doc: |
+          Trace of the energy axis. Could be linked from the respective 'AXISNAME_depends'
+          field.
       angular0(NX_NUMBER):
-        doc: "Trace of the first angular axis. Could be linked from the respective 'AXISNAME_depends' field."
         unit: NX_ANGLE
+        doc: |
+          Trace of the first angular axis. Could be linked from the respective
+          'AXISNAME_depends' field.
       angular1(NX_NUMBER):
-        doc: "Trace of the second axis. Could be linked from the respective 'AXISNAME_depends' field."
         unit: ANX_ANGLE
-      data(NX_NUMBER): # There is a block of numbers named data.
+        doc: |
+          Trace of the second axis. Could be linked from the respective 'AXISNAME_depends'
+          field.
+      data(NX_NUMBER):
+        unit: NX_ANY
         doc: |
           Represents a measure of three-dimensional photoemission counts, where
           the varied axes are energy, and one or more angular coordinates. Axes traces
           should be linked to the actual encoder position in NXinstrument or calibrated axes in NXprocess.
-        unit: NX_ANY
+
+# ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
+# b550ab06085897f916a57c3670dbe3222913b72b29731c6ba6cd0d5d4f1e160f
+# <?xml version='1.0' encoding='UTF-8'?>
+# <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+# <!--
+# # NeXus - Neutron and X-ray Common Data Format
+# #
+# # Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+# #
+# # This library is free software; you can redistribute it and/or
+# # modify it under the terms of the GNU Lesser General Public
+# # License as published by the Free Software Foundation; either
+# # version 3 of the License, or (at your option) any later version.
+# #
+# # This library is distributed in the hope that it will be useful,
+# # but WITHOUT ANY WARRANTY; without even the implied warranty of
+# # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# # Lesser General Public License for more details.
+# #
+# # You should have received a copy of the GNU Lesser General Public
+# # License along with this library; if not, write to the Free Software
+# # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# #
+# # For further information, see http://www.nexusformat.org
+# -->
+# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXmpes_arpes" extends="NXmpes" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+#     <!--
+# Pincelli, Rettig, Arora at fhi-berlin.mpg.de, Dobener at hu-berlin.de, 06/2022
+# Draft version of a NeXus application definition for angle resolved photoemission.
+# This appdef aims to describe data produced from hemispherical analysers,
+# with at least an angular coordinate and one energy coordinate.
+# It is designed to be extended by other application definitions
+# with higher granularity in the data description.
+# -->
+#     <doc>
+#          This is an general application definition for angle-resolved multidimensional
+#          photoelectron spectroscopy.
+#     </doc>
+#     <group type="NXentry">
+#         <field name="definition">
+#             <attribute name="version"/>
+#             <enumeration>
+#                 <item value="NXmpes_arpes"/>
+#             </enumeration>
+#         </field>
+#         <group name="geometries" type="NXcoordinate_system_set">
+#             <group name="arpes_geometry" type="NXcoordinate_system">
+#                 <field name="depends_on" type="NX_CHAR">
+#                     <doc>
+#                          Link to transformations defining an APRES base coordinate system,
+#                          which is defined such that the positive z-axis points towards the analyzer entry,
+#                          and the x-axis lies within the beam/analyzer plane.
+#                     </doc>
+#                 </field>
+#                 <group type="NXtransformations">
+#                     <doc>
+#                          Set of transformations, describing the orientation of the ARPES coordinate system
+#                          with respect to the beam coordinate system (.).
+#                     </doc>
+#                 </group>
+#             </group>
+#         </group>
+#         <group type="NXinstrument">
+#             <group name="angularN_resolution" type="NXresolution" recommended="true">
+#                 <doc>
+#                      Overall angular resolution along the Nth angular axis. Create one such entry per relevant angular axis,
+#                      corresponding to the angular axes in NXdata.
+#                      For hemispherical analyzers, angular0_resolution corresponds to the direction along the analyzer slit,
+#                      and angular1_resolution to the one perpendicular to it.
+#                 </doc>
+#                 <field name="physical_quantity">
+#                     <enumeration>
+#                         <item value="angle"/>
+#                     </enumeration>
+#                 </field>
+#                 <field name="type" recommended="true"/>
+#                 <field name="resolution" type="NX_FLOAT" units="NX_ANGLE"/>
+#             </group>
+#             <group type="NXelectronanalyser">
+#                 <group name="angularN_resolution" type="NXresolution" recommended="true">
+#                     <doc>
+#                          Analyzer angular resolution along the Nth angular axis.
+#                          Create one such entry per relevant angular axis, corresponding to the angular axes in NXdata.
+#                          For hemispherical analyzers, angular0_resolution corresponds to the direction along the analyzer slit,
+#                          and angular1_resolution to the one perpendicular to it.
+#                     </doc>
+#                     <field name="physical_quantity">
+#                         <enumeration>
+#                             <item value="angle"/>
+#                         </enumeration>
+#                     </field>
+#                     <field name="type" recommended="true"/>
+#                     <field name="resolution" type="NX_FLOAT" units="NX_ANGLE"/>
+#                 </group>
+#                 <field name="depends_on" type="NX_CHAR">
+#                     <doc>
+#                          Reference to the last transformation describing the orientation of the analyzer relative to the beam,
+#                          e.g. transformations/analyzer_elevation.
+#                     </doc>
+#                 </field>
+#                 <group name="transformations" type="NXtransformations">
+#                     <doc>
+#                          Set of transformations, describing the relative orientation of the analyzer
+#                          with respect to the beam coordinate system (.).
+#                     </doc>
+#                     <field name="analyzer_rotation" type="NX_NUMBER" units="NX_ANGLE">
+#                         <doc>
+#                              Rotation about the analyzer lens axis.
+#                              Its zero reference is defined such that the angular0 axis is
+#                              increasing towards the positive y axis (analyzer slit vertical).
+#                         </doc>
+#                         <attribute name="transformation_type">
+#                             <enumeration>
+#                                 <item value="rotation"/>
+#                             </enumeration>
+#                         </attribute>
+#                         <attribute name="vector">
+#                             <enumeration>
+#                                 <item value="[0, 0, 1]"/>
+#                             </enumeration>
+#                         </attribute>
+#                         <attribute name="depends_on">
+#                             <doc>
+#                                  Path to a transformation that places the analyzer origin system into the
+#                                  arpes_geometry coordinate system.
+#                             </doc>
+#                         </attribute>
+#                     </field>
+#                     <field name="analyzer_elevation" type="NX_NUMBER" units="NX_ANGLE">
+#                         <doc>
+#                              Elevation of the effective analyzer acceptance area, e.g. realized by
+#                              deflectors, or as one angle in a TOF detector. If a resolved angle, place the
+#                              calibrated axis coordinates here.
+#                         </doc>
+#                         <attribute name="transformation_type">
+#                             <enumeration>
+#                                 <item value="rotation"/>
+#                             </enumeration>
+#                         </attribute>
+#                         <attribute name="vector">
+#                             <enumeration>
+#                                 <item value="[0, 1, 0]"/>
+#                             </enumeration>
+#                         </attribute>
+#                         <attribute name="depends_on">
+#                             <enumeration>
+#                                 <item value="analyzer_dispersion"/>
+#                             </enumeration>
+#                         </attribute>
+#                     </field>
+#                     <field name="analyzer_dispersion" type="NX_NUMBER" units="NX_ANGLE">
+#                         <doc>
+#                              In-plane analyzer coordinate along a dispersive direction,
+#                              e.g. along an analyzer slit. If a resolved angle, place the calibrated coordinates here.
+#                         </doc>
+#                         <attribute name="transformation_type">
+#                             <enumeration>
+#                                 <item value="rotation"/>
+#                             </enumeration>
+#                         </attribute>
+#                         <attribute name="vector">
+#                             <enumeration>
+#                                 <item value="[1, 0, 0]"/>
+#                             </enumeration>
+#                         </attribute>
+#                         <attribute name="depends_on">
+#                             <enumeration>
+#                                 <item value="analyzer_rotation"/>
+#                             </enumeration>
+#                         </attribute>
+#                     </field>
+#                 </group>
+#                 <group type="NXcollectioncolumn">
+#                     <field name="scheme" recommended="true">
+#                         <doc>
+#                              Scheme of the electron collection column.
+#                         </doc>
+#                         <enumeration>
+#                             <item value="angular dispersive"/>
+#                             <item value="non-dispersive"/>
+#                         </enumeration>
+#                     </field>
+#                     <field name="angular_acceptance" type="NX_FLOAT" recommended="true"/>
+#                 </group>
+#                 <group type="NXenergydispersion">
+#                     <field name="diameter" type="NX_NUMBER" recommended="true" units="NX_LENGTH"/>
+#                     <group name="entrance_slit" type="NXaperture" recommended="true">
+#                         <field name="shape">
+#                             <enumeration>
+#                                 <item value="straight slit"/>
+#                                 <item value="curved slit"/>
+#                             </enumeration>
+#                         </field>
+#                     </group>
+#                 </group>
+#             </group>
+#         </group>
+#         <group type="NXsample">
+#             <field name="situation">
+#                 <enumeration>
+#                     <item value="vacuum"/>
+#                 </enumeration>
+#             </field>
+#             <field name="depends_on" type="NX_CHAR">
+#                 <doc>
+#                      Reference to the end of the transformation chain,
+#                      orienting the sample surface within the arpes_geometry coordinate system
+#                      (sample_azimuth or anything depending on it).
+#                 </doc>
+#             </field>
+#             <group name="transformations" type="NXtransformations">
+#                 <doc>
+#                      Set of transformations, describing the relative orientation of the sample
+#                      with respect to the arpes_geometry coordinate system.
+#                 </doc>
+#                 <field name="sample_polar" type="NX_NUMBER" units="NX_ANGLE">
+#                     <doc>
+#                          Rotation about the y axis (typically the long manipulator axis).
+#                     </doc>
+#                     <attribute name="transformation_type">
+#                         <enumeration>
+#                             <item value="rotation"/>
+#                         </enumeration>
+#                     </attribute>
+#                     <attribute name="vector">
+#                         <enumeration>
+#                             <item value="[0, 1, 0]"/>
+#                         </enumeration>
+#                     </attribute>
+#                     <attribute name="depends_on">
+#                         <doc>
+#                              Path to a transformation that places the sample surface
+#                              into the origin of the arpes_geometry coordinate system.
+#                         </doc>
+#                     </attribute>
+#                 </field>
+#                 <field name="offset_polar" type="NX_NUMBER" units="NX_ANGLE">
+#                     <doc>
+#                          Offset of polar rotation.
+#                     </doc>
+#                     <attribute name="transformation_type">
+#                         <enumeration>
+#                             <item value="rotation"/>
+#                         </enumeration>
+#                     </attribute>
+#                     <attribute name="vector">
+#                         <enumeration>
+#                             <item value="[0, 1, 0]"/>
+#                         </enumeration>
+#                     </attribute>
+#                     <attribute name="depends_on">
+#                         <enumeration>
+#                             <item value="sample_polar"/>
+#                         </enumeration>
+#                     </attribute>
+#                 </field>
+#                 <field name="sample_tilt" type="NX_NUMBER" units="NX_ANGLE">
+#                     <doc>
+#                          Rotation about the x axis (typically a manipulator tilt).
+#                     </doc>
+#                     <attribute name="transformation_type">
+#                         <enumeration>
+#                             <item value="rotation"/>
+#                         </enumeration>
+#                     </attribute>
+#                     <attribute name="vector">
+#                         <enumeration>
+#                             <item value="[1, 0, 0]"/>
+#                         </enumeration>
+#                     </attribute>
+#                     <attribute name="depends_on">
+#                         <enumeration>
+#                             <item value="offset_polar"/>
+#                         </enumeration>
+#                     </attribute>
+#                 </field>
+#                 <field name="offset_tilt" type="NX_NUMBER" units="NX_ANGLE">
+#                     <doc>
+#                          Offset of tilt rotation.
+#                     </doc>
+#                     <attribute name="transformation_type">
+#                         <enumeration>
+#                             <item value="rotation"/>
+#                         </enumeration>
+#                     </attribute>
+#                     <attribute name="vector">
+#                         <enumeration>
+#                             <item value="[1, 0, 0]"/>
+#                         </enumeration>
+#                     </attribute>
+#                     <attribute name="depends_on">
+#                         <enumeration>
+#                             <item value="sample_tilt"/>
+#                         </enumeration>
+#                     </attribute>
+#                 </field>
+#                 <field name="sample_azimuth" type="NX_NUMBER" units="NX_ANGLE">
+#                     <doc>
+#                          Rotation about the z axis (azimuthal rotation within the sample plane).
+#                     </doc>
+#                     <attribute name="transformation_type">
+#                         <enumeration>
+#                             <item value="rotation"/>
+#                         </enumeration>
+#                     </attribute>
+#                     <attribute name="vector">
+#                         <enumeration>
+#                             <item value="[0, 0, 1]"/>
+#                         </enumeration>
+#                     </attribute>
+#                     <attribute name="depends_on">
+#                         <enumeration>
+#                             <item value="offset_tilt"/>
+#                         </enumeration>
+#                     </attribute>
+#                 </field>
+#                 <field name="offset_azimuth" type="NX_NUMBER" units="NX_ANGLE">
+#                     <doc>
+#                          Offset of azimuthal rotation.
+#                     </doc>
+#                     <attribute name="transformation_type">
+#                         <enumeration>
+#                             <item value="rotation"/>
+#                         </enumeration>
+#                     </attribute>
+#                     <attribute name="vector">
+#                         <enumeration>
+#                             <item value="[0, 0, 1]"/>
+#                         </enumeration>
+#                     </attribute>
+#                     <attribute name="depends_on">
+#                         <enumeration>
+#                             <item value="sample_azimuth"/>
+#                         </enumeration>
+#                     </attribute>
+#                 </field>
+#             </group>
+#         </group>
+#         <group name="data" type="NXdata">
+#             <attribute name="signal">
+#                 <doc>
+#                      There is an object named data that contains the signal.
+#                 </doc>
+#                 <enumeration>
+#                     <item value="data"/>
+#                 </enumeration>
+#             </attribute>
+#             <attribute name="axes">
+#                 <doc>
+#                      There are three dimensions, one energy and two angular coordinates. Any coordinates that do not move,
+#                      are represented by one point.
+#                 </doc>
+#                 <enumeration>
+#                     <item value="['angular0', 'angular1', 'energy']"/>
+#                 </enumeration>
+#             </attribute>
+#             <attribute name="energy_indices"/>
+#             <attribute name="angular0_indices"/>
+#             <attribute name="angular1_indices"/>
+#             <attribute name="angular0_depends">
+#                 <doc>
+#                      Points to the path to a field defining the axis on which the angular axis depends.
+#                      For example:
+#                      @angular0_depends: '/entry/sample/transformations/sample_tilt' for a manipulator angular scan
+#                      @angular0_depends: '/entry/instrument/detector/sensor_x' for a 2D detector
+#                      @angular0_depends: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
+#                      @angular0_depends: '/entry/process/calibration/angular0_calibration/calibrated_axis' for a preprocessed axis.
+#                 </doc>
+#             </attribute>
+#             <attribute name="angular1_depends">
+#                 <doc>
+#                      Points to the path to a field defining the axis on which the angular axis depends.
+#                      For example:
+#                      @angular1_depends: '/entry/sample/transformations/sample_polar' for a manipulator angular scan
+#                      @angular1_depends: '/entry/instrument/detector/sensor_x' for a 2D detector
+#                      @angular1_depends: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
+#                      @angular1_depends: '/entry/process/calibration/angular1_calibration/calibrated_axis' for a preprocessed axis.
+#                 </doc>
+#             </attribute>
+#             <attribute name="energy_depends">
+#                 <doc>
+#                      Points to the path to a field defining the axis on which the energy axis depends.
+#                      For example:
+#                      @energy_depends: '/entry/instrument/detector/sensor_y' for a 2D detector
+#                      @energy_depends: '/entry/instrument/energydispersion/center_kinetic_energy' for a swept scan
+#                      @energy_depends: '/entry/process/calibration/energy_calibration/calibrated_axis' for a preprocessed axis.
+#                 </doc>
+#             </attribute>
+#             <field name="energy" type="NX_NUMBER" units="NY_ENERGY">
+#                 <doc>
+#                      Trace of the energy axis. Could be linked from the respective 'AXISNAME_depends'
+#                      field.
+#                 </doc>
+#             </field>
+#             <field name="angular0" type="NX_NUMBER" units="NX_ANGLE">
+#                 <doc>
+#                      Trace of the first angular axis. Could be linked from the respective
+#                      'AXISNAME_depends' field.
+#                 </doc>
+#             </field>
+#             <field name="angular1" type="NX_NUMBER" units="ANX_ANGLE">
+#                 <doc>
+#                      Trace of the second axis. Could be linked from the respective 'AXISNAME_depends'
+#                      field.
+#                 </doc>
+#             </field>
+#             <field name="data" type="NX_NUMBER" units="NX_ANY">
+#                 <doc>
+#                      Represents a measure of three-dimensional photoemission counts, where
+#                      the varied axes are energy, and one or more angular coordinates. Axes traces
+#                      should be linked to the actual encoder position in NXinstrument or calibrated axes in NXprocess.
+#                 </doc>
+#             </field>
+#         </group>
+#     </group>
+# </definition>


### PR DESCRIPTION
The nyaml file was changed a bit because I also ran the backwards conversion. Note that inline comments in the nyaml are not being picked up during the nyaml2nxdl conversion. I either removed unneeded comments or put them into the official docs.

Eventually, we need to discuss how we want to handle the issue that NXdata derived base classes are not recognized as NXdata. This is probably also a problem for other tools that don't have base class extensions yet.

Fixes #233 