### PR TITLE
Small modifications to clarify NXmpes

### DIFF
--- a/base_classes/NXbeam.nxdl.xml
+++ b/base_classes/NXbeam.nxdl.xml
@@ -228,7 +228,7 @@
     </field>
     <field name="final_polarization" type="NX_NUMBER" units="NX_ANY">
         <doc>
-             Polarization as Stokes vector on leaving beamline component
+             Polarization vector on leaving beamline component
         </doc>
         <dimensions rank="2">
             <dim index="1" value="nP"/>

--- a/base_classes/NXbeam.nxdl.xml
+++ b/base_classes/NXbeam.nxdl.xml
@@ -225,6 +225,24 @@
             <dim index="1" value="nP"/>
             <dim index="2" value="2"/>
         </dimensions>
+        <attribute name="units" type="NX_CHAR">
+            <doc>
+                 The units for this observable are not included in the NIAC list.
+                 Responsibility on correct formatting and parsing is handed to the user
+                 by using `NX_ANY`. Correct parsing can still be implemented by using
+                 this attribute.
+                 
+                 | Fill with:
+                 
+                 * The unit unidata symbol if the unit has one (Example: T for the unit of magnetic flux density tesla).
+                 * The unit unidata name if the unit has a name (Example: farad for capacitance).
+                 * A string describing the units according to unidata unit operation notation, if the unit is a complex combination of named units and
+                   does not have a name.
+                 
+                 Example: for lightsource brilliance (SI) 1/(s.mm2.mrad2).
+                 Here: SI units are V2/m2.
+            </doc>
+        </attribute>
     </field>
     <field name="final_polarization" type="NX_NUMBER" units="NX_ANY">
         <doc>
@@ -234,6 +252,24 @@
             <dim index="1" value="nP"/>
             <dim index="2" value="2"/>
         </dimensions>
+        <attribute name="units" type="NX_CHAR">
+            <doc>
+                 The units for this observable are not included in the NIAC list.
+                 Responsibility on correct formatting and parsing is handed to the user
+                 by using `NX_ANY`. Correct parsing can still be implemented by using
+                 this attribute.
+                 
+                 | Fill with:
+                 
+                 * The unit unidata symbol if the unit has one (Example: T for the unit of magnetic flux density tesla).
+                 * The unit unidata name if the unit has a name (Example: farad for capacitance).
+                 * A string describing the units according to unidata unit operation notation, if the unit is a complex combination of named units and
+                   does not have a name.
+                 
+                 Example: for lightsource brilliance (SI) 1/(s.mm2.mrad2).
+                 Here: SI units are V2/m2.
+            </doc>
+        </attribute>
     </field>
     <field name="incident_polarization_stokes" type="NX_NUMBER" units="NX_ANY">
         <doc>

--- a/base_classes/NXbeam.nxdl.xml
+++ b/base_classes/NXbeam.nxdl.xml
@@ -219,31 +219,12 @@
     </field>
     <field name="incident_polarization" type="NX_NUMBER" units="NX_ANY">
         <doc>
-             Incident polarization as a Stokes vector
-             on entering beamline component
+             Polarization vector on entering beamline component
         </doc>
         <dimensions rank="2">
             <dim index="1" value="nP"/>
             <dim index="2" value="2"/>
         </dimensions>
-        <attribute name="units" type="NX_CHAR">
-            <doc>
-                 The units for this observable are not included in the NIAC list.
-                 Responsibility on correct formatting and parsing is handed to the user
-                 by using `NX_ANY`. Correct parsing can still be implemented by using
-                 this attribute.
-                 
-                 | Fill with:
-                 
-                 * The unit unidata symbol if the unit has one (Example: T for the unit of magnetic flux density tesla).
-                 * The unit unidata name if the unit has a name (Example: farad for capacitance).
-                 * A string describing the units according to unidata unit operation notation, if the unit is a complex combination of named units and
-                   does not have a name.
-                 
-                 Example: for lightsource brilliance (SI) 1/(s.mm2.mrad2).
-                 Here: SI units are V2/m2.
-            </doc>
-        </attribute>
     </field>
     <field name="final_polarization" type="NX_NUMBER" units="NX_ANY">
         <doc>
@@ -253,24 +234,6 @@
             <dim index="1" value="nP"/>
             <dim index="2" value="2"/>
         </dimensions>
-        <attribute name="units" type="NX_CHAR">
-            <doc>
-                 The units for this observable are not included in the NIAC list.
-                 Responsibility on correct formatting and parsing is handed to the user
-                 by using `NX_ANY`. Correct parsing can still be implemented by using
-                 this attribute.
-                 
-                 | Fill with:
-                 
-                 * The unit unidata symbol if the unit has one (Example: T for the unit of magnetic flux density tesla).
-                 * The unit unidata name if the unit has a name (Example: farad for capacitance).
-                 * A string describing the units according to unidata unit operation notation, if the unit is a complex combination of named units and
-                   does not have a name.
-                 
-                 Example: for lightsource brilliance (SI) 1/(s.mm2.mrad2).
-                 Here: SI units are V2/m2.
-            </doc>
-        </attribute>
     </field>
     <field name="incident_polarization_stokes" type="NX_NUMBER" units="NX_ANY">
         <doc>
@@ -495,7 +458,7 @@
     </field>
     <field name="next_device">
         <doc>
-             
+             Gives the beam device which this beam will interact with next.
         </doc>
     </field>
 </definition>

--- a/base_classes/NXenvironment.nxdl.xml
+++ b/base_classes/NXenvironment.nxdl.xml
@@ -58,6 +58,17 @@
              Note, it is recommended to use NXtransformations instead.
         </doc>
     </group>
+    <field name="value" type="NX_FLOAT" units="NX_ANY">
+        <doc>
+             This is to be used if there is no actuator/sensor that controls/measures
+             the environment parameters, but the user would still like to give a value for
+             it. An example would be a room temperature experiment where the temperature is
+             not actively measured, but rather estimated.
+             
+             Note that this method for recording the environment parameters is not advised,
+             but using NXsensor and NXactuator is strongly recommended instead.
+        </doc>
+    </field>
     <field name="depends_on" type="NX_CHAR">
         <doc>
              NeXus positions components by applying a set of translations and rotations

--- a/base_classes/nyaml/NXbeam.yaml
+++ b/base_classes/nyaml/NXbeam.yaml
@@ -172,28 +172,10 @@ NXbeam(NXobject):
   incident_polarization(NX_NUMBER):
     unit: NX_ANY
     doc: |
-      Incident polarization as a Stokes vector
-      on entering beamline component
+      Polarization vector on entering beamline component
     dimensions:
       rank: 2
       dim: [[1, nP], [2, 2]]
-    \@units:
-      type: NX_CHAR
-      doc: |
-        The units for this observable are not included in the NIAC list.
-        Responsibility on correct formatting and parsing is handed to the user
-        by using `NX_ANY`. Correct parsing can still be implemented by using
-        this attribute.
-        
-        | Fill with:
-        
-        * The unit unidata symbol if the unit has one (Example: T for the unit of magnetic flux density tesla).
-        * The unit unidata name if the unit has a name (Example: farad for capacitance).
-        * A string describing the units according to unidata unit operation notation, if the unit is a complex combination of named units and
-          does not have a name.
-        
-        Example: for lightsource brilliance (SI) 1/(s.mm2.mrad2).
-        Here: SI units are V2/m2.
   final_polarization(NX_NUMBER):
     unit: NX_ANY
     doc: |
@@ -201,23 +183,6 @@ NXbeam(NXobject):
     dimensions:
       rank: 2
       dim: [[1, nP], [2, 2]]
-    \@units:
-      type: NX_CHAR
-      doc: |
-        The units for this observable are not included in the NIAC list.
-        Responsibility on correct formatting and parsing is handed to the user
-        by using `NX_ANY`. Correct parsing can still be implemented by using
-        this attribute.
-        
-        | Fill with:
-        
-        * The unit unidata symbol if the unit has one (Example: T for the unit of magnetic flux density tesla).
-        * The unit unidata name if the unit has a name (Example: farad for capacitance).
-        * A string describing the units according to unidata unit operation notation, if the unit is a complex combination of named units and
-          does not have a name.
-        
-        Example: for lightsource brilliance (SI) 1/(s.mm2.mrad2).
-        Here: SI units are V2/m2.
   incident_polarization_stokes(NX_NUMBER):
     unit: NX_ANY
     doc: |
@@ -394,22 +359,23 @@ NXbeam(NXobject):
         doc: |
           Points to the path to a field defining the location on which this
           depends or the string "." for origin.
-  previous_device: 
+  previous_device:
     doc: |
       Indicates the beam device from which this beam originates.
       This defines, whether the beam in an "input" or "output" beam.
-  next_device: 
+  next_device:
     doc: |
       Gives the beam device which this beam will interact with next.
+
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# dbe7fba854b6a29c068ef96a3c8fbe28c8217579d5d8a990ffa730ecd269bf21
-# <?xml version="1.0" encoding="UTF-8"?>
+# 99ae6b0983bbcf045b173aa2b48b0be9a1c93f34369e5ee59ddc12bdb3177db7
+# <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
 # # NeXus - Neutron and X-ray Common Data Format
-# # 
-# # Copyright (C) 2014-2022 NeXus International Advisory Committee (NIAC)
-# # 
+# #
+# # Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+# #
 # # This library is free software; you can redistribute it and/or
 # # modify it under the terms of the GNU Lesser General Public
 # # License as published by the Free Software Foundation; either
@@ -624,31 +590,12 @@ NXbeam(NXobject):
 #     </field>
 #     <field name="incident_polarization" type="NX_NUMBER" units="NX_ANY">
 #         <doc>
-#              Incident polarization as a Stokes vector
-#              on entering beamline component
+#              Polarization vector on entering beamline component
 #         </doc>
 #         <dimensions rank="2">
 #             <dim index="1" value="nP"/>
 #             <dim index="2" value="2"/>
 #         </dimensions>
-#         <attribute name="units" type="NX_CHAR">
-#             <doc>
-#                  The units for this observable are not included in the NIAC list.
-#                  Responsibility on correct formatting and parsing is handed to the user
-#                  by using `NX_ANY`. Correct parsing can still be implemented by using
-#                  this attribute.
-#                  
-#                  | Fill with:
-#                  
-#                  * The unit unidata symbol if the unit has one (Example: T for the unit of magnetic flux density tesla).
-#                  * The unit unidata name if the unit has a name (Example: farad for capacitance).
-#                  * A string describing the units according to unidata unit operation notation, if the unit is a complex combination of named units and
-#                    does not have a name.
-#                  
-#                  Example: for lightsource brilliance (SI) 1/(s.mm2.mrad2).
-#                  Here: SI units are V2/m2.
-#             </doc>
-#         </attribute>
 #     </field>
 #     <field name="final_polarization" type="NX_NUMBER" units="NX_ANY">
 #         <doc>
@@ -658,24 +605,6 @@ NXbeam(NXobject):
 #             <dim index="1" value="nP"/>
 #             <dim index="2" value="2"/>
 #         </dimensions>
-#         <attribute name="units" type="NX_CHAR">
-#             <doc>
-#                  The units for this observable are not included in the NIAC list.
-#                  Responsibility on correct formatting and parsing is handed to the user
-#                  by using `NX_ANY`. Correct parsing can still be implemented by using
-#                  this attribute.
-#                  
-#                  | Fill with:
-#                  
-#                  * The unit unidata symbol if the unit has one (Example: T for the unit of magnetic flux density tesla).
-#                  * The unit unidata name if the unit has a name (Example: farad for capacitance).
-#                  * A string describing the units according to unidata unit operation notation, if the unit is a complex combination of named units and
-#                    does not have a name.
-#                  
-#                  Example: for lightsource brilliance (SI) 1/(s.mm2.mrad2).
-#                  Here: SI units are V2/m2.
-#             </doc>
-#         </attribute>
 #     </field>
 #     <field name="incident_polarization_stokes" type="NX_NUMBER" units="NX_ANY">
 #         <doc>
@@ -859,7 +788,7 @@ NXbeam(NXobject):
 #             <attribute name="depends_on" type="NX_CHAR">
 #                 <doc>
 #                      Points to the path to a field defining the location on which this
-#                      depends or the string &quot;.&quot; for origin.
+#                      depends or the string "." for origin.
 #                 </doc>
 #             </attribute>
 #         </field>
@@ -887,9 +816,20 @@ NXbeam(NXobject):
 #             <attribute name="depends_on" type="NX_CHAR">
 #                 <doc>
 #                      Points to the path to a field defining the location on which this
-#                      depends or the string &quot;.&quot; for origin.
+#                      depends or the string "." for origin.
 #                 </doc>
 #             </attribute>
 #         </field>
 #     </group>
+#     <field name="previous_device">
+#         <doc>
+#              Indicates the beam device from which this beam originates.
+#              This defines, whether the beam in an "input" or "output" beam.
+#         </doc>
+#     </field>
+#     <field name="next_device">
+#         <doc>
+#              Gives the beam device which this beam will interact with next.
+#         </doc>
+#     </field>
 # </definition>

--- a/base_classes/nyaml/NXbeam.yaml
+++ b/base_classes/nyaml/NXbeam.yaml
@@ -179,7 +179,7 @@ NXbeam(NXobject):
   final_polarization(NX_NUMBER):
     unit: NX_ANY
     doc: |
-      Polarization as Stokes vector on leaving beamline component
+      Polarization vector on leaving beamline component
     dimensions:
       rank: 2
       dim: [[1, nP], [2, 2]]
@@ -368,7 +368,7 @@ NXbeam(NXobject):
       Gives the beam device which this beam will interact with next.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 99ae6b0983bbcf045b173aa2b48b0be9a1c93f34369e5ee59ddc12bdb3177db7
+# 8f2a9f6acd2587ac3b957f5d70a5058e48c7c1fec45dde083733436fc8bddab0
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -599,7 +599,7 @@ NXbeam(NXobject):
 #     </field>
 #     <field name="final_polarization" type="NX_NUMBER" units="NX_ANY">
 #         <doc>
-#              Polarization as Stokes vector on leaving beamline component
+#              Polarization vector on leaving beamline component
 #         </doc>
 #         <dimensions rank="2">
 #             <dim index="1" value="nP"/>

--- a/base_classes/nyaml/NXbeam.yaml
+++ b/base_classes/nyaml/NXbeam.yaml
@@ -176,6 +176,23 @@ NXbeam(NXobject):
     dimensions:
       rank: 2
       dim: [[1, nP], [2, 2]]
+    \@units:
+      type: NX_CHAR
+      doc: |
+        The units for this observable are not included in the NIAC list.
+        Responsibility on correct formatting and parsing is handed to the user
+        by using `NX_ANY`. Correct parsing can still be implemented by using
+        this attribute.
+        
+        | Fill with:
+        
+        * The unit unidata symbol if the unit has one (Example: T for the unit of magnetic flux density tesla).
+        * The unit unidata name if the unit has a name (Example: farad for capacitance).
+        * A string describing the units according to unidata unit operation notation, if the unit is a complex combination of named units and
+          does not have a name.
+        
+        Example: for lightsource brilliance (SI) 1/(s.mm2.mrad2).
+        Here: SI units are V2/m2.
   final_polarization(NX_NUMBER):
     unit: NX_ANY
     doc: |
@@ -183,6 +200,23 @@ NXbeam(NXobject):
     dimensions:
       rank: 2
       dim: [[1, nP], [2, 2]]
+    \@units:
+      type: NX_CHAR
+      doc: |
+        The units for this observable are not included in the NIAC list.
+        Responsibility on correct formatting and parsing is handed to the user
+        by using `NX_ANY`. Correct parsing can still be implemented by using
+        this attribute.
+        
+        | Fill with:
+        
+        * The unit unidata symbol if the unit has one (Example: T for the unit of magnetic flux density tesla).
+        * The unit unidata name if the unit has a name (Example: farad for capacitance).
+        * A string describing the units according to unidata unit operation notation, if the unit is a complex combination of named units and
+          does not have a name.
+        
+        Example: for lightsource brilliance (SI) 1/(s.mm2.mrad2).
+        Here: SI units are V2/m2.
   incident_polarization_stokes(NX_NUMBER):
     unit: NX_ANY
     doc: |
@@ -368,7 +402,7 @@ NXbeam(NXobject):
       Gives the beam device which this beam will interact with next.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 8f2a9f6acd2587ac3b957f5d70a5058e48c7c1fec45dde083733436fc8bddab0
+# 0f4d4d5bf996841b80a3b24691b91622899dedd9e07a1944f462d2df2f478f09
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -596,6 +630,24 @@ NXbeam(NXobject):
 #             <dim index="1" value="nP"/>
 #             <dim index="2" value="2"/>
 #         </dimensions>
+#         <attribute name="units" type="NX_CHAR">
+#             <doc>
+#                  The units for this observable are not included in the NIAC list.
+#                  Responsibility on correct formatting and parsing is handed to the user
+#                  by using `NX_ANY`. Correct parsing can still be implemented by using
+#                  this attribute.
+#                  
+#                  | Fill with:
+#                  
+#                  * The unit unidata symbol if the unit has one (Example: T for the unit of magnetic flux density tesla).
+#                  * The unit unidata name if the unit has a name (Example: farad for capacitance).
+#                  * A string describing the units according to unidata unit operation notation, if the unit is a complex combination of named units and
+#                    does not have a name.
+#                  
+#                  Example: for lightsource brilliance (SI) 1/(s.mm2.mrad2).
+#                  Here: SI units are V2/m2.
+#             </doc>
+#         </attribute>
 #     </field>
 #     <field name="final_polarization" type="NX_NUMBER" units="NX_ANY">
 #         <doc>
@@ -605,6 +657,24 @@ NXbeam(NXobject):
 #             <dim index="1" value="nP"/>
 #             <dim index="2" value="2"/>
 #         </dimensions>
+#         <attribute name="units" type="NX_CHAR">
+#             <doc>
+#                  The units for this observable are not included in the NIAC list.
+#                  Responsibility on correct formatting and parsing is handed to the user
+#                  by using `NX_ANY`. Correct parsing can still be implemented by using
+#                  this attribute.
+#                  
+#                  | Fill with:
+#                  
+#                  * The unit unidata symbol if the unit has one (Example: T for the unit of magnetic flux density tesla).
+#                  * The unit unidata name if the unit has a name (Example: farad for capacitance).
+#                  * A string describing the units according to unidata unit operation notation, if the unit is a complex combination of named units and
+#                    does not have a name.
+#                  
+#                  Example: for lightsource brilliance (SI) 1/(s.mm2.mrad2).
+#                  Here: SI units are V2/m2.
+#             </doc>
+#         </attribute>
 #     </field>
 #     <field name="incident_polarization_stokes" type="NX_NUMBER" units="NX_ANY">
 #         <doc>

--- a/base_classes/nyaml/NXenvironment.yaml
+++ b/base_classes/nyaml/NXenvironment.yaml
@@ -24,6 +24,16 @@ NXenvironment(NXobject):
     doc: |
       The position and orientation of the apparatus.
       Note, it is recommended to use NXtransformations instead.
+  value(NX_FLOAT):
+    unit: NX_ANY
+    doc: |
+      This is to be used if there is no actuator/sensor that controls/measures
+      the environment parameters, but the user would still like to give a value for
+      it. An example would be a room temperature experiment where the temperature is
+      not actively measured, but rather estimated.
+      
+      Note that this method for recording the environment parameters is not advised,
+      but using NXsensor and NXactuator is strongly recommended instead.
   depends_on(NX_CHAR):
     doc: |
       NeXus positions components by applying a set of translations and rotations
@@ -63,7 +73,7 @@ NXenvironment(NXobject):
       for a summary of the discussion.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 4e4bd4fe380d78389677def141557774db0580c77850b6cfe755ba06e7b57cef
+# 3ce4fc8a319f3ee0ad9eb40c88d67121e939a5f05f690725500c62ba88e7632a
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -124,6 +134,17 @@ NXenvironment(NXobject):
 #              Note, it is recommended to use NXtransformations instead.
 #         </doc>
 #     </group>
+#     <field name="value" type="NX_FLOAT" units="NX_ANY">
+#         <doc>
+#              This is to be used if there is no actuator/sensor that controls/measures
+#              the environment parameters, but the user would still like to give a value for
+#              it. An example would be a room temperature experiment where the temperature is
+#              not actively measured, but rather estimated.
+#              
+#              Note that this method for recording the environment parameters is not advised,
+#              but using NXsensor and NXactuator is strongly recommended instead.
+#         </doc>
+#     </field>
 #     <field name="depends_on" type="NX_CHAR">
 #         <doc>
 #              NeXus positions components by applying a set of translations and rotations

--- a/contributed_definitions/NXmpes.nxdl.xml
+++ b/contributed_definitions/NXmpes.nxdl.xml
@@ -377,10 +377,10 @@
                              Contains the raw data collected by the detector before calibration.
                              The data which is considered raw might change from experiment to experiment
                              due to hardware pre-processing of the data.
-                             This field ideally collects the data with the lowest level of processing
+                             This group ideally collects the data with the lowest level of processing
                              possible.
                              
-                             Fields should be named according to new following convention:
+                             Fields should be named according to the following convention:
                              
                              - **pixel_x**: Detector pixel in x direction.
                              - **pixel_y**: Detector pixel in y direction.
@@ -405,6 +405,9 @@
                              - **time_of_flight**: Total time of flight. Unit category: NX_TIME_OF_FLIGHT
                              - **time_of_flight_adc**: Time-of-flight values, analog-to-digital converted.
                              - **external_AXIS**: Describes an axis which is coming from outside the detectors scope.
+                             
+                             Note that this list is a glossary with explicitly named axis names, which is only intended to cover the most
+                             common measurement axes and is therefore not complete. It is possible to add axes with other names at any time.
                         </doc>
                         <attribute name="signal">
                             <enumeration>
@@ -496,9 +499,9 @@
                     <field name="identifier" recommended="true"/>
                 </group>
             </group>
-            <group name="pressure_gauge" type="NXsensor" recommended="true">
+            <group name="pressure_gaugeID" type="NXsensor" recommended="true">
                 <doc>
-                     Device to measure the gas pressure around the sample.
+                     Device to measure the gas pressure in some part of the instrument.
                 </doc>
                 <field name="name" recommended="true"/>
                 <field name="measurement">
@@ -509,8 +512,8 @@
                 <field name="type" optional="true"/>
                 <field name="value" type="NX_FLOAT" units="NX_PRESSURE">
                     <doc>
-                         In case of a single or averaged gas pressure measurement, this is the scalar gas pressure around
-                         the sample. It can also be an 1D array of measured pressures (without time stamps).
+                         In case of a single or averaged gas pressure measurement, this is the scalar gas pressure.
+                         It can also be an 1D array of measured pressures (without time stamps).
                     </doc>
                 </field>
                 <group name="value_log" type="NXlog" optional="true">
@@ -665,93 +668,158 @@
                     </field>
                 </group>
             </group>
-            <group name="temperature" type="NXenvironment" recommended="true">
+            <group name="temperature_env" type="NXenvironment" recommended="true">
                 <doc>
-                     Sample temperature (either controlled or just measured).
+                     Sample temperature (either controlled or just measured) and actuators/sensors
+                     controlling/measuring it.
                 </doc>
-                <group name="temperature_sensor" type="NXsensor">
+                <group name="temperature_sensor" type="NXsensor" recommended="true">
                     <doc>
                          Temperature sensor measuring the sample temperature.
-                         This should be a link to /entry/instrument/manipulator/temperature_sensor.
+                         
+                         In most cases, this can be a link to /entry/instrument/manipulator/temperature_sensor
+                         if a manipulator is present in the instrument.
                     </doc>
                 </group>
                 <group name="sample_heater" type="NXactuator" optional="true">
                     <doc>
                          Device to heat the sample.
-                         This should be a link to /entry/instrument/manipulator/sample_heater.
+                         
+                         In most cases, this can be a link to /entry/instrument/manipulator/sample_heater
+                         if a manipulator is present in the instrument.
                     </doc>
                 </group>
                 <group name="cryostat" type="NXactuator" optional="true">
                     <doc>
                          Cryostat for cooling the sample.
-                         This should be a link to /entry/instrument/manipulator/cryostat.
+                         
+                         In most cases, this can be a link to /entry/instrument/manipulator/cryostat
+                         if a manipulator is present in the instrument.
                     </doc>
                 </group>
+                <field name="value" type="NX_FLOAT" optional="true" units="NX_TEMPERATURE">
+                    <doc>
+                         This is to be used if there is no actuator/sensor that controls/measures
+                         the temperature.
+                         
+                         An example would be a room temperature experiment where the temperature is
+                         not actively measured, but rather estimated.
+                         
+                         Note that this method for recording the temperature is not advised, but using
+                         NXsensor and NXactuator is strongly recommended instead.
+                    </doc>
+                </field>
             </group>
-            <group name="gas_pressure" type="NXenvironment" recommended="true">
+            <group name="gas_pressure_env" type="NXenvironment" recommended="true">
                 <doc>
-                     Gas pressure surrounding the sample.
+                     Gas pressure surrounding the sample and actuators/sensors controlling/measuring
+                     it.
                 </doc>
-                <group name="pressure_gauge" type="NXsensor">
+                <group name="pressure_gauge" type="NXsensor" recommended="true">
                     <doc>
                          Gauge measuring the gas pressure.
                          
-                         This should be a link to /entry/instrument/pressure_gauge.
+                         In most cases, this can be a link to one of the pressure gauges in
+                         /entry/instrument/pressure_gaugeID (typically, the gauge in closest proximity to the
+                         sample) if a pressure gauge is present in the instrument.
                     </doc>
                 </group>
+                <field name="value" type="NX_FLOAT" optional="true" units="NX_PRESSURE">
+                    <doc>
+                         This is to be used if there is no actuator/sensor that controls/measures
+                         the gas pressure around the sample. An example would be a UHV experiment where the
+                         gas pressure is not monitored.
+                         
+                         Note that this method for recording the gas pressure is not advised, but using
+                         NXsensor and NXactuator is strongly recommended instead.
+                    </doc>
+                </field>
             </group>
-            <group name="bias" type="NXenvironment" recommended="true">
+            <group name="bias_env" type="NXenvironment" recommended="true">
                 <doc>
-                     Bias of the sample with respect to analyser ground.
+                     Bias of the sample with respect to analyser ground and actuators/sensors
+                     controlling/measuring it.
                      
                      This concept is related to term `8.41`_ of the ISO 18115-1:2023 standard.
                      
                      .. _8.41: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:8.41
                 </doc>
-                <group name="voltmeter" type="NXsensor">
+                <group name="voltmeter" type="NXsensor" recommended="true">
                     <doc>
                          Sensor measuring the applied voltage.
                          
-                         This should be a link to /entry/instrument/manipulator/sample_bias_voltmeter.
+                         In most cases, this can be a link to /entry/instrument/manipulator/sample_bias_voltmeter
+                         if a manipulator is present in the instrument.
                     </doc>
                 </group>
                 <group name="potentiostat" type="NXactuator" optional="true">
                     <doc>
                          Actuator applying a voltage to sample and sample holder.
                          
-                         This should be a link to /entry/instrument/manipulator/sample_bias_potentiostat.
+                         In most cases, this can be a link to /entry/instrument/manipulator/sample_bias_potentiostat
+                         if a manipulator is present in the instrument.
                     </doc>
                 </group>
+                <field name="value" type="NX_FLOAT" optional="true" units="NX_VOLTAGE">
+                    <doc>
+                         This is to be used if there is no actuator/sensor that controls/measures
+                         the bias.
+                         
+                         Note that this method for recording the bias is not advised, but using
+                         NXsensor and NXactuator is strongly recommended instead.
+                    </doc>
+                </field>
             </group>
-            <group name="drain_current" type="NXenvironment" optional="true">
+            <group name="drain_current_env" type="NXenvironment" optional="true">
                 <doc>
                      Drain current of the sample and sample holder.
                 </doc>
-                <group name="amperemeter" type="NXsensor">
+                <group name="amperemeter" type="NXsensor" recommended="true">
                     <doc>
                          Amperemeter measuring the drain current of the sample and sample holder.
                          
-                         This should be a link to /entry/instrument/manipulator/drain_current_amperemeter.
+                         In most cases, this can be a link to /entry/instrument/manipulator/drain_current_amperemeter
+                         if a manipulator is present in the instrument.
                     </doc>
                 </group>
+                <field name="value" type="NX_FLOAT" optional="true" units="NX_CURRENT">
+                    <doc>
+                         This is to be used if there is no actuator/sensor that controls/measures
+                         the drain current.
+                         
+                         Note that this method for recording the drain current is not advised, but using
+                         NXsensor and NXactuator is strongly recommended instead.
+                    </doc>
+                </field>
             </group>
-            <group name="flood_gun_current" type="NXenvironment" optional="true">
+            <group name="flood_gun_current_env" type="NXenvironment" optional="true">
                 <doc>
-                     Current of low-energy electrons to the sample for charge neutralization.
+                     Current of low-energy electrons to the sample (for charge neutralization) and
+                     actuators/sensors controlling/measuring it.
                 </doc>
-                <group name="flood_gun" type="NXactuator">
+                <group name="flood_gun" type="NXactuator" recommended="true">
                     <doc>
                          Flood gun creating a current of low-energy electrons.
                          
-                         This should be a link to /entry/instrument/flood_gun.
+                         In most cases this can be a link to /entry/instrument/flood_gun
+                         if a flood_gun is present in the instrument.
                     </doc>
+                    <field name="value" type="NX_FLOAT" optional="true" units="NX_CURRENT">
+                        <doc>
+                             This is to be used if there is no actuator/sensor that controls/measures
+                             the drain_current.
+                             
+                             Note that this method for recording the flood gun current is not advised, but using
+                             NXsensor and NXactuator is strongly recommended instead.
+                        </doc>
+                    </field>
                 </group>
             </group>
         </group>
         <group name="data" type="NXdata">
             <doc>
-                 The default NXdata field containing a view on the measured data.
-                 This NXdata field contains a collection of the main relevant fields (axes).
+                 The default NXdata group containing a view on the measured data.
+                 This NXdata group contains a collection of the main relevant fields (axes).
                  If you want to provide additional views on your data, you can additionally use
                  the generic NXdata group of NXentry.
                  
@@ -781,6 +849,9 @@
                    Could be a link to /entry/instrument/beam/incident_ellipticity or
                    /entry/instrument/beam/final_ellipticity if they exist.
                    Unit category: NX_ANGLE (° or rad)
+                 
+                 Note that this list is a glossary with explicitly named axis names, which is only intended to cover the most
+                 common measurement axes and is therefore not complete. It is possible to add axes with other names at any time.
             </doc>
             <attribute name="signal">
                 <enumeration>

--- a/contributed_definitions/nyaml/NXmpes.yaml
+++ b/contributed_definitions/nyaml/NXmpes.yaml
@@ -318,10 +318,10 @@ NXmpes(NXobject):
               Contains the raw data collected by the detector before calibration.
               The data which is considered raw might change from experiment to experiment
               due to hardware pre-processing of the data.
-              This field ideally collects the data with the lowest level of processing
+              This group ideally collects the data with the lowest level of processing
               possible.
               
-              Fields should be named according to new following convention:
+              Fields should be named according to the following convention:
               
               - **pixel_x**: Detector pixel in x direction.
               - **pixel_y**: Detector pixel in y direction.
@@ -346,6 +346,9 @@ NXmpes(NXobject):
               - **time_of_flight**: Total time of flight. Unit category: NX_TIME_OF_FLIGHT
               - **time_of_flight_adc**: Time-of-flight values, analog-to-digital converted.
               - **external_AXIS**: Describes an axis which is coming from outside the detectors scope.
+              
+              Note that this list is a glossary with explicitly named axis names, which is only intended to cover the most
+              common measurement axes and is therefore not complete. It is possible to add axes with other names at any time.
             \@signal:
               enumeration: [raw]
             raw(NX_NUMBER):
@@ -426,10 +429,10 @@ NXmpes(NXobject):
             exists: recommended
           identifier:
             exists: recommended
-      pressure_gauge(NXsensor):
+      pressure_gaugeID(NXsensor):
         exists: recommended
         doc: |
-          Device to measure the gas pressure around the sample.
+          Device to measure the gas pressure in some part of the instrument.
         name:
           exists: recommended
         measurement:
@@ -439,8 +442,8 @@ NXmpes(NXobject):
         value(NX_FLOAT):
           unit: NX_PRESSURE
           doc: |
-            In case of a single or averaged gas pressure measurement, this is the scalar gas pressure around
-            the sample. It can also be an 1D array of measured pressures (without time stamps).
+            In case of a single or averaged gas pressure measurement, this is the scalar gas pressure.
+            It can also be an 1D array of measured pressures (without time stamps).
         value_log(NXlog):
           exists: optional
           value(NX_NUMBER):
@@ -588,76 +591,146 @@ NXmpes(NXobject):
             doc: |
               Details about the method of sample preparation before the photoemission
               experiment.
-      temperature(NXenvironment):
+      temperature_env(NXenvironment):
         exists: recommended
         doc: |
-          Sample temperature (either controlled or just measured).
+          Sample temperature (either controlled or just measured) and actuators/sensors
+          controlling/measuring it.
         temperature_sensor(NXsensor):
+          exists: recommended
           doc: |
             Temperature sensor measuring the sample temperature.
-            This should be a link to /entry/instrument/manipulator/temperature_sensor.
+            
+            In most cases, this can be a link to /entry/instrument/manipulator/temperature_sensor
+            if a manipulator is present in the instrument.
         sample_heater(NXactuator):
           exists: optional
           doc: |
             Device to heat the sample.
-            This should be a link to /entry/instrument/manipulator/sample_heater.
+            
+            In most cases, this can be a link to /entry/instrument/manipulator/sample_heater
+            if a manipulator is present in the instrument.
         cryostat(NXactuator):
           exists: optional
           doc: |
             Cryostat for cooling the sample.
-            This should be a link to /entry/instrument/manipulator/cryostat.
-      gas_pressure(NXenvironment):
+            
+            In most cases, this can be a link to /entry/instrument/manipulator/cryostat
+            if a manipulator is present in the instrument.
+        value(NX_FLOAT):
+          exists: optional
+          unit: NX_TEMPERATURE
+          doc: |
+            This is to be used if there is no actuator/sensor that controls/measures
+            the temperature.
+            
+            An example would be a room temperature experiment where the temperature is
+            not actively measured, but rather estimated.
+            
+            Note that this method for recording the temperature is not advised, but using
+            NXsensor and NXactuator is strongly recommended instead.
+      gas_pressure_env(NXenvironment):
         exists: recommended
         doc: |
-          Gas pressure surrounding the sample.
+          Gas pressure surrounding the sample and actuators/sensors controlling/measuring
+          it.
         pressure_gauge(NXsensor):
+          exists: recommended
           doc: |
             Gauge measuring the gas pressure.
             
-            This should be a link to /entry/instrument/pressure_gauge.
-      bias(NXenvironment):
+            In most cases, this can be a link to one of the pressure gauges in
+            /entry/instrument/pressure_gaugeID (typically, the gauge in closest proximity to the
+            sample) if a pressure gauge is present in the instrument.
+        value(NX_FLOAT):
+          exists: optional
+          unit: NX_PRESSURE
+          doc: |
+            This is to be used if there is no actuator/sensor that controls/measures
+            the gas pressure around the sample. An example would be a UHV experiment where the
+            gas pressure is not monitored.
+            
+            Note that this method for recording the gas pressure is not advised, but using
+            NXsensor and NXactuator is strongly recommended instead.
+      bias_env(NXenvironment):
         exists: recommended
         doc:
         - |
-          Bias of the sample with respect to analyser ground.
+          Bias of the sample with respect to analyser ground and actuators/sensors
+          controlling/measuring it.
         - |
           xref:
             spec: ISO 18115-1:2023
             term: 8.41
             url: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:8.41
         voltmeter(NXsensor):
+          exists: recommended
           doc: |
             Sensor measuring the applied voltage.
             
-            This should be a link to /entry/instrument/manipulator/sample_bias_voltmeter.
+            In most cases, this can be a link to /entry/instrument/manipulator/sample_bias_voltmeter
+            if a manipulator is present in the instrument.
         potentiostat(NXactuator):
           exists: optional
           doc: |
             Actuator applying a voltage to sample and sample holder.
             
-            This should be a link to /entry/instrument/manipulator/sample_bias_potentiostat.
-      drain_current(NXenvironment):
+            In most cases, this can be a link to /entry/instrument/manipulator/sample_bias_potentiostat
+            if a manipulator is present in the instrument.
+        value(NX_FLOAT):
+          exists: optional
+          unit: NX_VOLTAGE
+          doc: |
+            This is to be used if there is no actuator/sensor that controls/measures
+            the bias.
+            
+            Note that this method for recording the bias is not advised, but using
+            NXsensor and NXactuator is strongly recommended instead.
+      drain_current_env(NXenvironment):
         exists: optional
         doc: |
           Drain current of the sample and sample holder.
         amperemeter(NXsensor):
+          exists: recommended
           doc: |
             Amperemeter measuring the drain current of the sample and sample holder.
             
-            This should be a link to /entry/instrument/manipulator/drain_current_amperemeter.
-      flood_gun_current(NXenvironment):
+            In most cases, this can be a link to /entry/instrument/manipulator/drain_current_amperemeter
+            if a manipulator is present in the instrument.
+        value(NX_FLOAT):
+          exists: optional
+          unit: NX_CURRENT
+          doc: |
+            This is to be used if there is no actuator/sensor that controls/measures
+            the drain current.
+            
+            Note that this method for recording the drain current is not advised, but using
+            NXsensor and NXactuator is strongly recommended instead.
+      flood_gun_current_env(NXenvironment):
         exists: optional
         doc: |
-          Current of low-energy electrons to the sample for charge neutralization.
+          Current of low-energy electrons to the sample (for charge neutralization) and
+          actuators/sensors controlling/measuring it.
         flood_gun(NXactuator):
+          exists: recommended
           doc: |
             Flood gun creating a current of low-energy electrons.
             
-            This should be a link to /entry/instrument/flood_gun.
+            In most cases this can be a link to /entry/instrument/flood_gun
+            if a flood_gun is present in the instrument.
+          value(NX_FLOAT):
+            exists: optional
+            unit: NX_CURRENT
+            doc: |
+              This is to be used if there is no actuator/sensor that controls/measures
+              the drain_current.
+              
+              Note that this method for recording the flood gun current is not advised, but using
+              NXsensor and NXactuator is strongly recommended instead.
     data(NXdata):
       doc: |
-        The default NXdata field containing a view on the measured data.
-        This NXdata field contains a collection of the main relevant fields (axes).
+        The default NXdata group containing a view on the measured data.
+        This NXdata group contains a collection of the main relevant fields (axes).
         If you want to provide additional views on your data, you can additionally use
         the generic NXdata group of NXentry.
         
@@ -687,6 +760,9 @@ NXmpes(NXobject):
           Could be a link to /entry/instrument/beam/incident_ellipticity or
           /entry/instrument/beam/final_ellipticity if they exist.
           Unit category: NX_ANGLE (° or rad)
+        
+        Note that this list is a glossary with explicitly named axis names, which is only intended to cover the most
+        common measurement axes and is therefore not complete. It is possible to add axes with other names at any time.
       \@signal:
         enumeration: [data]
       data(NX_NUMBER):
@@ -718,7 +794,7 @@ NXmpes(NXobject):
             @energy_depends: 'entry/process/energy_calibration'
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 7f45ab08c78a105a15e2c6f5ddbcdcab4002929bf8d19e8ec2987bd507525680
+# 6160b91a61ca173d4edfb5387255cfa174deb259b0b7d262bf45b45c493dd669
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -1098,10 +1174,10 @@ NXmpes(NXobject):
 #                              Contains the raw data collected by the detector before calibration.
 #                              The data which is considered raw might change from experiment to experiment
 #                              due to hardware pre-processing of the data.
-#                              This field ideally collects the data with the lowest level of processing
+#                              This group ideally collects the data with the lowest level of processing
 #                              possible.
 #                              
-#                              Fields should be named according to new following convention:
+#                              Fields should be named according to the following convention:
 #                              
 #                              - **pixel_x**: Detector pixel in x direction.
 #                              - **pixel_y**: Detector pixel in y direction.
@@ -1126,6 +1202,9 @@ NXmpes(NXobject):
 #                              - **time_of_flight**: Total time of flight. Unit category: NX_TIME_OF_FLIGHT
 #                              - **time_of_flight_adc**: Time-of-flight values, analog-to-digital converted.
 #                              - **external_AXIS**: Describes an axis which is coming from outside the detectors scope.
+#                              
+#                              Note that this list is a glossary with explicitly named axis names, which is only intended to cover the most
+#                              common measurement axes and is therefore not complete. It is possible to add axes with other names at any time.
 #                         </doc>
 #                         <attribute name="signal">
 #                             <enumeration>
@@ -1217,9 +1296,9 @@ NXmpes(NXobject):
 #                     <field name="identifier" recommended="true"/>
 #                 </group>
 #             </group>
-#             <group name="pressure_gauge" type="NXsensor" recommended="true">
+#             <group name="pressure_gaugeID" type="NXsensor" recommended="true">
 #                 <doc>
-#                      Device to measure the gas pressure around the sample.
+#                      Device to measure the gas pressure in some part of the instrument.
 #                 </doc>
 #                 <field name="name" recommended="true"/>
 #                 <field name="measurement">
@@ -1230,8 +1309,8 @@ NXmpes(NXobject):
 #                 <field name="type" optional="true"/>
 #                 <field name="value" type="NX_FLOAT" units="NX_PRESSURE">
 #                     <doc>
-#                          In case of a single or averaged gas pressure measurement, this is the scalar gas pressure around
-#                          the sample. It can also be an 1D array of measured pressures (without time stamps).
+#                          In case of a single or averaged gas pressure measurement, this is the scalar gas pressure.
+#                          It can also be an 1D array of measured pressures (without time stamps).
 #                     </doc>
 #                 </field>
 #                 <group name="value_log" type="NXlog" optional="true">
@@ -1386,93 +1465,158 @@ NXmpes(NXobject):
 #                     </field>
 #                 </group>
 #             </group>
-#             <group name="temperature" type="NXenvironment" recommended="true">
+#             <group name="temperature_env" type="NXenvironment" recommended="true">
 #                 <doc>
-#                      Sample temperature (either controlled or just measured).
+#                      Sample temperature (either controlled or just measured) and actuators/sensors
+#                      controlling/measuring it.
 #                 </doc>
-#                 <group name="temperature_sensor" type="NXsensor">
+#                 <group name="temperature_sensor" type="NXsensor" recommended="true">
 #                     <doc>
 #                          Temperature sensor measuring the sample temperature.
-#                          This should be a link to /entry/instrument/manipulator/temperature_sensor.
+#                          
+#                          In most cases, this can be a link to /entry/instrument/manipulator/temperature_sensor
+#                          if a manipulator is present in the instrument.
 #                     </doc>
 #                 </group>
 #                 <group name="sample_heater" type="NXactuator" optional="true">
 #                     <doc>
 #                          Device to heat the sample.
-#                          This should be a link to /entry/instrument/manipulator/sample_heater.
+#                          
+#                          In most cases, this can be a link to /entry/instrument/manipulator/sample_heater
+#                          if a manipulator is present in the instrument.
 #                     </doc>
 #                 </group>
 #                 <group name="cryostat" type="NXactuator" optional="true">
 #                     <doc>
 #                          Cryostat for cooling the sample.
-#                          This should be a link to /entry/instrument/manipulator/cryostat.
+#                          
+#                          In most cases, this can be a link to /entry/instrument/manipulator/cryostat
+#                          if a manipulator is present in the instrument.
 #                     </doc>
 #                 </group>
+#                 <field name="value" type="NX_FLOAT" optional="true" units="NX_TEMPERATURE">
+#                     <doc>
+#                          This is to be used if there is no actuator/sensor that controls/measures
+#                          the temperature.
+#                          
+#                          An example would be a room temperature experiment where the temperature is
+#                          not actively measured, but rather estimated.
+#                          
+#                          Note that this method for recording the temperature is not advised, but using
+#                          NXsensor and NXactuator is strongly recommended instead.
+#                     </doc>
+#                 </field>
 #             </group>
-#             <group name="gas_pressure" type="NXenvironment" recommended="true">
+#             <group name="gas_pressure_env" type="NXenvironment" recommended="true">
 #                 <doc>
-#                      Gas pressure surrounding the sample.
+#                      Gas pressure surrounding the sample and actuators/sensors controlling/measuring
+#                      it.
 #                 </doc>
-#                 <group name="pressure_gauge" type="NXsensor">
+#                 <group name="pressure_gauge" type="NXsensor" recommended="true">
 #                     <doc>
 #                          Gauge measuring the gas pressure.
 #                          
-#                          This should be a link to /entry/instrument/pressure_gauge.
+#                          In most cases, this can be a link to one of the pressure gauges in
+#                          /entry/instrument/pressure_gaugeID (typically, the gauge in closest proximity to the
+#                          sample) if a pressure gauge is present in the instrument.
 #                     </doc>
 #                 </group>
+#                 <field name="value" type="NX_FLOAT" optional="true" units="NX_PRESSURE">
+#                     <doc>
+#                          This is to be used if there is no actuator/sensor that controls/measures
+#                          the gas pressure around the sample. An example would be a UHV experiment where the
+#                          gas pressure is not monitored.
+#                          
+#                          Note that this method for recording the gas pressure is not advised, but using
+#                          NXsensor and NXactuator is strongly recommended instead.
+#                     </doc>
+#                 </field>
 #             </group>
-#             <group name="bias" type="NXenvironment" recommended="true">
+#             <group name="bias_env" type="NXenvironment" recommended="true">
 #                 <doc>
-#                      Bias of the sample with respect to analyser ground.
+#                      Bias of the sample with respect to analyser ground and actuators/sensors
+#                      controlling/measuring it.
 #                      
 #                      This concept is related to term `8.41`_ of the ISO 18115-1:2023 standard.
 #                      
 #                      .. _8.41: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:8.41
 #                 </doc>
-#                 <group name="voltmeter" type="NXsensor">
+#                 <group name="voltmeter" type="NXsensor" recommended="true">
 #                     <doc>
 #                          Sensor measuring the applied voltage.
 #                          
-#                          This should be a link to /entry/instrument/manipulator/sample_bias_voltmeter.
+#                          In most cases, this can be a link to /entry/instrument/manipulator/sample_bias_voltmeter
+#                          if a manipulator is present in the instrument.
 #                     </doc>
 #                 </group>
 #                 <group name="potentiostat" type="NXactuator" optional="true">
 #                     <doc>
 #                          Actuator applying a voltage to sample and sample holder.
 #                          
-#                          This should be a link to /entry/instrument/manipulator/sample_bias_potentiostat.
+#                          In most cases, this can be a link to /entry/instrument/manipulator/sample_bias_potentiostat
+#                          if a manipulator is present in the instrument.
 #                     </doc>
 #                 </group>
+#                 <field name="value" type="NX_FLOAT" optional="true" units="NX_VOLTAGE">
+#                     <doc>
+#                          This is to be used if there is no actuator/sensor that controls/measures
+#                          the bias.
+#                          
+#                          Note that this method for recording the bias is not advised, but using
+#                          NXsensor and NXactuator is strongly recommended instead.
+#                     </doc>
+#                 </field>
 #             </group>
-#             <group name="drain_current" type="NXenvironment" optional="true">
+#             <group name="drain_current_env" type="NXenvironment" optional="true">
 #                 <doc>
 #                      Drain current of the sample and sample holder.
 #                 </doc>
-#                 <group name="amperemeter" type="NXsensor">
+#                 <group name="amperemeter" type="NXsensor" recommended="true">
 #                     <doc>
 #                          Amperemeter measuring the drain current of the sample and sample holder.
 #                          
-#                          This should be a link to /entry/instrument/manipulator/drain_current_amperemeter.
+#                          In most cases, this can be a link to /entry/instrument/manipulator/drain_current_amperemeter
+#                          if a manipulator is present in the instrument.
 #                     </doc>
 #                 </group>
+#                 <field name="value" type="NX_FLOAT" optional="true" units="NX_CURRENT">
+#                     <doc>
+#                          This is to be used if there is no actuator/sensor that controls/measures
+#                          the drain current.
+#                          
+#                          Note that this method for recording the drain current is not advised, but using
+#                          NXsensor and NXactuator is strongly recommended instead.
+#                     </doc>
+#                 </field>
 #             </group>
-#             <group name="flood_gun_current" type="NXenvironment" optional="true">
+#             <group name="flood_gun_current_env" type="NXenvironment" optional="true">
 #                 <doc>
-#                      Current of low-energy electrons to the sample for charge neutralization.
+#                      Current of low-energy electrons to the sample (for charge neutralization) and
+#                      actuators/sensors controlling/measuring it.
 #                 </doc>
-#                 <group name="flood_gun" type="NXactuator">
+#                 <group name="flood_gun" type="NXactuator" recommended="true">
 #                     <doc>
 #                          Flood gun creating a current of low-energy electrons.
 #                          
-#                          This should be a link to /entry/instrument/flood_gun.
+#                          In most cases this can be a link to /entry/instrument/flood_gun
+#                          if a flood_gun is present in the instrument.
 #                     </doc>
+#                     <field name="value" type="NX_FLOAT" optional="true" units="NX_CURRENT">
+#                         <doc>
+#                              This is to be used if there is no actuator/sensor that controls/measures
+#                              the drain_current.
+#                              
+#                              Note that this method for recording the flood gun current is not advised, but using
+#                              NXsensor and NXactuator is strongly recommended instead.
+#                         </doc>
+#                     </field>
 #                 </group>
 #             </group>
 #         </group>
 #         <group name="data" type="NXdata">
 #             <doc>
-#                  The default NXdata field containing a view on the measured data.
-#                  This NXdata field contains a collection of the main relevant fields (axes).
+#                  The default NXdata group containing a view on the measured data.
+#                  This NXdata group contains a collection of the main relevant fields (axes).
 #                  If you want to provide additional views on your data, you can additionally use
 #                  the generic NXdata group of NXentry.
 #                  
@@ -1502,6 +1646,9 @@ NXmpes(NXobject):
 #                    Could be a link to /entry/instrument/beam/incident_ellipticity or
 #                    /entry/instrument/beam/final_ellipticity if they exist.
 #                    Unit category: NX_ANGLE (° or rad)
+#                  
+#                  Note that this list is a glossary with explicitly named axis names, which is only intended to cover the most
+#                  common measurement axes and is therefore not complete. It is possible to add axes with other names at any time.
 #             </doc>
 #             <attribute name="signal">
 #                 <enumeration>


### PR DESCRIPTION
- [x] clarify that the explicit axis names are not exhaustive and other names are allowed
- [x] rename all environments in NXmpes/NXsample to `*_env` to distinguish them from the same `NX_FLOAT` concepts in the base class `NXsample`
- [x] add the (not recommended) possibility to write a float `value` in these environments if there are no actuators/sensors
- [x] allow multiple of `pressure_gaugeID(NXsensor)` on NXinstrument -> in preparation for a `NXnapxps` appdef
- [x] remove changes to `final_polarization` and `incident_polarization` from `NXsample`

@rettigl @domna this bundles all of the changes we were discussing in the last few days, also with respect to the requests from Stefan and Uwe. My plan is to first merge this and then rebase the `mpes-liquid` branch and finally make the necessary changes on `NXmpes_liquid` there.