### PR TITLE
Fix docs CI to only keep orphan branch

### DIFF
--- a/.github/workflows/fairmat-build-pages.yaml
+++ b/.github/workflows/fairmat-build-pages.yaml
@@ -3,8 +3,8 @@ name: GH pages fairmat proposal
 on:
   push:
     branches: [fairmat]
-  pull_request:
-    branches: [fairmat]
+  # pull_request:
+  #   branches: [fairmat]
 
 jobs:
   pages:
@@ -31,24 +31,40 @@ jobs:
       run: make html
     - name: Remove build artifacts
       run: rm -rf build/manual/build/html/.doctrees
-    - name: Deploy
+    - name: Checkout fairmat-docs branch
+      run: |
+        git fetch origin fairmat-docs
+        git checkout fairmat-docs || git checkout --orphan fairmat-docs
+    
+    - name: Move default branch build into fairmat-docs
       if: steps.branch-name.outputs.is_default == 'true'
+      run: |
+        mkdir -p docs
+        mv -r build/manual/build/html/* docs
+    - name: Move PR build into fairmat-docs
+      if: steps.branch-name.outputs.is_default == 'false'
+      run: |
+        mkdir -p docs/${{ steps.branch-name.outputs.current_branch }}
+        mv -f build/manual/build/html/* docs/${{ steps.branch-name.outputs.current_branch }} 
+    - name: Deploy
+      #if: steps.branch-name.outputs.is_default == 'true'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: build/manual/build/html
+        publish_dir: docs
         publish_branch: fairmat-docs
         destination_dir: docs
         force_orphan: true
-    - name: Deploy PR
-      if: steps.branch-name.outputs.is_default == 'false'
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: build/manual/build/html
-        publish_branch: fairmat-docs
-        destination_dir: docs/${{ steps.branch-name.outputs.current_branch }}
-        force_orphan: true
+
+    # - name: Deploy PR
+    #   if: steps.branch-name.outputs.is_default == 'false'
+    #   uses: peaceiris/actions-gh-pages@v3
+    #   with:
+    #     github_token: ${{ secrets.GITHUB_TOKEN }}
+    #     publish_dir: docs
+    #     publish_branch: fairmat-docs
+    #     destination_dir: docs
+    #     force_orphan: true
 
 
       

--- a/.github/workflows/fairmat-build-pages.yaml
+++ b/.github/workflows/fairmat-build-pages.yaml
@@ -40,12 +40,14 @@ jobs:
       if: steps.branch-name.outputs.is_default == 'true'
       run: |
         mkdir -p docs
-        mv -r build/manual/build/html/* docs
+        cp -r build/manual/build/html/* docs 
+        rm -R build/manual/build/html/*
     - name: Move PR build into fairmat-docs
       if: steps.branch-name.outputs.is_default == 'false'
       run: |
         mkdir -p docs/${{ steps.branch-name.outputs.current_branch }}
-        mv -f build/manual/build/html/* docs/${{ steps.branch-name.outputs.current_branch }} 
+        cp -r build/manual/build/html/* docs/${{ steps.branch-name.outputs.current_branch }}
+        rm -R build/manual/build/html/*
     - name: Deploy
       #if: steps.branch-name.outputs.is_default == 'true'
       uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/fairmat-build-pages.yaml
+++ b/.github/workflows/fairmat-build-pages.yaml
@@ -49,7 +49,6 @@ jobs:
         cp -r build/manual/build/html/* docs/${{ steps.branch-name.outputs.current_branch }}
         rm -R build/manual/build/html/*
     - name: Deploy
-      #if: steps.branch-name.outputs.is_default == 'true'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,16 +56,5 @@ jobs:
         publish_branch: fairmat-docs
         destination_dir: docs
         force_orphan: true
-
-    # - name: Deploy PR
-    #   if: steps.branch-name.outputs.is_default == 'false'
-    #   uses: peaceiris/actions-gh-pages@v3
-    #   with:
-    #     github_token: ${{ secrets.GITHUB_TOKEN }}
-    #     publish_dir: docs
-    #     publish_branch: fairmat-docs
-    #     destination_dir: docs
-    #     force_orphan: true
-
 
       

--- a/.github/workflows/fairmat-build-pages.yaml
+++ b/.github/workflows/fairmat-build-pages.yaml
@@ -3,8 +3,8 @@ name: GH pages fairmat proposal
 on:
   push:
     branches: [fairmat]
-  # pull_request:
-  #   branches: [fairmat]
+  pull_request:
+    branches: [fairmat]
 
 jobs:
   pages:

--- a/.github/workflows/fairmat-build-pages.yaml
+++ b/.github/workflows/fairmat-build-pages.yaml
@@ -29,6 +29,8 @@ jobs:
       run: make prepare
     - name: html
       run: make html
+    - name: Remove build artifacts
+      run: rm -rf build/manual/build/html/.doctrees
     - name: Deploy
       if: steps.branch-name.outputs.is_default == 'true'
       uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/fairmat-build-pages.yaml
+++ b/.github/workflows/fairmat-build-pages.yaml
@@ -3,8 +3,8 @@ name: GH pages fairmat proposal
 on:
   push:
     branches: [fairmat]
-  pull_request:
-    branches: [fairmat]
+  # pull_request:
+  #   branches: [fairmat]
 
 jobs:
   pages:
@@ -31,19 +31,22 @@ jobs:
       run: make html
     - name: Deploy
       if: steps.branch-name.outputs.is_default == 'true'
-      uses: JamesIves/github-pages-deploy-action@v4
+      uses: peaceiris/actions-gh-pages@v3
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        folder: build/manual/build/html
-        branch: fairmat-docs
-        target-folder: docs
-        clean: false
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: build/manual/build/html
+        publish_branch: fairmat-docs
+        destination_dir: docs
+        force_orphan: true
     - name: Deploy PR
       if: steps.branch-name.outputs.is_default == 'false'
-      uses: JamesIves/github-pages-deploy-action@v4
+      uses: peaceiris/actions-gh-pages@v3
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        folder: build/manual/build/html
-        branch: fairmat-docs
-        target-folder: docs/${{ steps.branch-name.outputs.current_branch }}
-        clean: false
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: build/manual/build/html
+        publish_branch: fairmat-docs
+        destination_dir: docs/${{ steps.branch-name.outputs.current_branch }}
+        force_orphan: true
+
+
+      


### PR DESCRIPTION
This changes the deploy action in the `.fairmat-build-pages.yaml` workflow to https://github.com/peaceiris/actions-gh-pages, which has a `force-orphan` option, so that the history of the `fairmat-docs` branch always only contains the docs for the active branches.