### PR TITLE
fix 2theta and use NXobject instead of collection.

### DIFF
--- a/contributed_definitions/NXxrd_pan.nxdl.xml
+++ b/contributed_definitions/NXxrd_pan.nxdl.xml
@@ -166,7 +166,7 @@ defracted_beam(NXbeam):-->
                     </doc>
                 </field>
             </group>
-            <group name="omega" type="NXcollection">
+            <group name="omega" type="NXobject">
                 <field name="start" type="NX_FLOAT" units="NX_ANGLE">
                     <doc>
                          Starting value of the incident angle.

--- a/contributed_definitions/NXxrd_pan.nxdl.xml
+++ b/contributed_definitions/NXxrd_pan.nxdl.xml
@@ -21,15 +21,22 @@
 #
 # For further information, see http://www.nexusformat.org
 -->
-<!--
-n_values - symbols
-! : additions
-? : could or should be modified?-->
 <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXxrd_pan" extends="NXxrd" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
     <doc>
-         NXxrd_pan is a specialisation of NXxrd with exptra properties
+         NXxrd_pan is a specialisation of NXxrd with extra properties 
+         for the PANalytical XRD data format.
     </doc>
     <group type="NXentry">
+        <field name="data_file" optional="true">
+            <doc>
+                 Name of the data file.
+            </doc>
+        </field>
+        <field name="measurement_type">
+            <doc>
+                 Type of measurement.
+            </doc>
+        </field>
         <field name="definition">
             <doc>
                  Official NeXus NXDL schema to which this file conforms.
@@ -138,11 +145,11 @@ n_values - symbols
 beams information about the beam and the object encountered by beam through the path
 incident_beam(NXbeam):
 defracted_beam(NXbeam):-->
-        <group type="NXcollection" optional="true">
+        <group name="experiment_config" type="NXobject" optional="true">
             <doc>
                  Collect user inputs e.g. name or path of the input file.
             </doc>
-            <group name="2theta" type="NXcollection">
+            <group name="two_theta" type="NXobject">
                 <field name="start" type="NX_FLOAT" units="NX_ANGLE">
                     <doc>
                          Starting value of the diffraction angle.
@@ -176,16 +183,6 @@ defracted_beam(NXbeam):-->
                     </doc>
                 </field>
             </group>
-            <field name="data_file" optional="true">
-                <doc>
-                     Name of the data file.
-                </doc>
-            </field>
-            <field name="measurement_type">
-                <doc>
-                     Type of measurement.
-                </doc>
-            </field>
             <field name="beam_attenuation_factors">
                 <doc>
                      Beam attenuation factors over the path.
@@ -212,7 +209,7 @@ defracted_beam(NXbeam):-->
                 </doc>
             </field>
         </group>
-        <group name="2theta_plot" type="NXdata">
+        <group name="two_theta_plot" type="NXdata">
             <doc>
                  Desired plot would be two_theta vs intensity.
             </doc>
@@ -290,11 +287,6 @@ defracted_beam(NXbeam):-->
                 <doc>
                      Usually in xrd sample are being analysed, but sample might be identified by
                      assumed name or given name.
-                </doc>
-            </field>
-            <field name="prepared_by">
-                <doc>
-                     
                 </doc>
             </field>
         </group>

--- a/contributed_definitions/nyaml/NXxrd_pan.yaml
+++ b/contributed_definitions/nyaml/NXxrd_pan.yaml
@@ -1,9 +1,8 @@
 category: application
 doc: |
-  NXxrd_pan is a specialisation of NXxrd with extra properties 
+  NXxrd_pan is a specialisation of NXxrd with extra properties
   for the PANalytical XRD data format.
-
-type: "group"
+type: group
 NXxrd_pan(NXxrd):
   (NXentry):
     data_file:
@@ -18,12 +17,13 @@ NXxrd_pan(NXxrd):
         Official NeXus NXDL schema to which this file conforms.
       enumeration: [NXxrd_pan]
     method:
-      enumeration: [X-Ray Diffraction (XRD)]
       doc: |
         Method used to collect the data
         default='X-Ray Diffraction (XRD)'
+      enumeration: [X-Ray Diffraction (XRD)]
     (NXinstrument):
-    # Need a group that explain 
+      
+      # Need a group that explain
       (NXsource):
         xray_tube_material:
           doc: |
@@ -37,6 +37,7 @@ NXxrd_pan(NXxrd):
           unit: NX_VOLTAGE
           doc: |
             Voltage of the X-ray tube.
+        
         # Unicode for alpha : \u03b1
         k_alpha_one(NX_FLOAT):
           unit: NX_WAVELENGTH
@@ -57,7 +58,7 @@ NXxrd_pan(NXxrd):
         kbeta(NX_FLOAT):
           exists: optional
           unit: NX_WAVELENGTH
-          doc: | 
+          doc: |
             Wavelength of the K\u00df line.
           \@units:
             enumeration: [angstrom]
@@ -68,8 +69,8 @@ NXxrd_pan(NXxrd):
             Wavelength of the X-ray source. Used to convert from 2-theta to Q.
       (NXdetector):
         scan_axis:
-         doc: |
-           Axis scanned.
+          doc: |
+            Axis scanned.
         scan_mode:
           doc: |
             Mode of scan.
@@ -78,6 +79,7 @@ NXxrd_pan(NXxrd):
           unit: NX_TIME
           doc: |
             Integration time per channel.
+    
     # Note: We should need to think about incident and deflected beam (NXbeam). As the data also contains
     # beams information about the beam and the object encountered by beam through the path
     # incident_beam(NXbeam):
@@ -90,7 +92,7 @@ NXxrd_pan(NXxrd):
         start(NX_FLOAT):
           unit: NX_ANGLE
           doc: |
-            Starting value of the diffraction angle. 
+            Starting value of the diffraction angle.
         end(NX_FLOAT):
           unit: NX_ANGLE
           doc: |
@@ -103,7 +105,7 @@ NXxrd_pan(NXxrd):
         start(NX_FLOAT):
           unit: NX_ANGLE
           doc: |
-            Starting value of the incident angle. 
+            Starting value of the incident angle.
         end(NX_FLOAT):
           unit: NX_ANGLE
           doc: |
@@ -113,7 +115,7 @@ NXxrd_pan(NXxrd):
           doc: |
             Minimum step size in the between two incident angles.
       beam_attenuation_factors:
-        doc: | 
+        doc: |
           Beam attenuation factors over the path.
       goniometer_x(NX_FLOAT):
         exists: optional
@@ -131,55 +133,55 @@ NXxrd_pan(NXxrd):
         doc: |
           Goniometer position Z
       count_time(NX_FLOAT):
-        unit: NX_TIME 
+        unit: NX_TIME
         doc: |
           Total time of count.
     two_theta_plot(NXdata):
-      doc: | 
-        Desired plot would be two_theta vs intensity. 
+      doc: |
+        Desired plot would be two_theta vs intensity.
       intensity(NX_FLOAT):
-        dimensions:
-          rank: 1
-          dim: [[1, nDet]]
         doc: |
           Number of scattered electrons per unit time.
+        dimensions:
+          rank: 1
+          dim: (nDet,)
       two_theta(NX_FLOAT):
-        dimensions:
-          rank: 1
-          dim: [[1, nDet]]
         doc: |
-          Axis scale represeting the 2-theta range of the difractogram. 
-      omega(NX_FLOAT):
+          Axis scale represeting the 2-theta range of the difractogram.
         dimensions:
           rank: 1
-          dim: [[1, nDet]]
+          dim: (nDet,)
+      omega(NX_FLOAT):
         exists: optional
         doc: |
           The omega range of the difractogram.
-      phi(NX_FLOAT):
         dimensions:
           rank: 1
-          dim: [[1, nDet]]
+          dim: (nDet,)
+      phi(NX_FLOAT):
         exists: optional
         doc: |
           The phi range of the difractogram
-      chi(NX_FLOAT):
         dimensions:
           rank: 1
-          dim: [[1, nDet]]
+          dim: (nDet,)
+      chi(NX_FLOAT):
         exists: optional
         doc: |
           The chi range of the difractogram
+        dimensions:
+          rank: 1
+          dim: (nDet,)
     q_plot(NXdata):
       exists: optional
       doc: |
         Desired plot would be q_vector vs intensity.
       q(NX_FLOAT):
-        doc: | 
+        doc: |
           Axis scale representing wavevector for scatter energy.
       intensity(NX_FLOAT):
-          doc: |
-            Number of scattered electrons per unit time.
+        doc: |
+          Number of scattered electrons per unit time.
     (NXsample):
       exists: optional
       doc: |
@@ -190,6 +192,304 @@ NXxrd_pan(NXxrd):
       sample_id:
         doc: |
           Id of sample.
-      sample_name: 
+      sample_name:
         doc: |
-          Usually in xrd sample are being analysed, but sample might be identified by assumed name or given name.
+          Usually in xrd sample are being analysed, but sample might be identified by
+          assumed name or given name.
+
+# ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
+# 26a7372651ba3ec8be938e09c1b54c9af5c6d031dc2cca78a9f4a39d3231f7ea
+# <?xml version='1.0' encoding='UTF-8'?>
+# <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+# <!--
+# # NeXus - Neutron and X-ray Common Data Format
+# #
+# # Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+# #
+# # This library is free software; you can redistribute it and/or
+# # modify it under the terms of the GNU Lesser General Public
+# # License as published by the Free Software Foundation; either
+# # version 3 of the License, or (at your option) any later version.
+# #
+# # This library is distributed in the hope that it will be useful,
+# # but WITHOUT ANY WARRANTY; without even the implied warranty of
+# # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# # Lesser General Public License for more details.
+# #
+# # You should have received a copy of the GNU Lesser General Public
+# # License along with this library; if not, write to the Free Software
+# # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# #
+# # For further information, see http://www.nexusformat.org
+# -->
+# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXxrd_pan" extends="NXxrd" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+#     <doc>
+#          NXxrd_pan is a specialisation of NXxrd with extra properties 
+#          for the PANalytical XRD data format.
+#     </doc>
+#     <group type="NXentry">
+#         <field name="data_file" optional="true">
+#             <doc>
+#                  Name of the data file.
+#             </doc>
+#         </field>
+#         <field name="measurement_type">
+#             <doc>
+#                  Type of measurement.
+#             </doc>
+#         </field>
+#         <field name="definition">
+#             <doc>
+#                  Official NeXus NXDL schema to which this file conforms.
+#             </doc>
+#             <enumeration>
+#                 <item value="NXxrd_pan"/>
+#             </enumeration>
+#         </field>
+#         <field name="method">
+#             <doc>
+#                  Method used to collect the data
+#                  default='X-Ray Diffraction (XRD)'
+#             </doc>
+#             <enumeration>
+#                 <item value="X-Ray Diffraction (XRD)"/>
+#             </enumeration>
+#         </field>
+#         <group type="NXinstrument">
+#             <!--Need a group that explain-->
+#             <group type="NXsource">
+#                 <field name="xray_tube_material">
+#                     <doc>
+#                          Type of the X-ray tube.
+#                     </doc>
+#                     <enumeration>
+#                         <item value="Cu"/>
+#                         <item value="Cr"/>
+#                         <item value="Mo"/>
+#                         <item value="Fe"/>
+#                         <item value="Ag"/>
+#                         <item value="In"/>
+#                         <item value="Ga"/>
+#                     </enumeration>
+#                 </field>
+#                 <field name="xray_tube_current" type="NX_FLOAT" units="NX_CURRENT">
+#                     <doc>
+#                          Current of the X-ray tube.
+#                     </doc>
+#                 </field>
+#                 <field name="xray_tube_voltage" type="NX_FLOAT" units="NX_VOLTAGE">
+#                     <doc>
+#                          Voltage of the X-ray tube.
+#                     </doc>
+#                 </field>
+#                 <!--Unicode for alpha : \u03b1-->
+#                 <field name="k_alpha_one" type="NX_FLOAT" units="NX_WAVELENGTH">
+#                     <doc>
+#                          Wavelength of the K\u03b1 1 line.
+#                     </doc>
+#                     <attribute name="units">
+#                         <enumeration>
+#                             <item value="angstrom"/>
+#                         </enumeration>
+#                     </attribute>
+#                 </field>
+#                 <field name="k_alpha_two" type="NX_FLOAT" units="NX_WAVELENGTH">
+#                     <doc>
+#                          Wavelength of the K\u03b1 2 line.
+#                     </doc>
+#                     <attribute name="units">
+#                         <enumeration>
+#                             <item value="angstrom"/>
+#                         </enumeration>
+#                     </attribute>
+#                 </field>
+#                 <field name="ratio_k_alphatwo_k_alphaone" type="NX_FLOAT" units="NX_DIMENSIONLESS">
+#                     <doc>
+#                          K\u03b1 2/K\u03b1 1 intensity ratio.
+#                     </doc>
+#                 </field>
+#                 <field name="kbeta" type="NX_FLOAT" optional="true" units="NX_WAVELENGTH">
+#                     <doc>
+#                          Wavelength of the K\u00df line.
+#                     </doc>
+#                     <attribute name="units">
+#                         <enumeration>
+#                             <item value="angstrom"/>
+#                         </enumeration>
+#                     </attribute>
+#                 </field>
+#                 <field name="source_peak_wavelength" type="NX_FLOAT" optional="true" units="NX_WAVELENGTH">
+#                     <doc>
+#                          Wavelength of the X-ray source. Used to convert from 2-theta to Q.
+#                     </doc>
+#                 </field>
+#             </group>
+#             <group type="NXdetector">
+#                 <field name="scan_axis">
+#                     <doc>
+#                          Axis scanned.
+#                     </doc>
+#                 </field>
+#                 <field name="scan_mode">
+#                     <doc>
+#                          Mode of scan.
+#                     </doc>
+#                 </field>
+#                 <field name="integration_time" type="NX_FLOAT" optional="true" units="NX_TIME">
+#                     <doc>
+#                          Integration time per channel.
+#                     </doc>
+#                 </field>
+#             </group>
+#         </group>
+#         <!--Note: We should need to think about incident and deflected beam (NXbeam). As the data also contains
+# beams information about the beam and the object encountered by beam through the path
+# incident_beam(NXbeam):
+# defracted_beam(NXbeam):-->
+#         <group name="experiment_config" type="NXobject" optional="true">
+#             <doc>
+#                  Collect user inputs e.g. name or path of the input file.
+#             </doc>
+#             <group name="two_theta" type="NXobject">
+#                 <field name="start" type="NX_FLOAT" units="NX_ANGLE">
+#                     <doc>
+#                          Starting value of the diffraction angle.
+#                     </doc>
+#                 </field>
+#                 <field name="end" type="NX_FLOAT" units="NX_ANGLE">
+#                     <doc>
+#                          Ending value of the diffraction angle.
+#                     </doc>
+#                 </field>
+#                 <field name="step" type="NX_FLOAT" units="NX_ANGLE">
+#                     <doc>
+#                          Minimum step size in-between two diffraction angles.
+#                     </doc>
+#                 </field>
+#             </group>
+#             <group name="omega" type="NXobject">
+#                 <field name="start" type="NX_FLOAT" units="NX_ANGLE">
+#                     <doc>
+#                          Starting value of the incident angle.
+#                     </doc>
+#                 </field>
+#                 <field name="end" type="NX_FLOAT" units="NX_ANGLE">
+#                     <doc>
+#                          Ending value of the incident angle.
+#                     </doc>
+#                 </field>
+#                 <field name="step" type="NX_FLOAT" units="NX_ANGLE">
+#                     <doc>
+#                          Minimum step size in the between two incident angles.
+#                     </doc>
+#                 </field>
+#             </group>
+#             <field name="beam_attenuation_factors">
+#                 <doc>
+#                      Beam attenuation factors over the path.
+#                 </doc>
+#             </field>
+#             <field name="goniometer_x" type="NX_FLOAT" optional="true" units="NX_LENGTH">
+#                 <doc>
+#                      Goniometer position X.
+#                 </doc>
+#             </field>
+#             <field name="goniometer_y" type="NX_FLOAT" optional="true" units="NX_LENGTH">
+#                 <doc>
+#                      Goniometer position Y.
+#                 </doc>
+#             </field>
+#             <field name="goniometer_z" type="NX_FLOAT" optional="true" units="NX_LENGTH">
+#                 <doc>
+#                      Goniometer position Z
+#                 </doc>
+#             </field>
+#             <field name="count_time" type="NX_FLOAT" units="NX_TIME">
+#                 <doc>
+#                      Total time of count.
+#                 </doc>
+#             </field>
+#         </group>
+#         <group name="two_theta_plot" type="NXdata">
+#             <doc>
+#                  Desired plot would be two_theta vs intensity.
+#             </doc>
+#             <field name="intensity" type="NX_FLOAT">
+#                 <doc>
+#                      Number of scattered electrons per unit time.
+#                 </doc>
+#                 <dimensions rank="1">
+#                     <dim index="1" value="nDet"/>
+#                 </dimensions>
+#             </field>
+#             <field name="two_theta" type="NX_FLOAT">
+#                 <doc>
+#                      Axis scale represeting the 2-theta range of the difractogram.
+#                 </doc>
+#                 <dimensions rank="1">
+#                     <dim index="1" value="nDet"/>
+#                 </dimensions>
+#             </field>
+#             <field name="omega" type="NX_FLOAT" optional="true">
+#                 <doc>
+#                      The omega range of the difractogram.
+#                 </doc>
+#                 <dimensions rank="1">
+#                     <dim index="1" value="nDet"/>
+#                 </dimensions>
+#             </field>
+#             <field name="phi" type="NX_FLOAT" optional="true">
+#                 <doc>
+#                      The phi range of the difractogram
+#                 </doc>
+#                 <dimensions rank="1">
+#                     <dim index="1" value="nDet"/>
+#                 </dimensions>
+#             </field>
+#             <field name="chi" type="NX_FLOAT" optional="true">
+#                 <doc>
+#                      The chi range of the difractogram
+#                 </doc>
+#                 <dimensions rank="1">
+#                     <dim index="1" value="nDet"/>
+#                 </dimensions>
+#             </field>
+#         </group>
+#         <group name="q_plot" type="NXdata" optional="true">
+#             <doc>
+#                  Desired plot would be q_vector vs intensity.
+#             </doc>
+#             <field name="q" type="NX_FLOAT">
+#                 <doc>
+#                      Axis scale representing wavevector for scatter energy.
+#                 </doc>
+#             </field>
+#             <field name="intensity" type="NX_FLOAT">
+#                 <doc>
+#                      Number of scattered electrons per unit time.
+#                 </doc>
+#             </field>
+#         </group>
+#         <group type="NXsample" optional="true">
+#             <doc>
+#                  Description on sample.
+#             </doc>
+#             <field name="sample_mode">
+#                 <doc>
+#                      Mode of sample.
+#                 </doc>
+#             </field>
+#             <field name="sample_id">
+#                 <doc>
+#                      Id of sample.
+#                 </doc>
+#             </field>
+#             <field name="sample_name">
+#                 <doc>
+#                      Usually in xrd sample are being analysed, but sample might be identified by
+#                      assumed name or given name.
+#                 </doc>
+#             </field>
+#         </group>
+#     </group>
+# </definition>

--- a/contributed_definitions/nyaml/NXxrd_pan.yaml
+++ b/contributed_definitions/nyaml/NXxrd_pan.yaml
@@ -1,12 +1,18 @@
 category: application
 doc: |
-  NXxrd_pan is a specialisation of NXxrd with exptra properties
-# n_values - symbols
-# ! : additions
-# ? : could or should be modified?
+  NXxrd_pan is a specialisation of NXxrd with extra properties 
+  for the PANalytical XRD data format.
+
 type: "group"
 NXxrd_pan(NXxrd):
   (NXentry):
+    data_file:
+      exists: optional
+      doc: |
+        Name of the data file.
+    measurement_type:
+      doc: |
+        Type of measurement.
     definition:
       doc: |
         Official NeXus NXDL schema to which this file conforms.
@@ -76,11 +82,11 @@ NXxrd_pan(NXxrd):
     # beams information about the beam and the object encountered by beam through the path
     # incident_beam(NXbeam):
     # defracted_beam(NXbeam):
-    (NXcollection):
+    experiment_config(NXobject):
       exists: optional
-      doc: | 
+      doc: |
         Collect user inputs e.g. name or path of the input file.
-      2theta(NXcollection):
+      two_theta(NXobject):
         start(NX_FLOAT):
           unit: NX_ANGLE
           doc: |
@@ -93,7 +99,7 @@ NXxrd_pan(NXxrd):
           unit: NX_ANGLE
           doc: |
             Minimum step size in-between two diffraction angles.
-      omega(NXcollection):
+      omega(NXobject):
         start(NX_FLOAT):
           unit: NX_ANGLE
           doc: |
@@ -106,13 +112,6 @@ NXxrd_pan(NXxrd):
           unit: NX_ANGLE
           doc: |
             Minimum step size in the between two incident angles.
-      data_file:
-        exists: optional
-        doc: |
-          Name of the data file.
-      measurement_type:
-        doc: |
-          Type of measurement.
       beam_attenuation_factors:
         doc: | 
           Beam attenuation factors over the path.
@@ -135,7 +134,7 @@ NXxrd_pan(NXxrd):
         unit: NX_TIME 
         doc: |
           Total time of count.
-    2theta_plot(NXdata):
+    two_theta_plot(NXdata):
       doc: | 
         Desired plot would be two_theta vs intensity. 
       intensity(NX_FLOAT):
@@ -194,5 +193,3 @@ NXxrd_pan(NXxrd):
       sample_name: 
         doc: |
           Usually in xrd sample are being analysed, but sample might be identified by assumed name or given name.
-      prepared_by:
-        doc: |


### PR DESCRIPTION
1. A quick fix for NeXus incompatible concept name `2theta` for XRD use case.
2. Replace NXcollection for NXobject.