### PR TITLE
Update optical spec website to include optical spectroscopy and raman

### DIFF
--- a/dev_tools/docs/nxdl_index.py
+++ b/dev_tools/docs/nxdl_index.py
@@ -68,7 +68,7 @@ def nxdl_indices() -> Dict[str, dict]:
             print("---------++++++++-", section)
         if file.endswith("contributed_definitions/index.rst"):
             rst_lines.append(f"{indentation}em-structure\n")
-            rst_lines.append(f"{indentation}optical-spectroscopy\n")
+            rst_lines.append(f"{indentation}optical-spectroscopy-structure\n")
             rst_lines.append(f"{indentation}mpes-structure\n")
             rst_lines.append(f"{indentation}apm-structure\n")
             rst_lines.append(f"{indentation}transport-structure\n")

--- a/dev_tools/docs/nxdl_index.py
+++ b/dev_tools/docs/nxdl_index.py
@@ -68,7 +68,7 @@ def nxdl_indices() -> Dict[str, dict]:
             print("---------++++++++-", section)
         if file.endswith("contributed_definitions/index.rst"):
             rst_lines.append(f"{indentation}em-structure\n")
-            rst_lines.append(f"{indentation}ellipsometry-structure\n")
+            rst_lines.append(f"{indentation}optical-spectroscopy\n")
             rst_lines.append(f"{indentation}mpes-structure\n")
             rst_lines.append(f"{indentation}apm-structure\n")
             rst_lines.append(f"{indentation}transport-structure\n")

--- a/dev_tools/docs/nxdl_index.py
+++ b/dev_tools/docs/nxdl_index.py
@@ -163,7 +163,7 @@ definitions and provide feedback to the authors before ratification
 and acceptance as either a base class or application definition.
 
 Some contributions are grouped together:
-  :ref:`Optical Spectroscopy <Ellipsometry-Structure>`
+  :ref:`Optical Spectroscopy <Optical-Spectroscopy-Structure>`
 
   :ref:`Multi-dimensional Photoemission Spectroscopy <Mpes-Structure>`
 

--- a/manual/source/classes/contributed_definitions/optical-spectroscopy-structure.rst
+++ b/manual/source/classes/contributed_definitions/optical-spectroscopy-structure.rst
@@ -1,4 +1,4 @@
-.. _Ellipsometry-Structure:
+.. _Optical-Spectroscopy-Structure:
 
 ====================
 Optical Spectroscopy

--- a/manual/source/ellipsometry-structure.rst
+++ b/manual/source/ellipsometry-structure.rst
@@ -5,8 +5,35 @@ Optical spectroscopy
 ====================
 
 .. index::
+   OpticalSpec1
    Ellipsometry1
+   Raman1
    DispersiveMaterial1
+
+.. _OpticalSpec1:
+
+Optical Spectroscopy
+##############
+
+
+
+
+Application Definitions
+-----------------------
+
+We created one application definition:
+
+    :ref:`NXoptical_spectroscopy`:
+       A general application definition for optical spectroscopy measurements. This includes specifically:
+         photoluminescence
+         transmission spectroscopy
+         reflection spectroscopy
+         and general spectroscopy experiments
+
+   General spectroscopy experiments refer to experiments of the type photon-in photon-out. A detector is required to measure the "photon-out"-signal.
+   For Ellipsomertry and Raman spectroscopy are specific application definitions listed below.
+
+
 
 
 .. _Ellipsometry1:
@@ -16,7 +43,7 @@ Ellipsometry
 
 Ellipsometry is an optical characterization method to describe optical properties of interfaces and thickness of films. The measurements are based on determining how the polarization state of light changes upon transmission and reflection. Interpretation is based on Fresnel equations and numerical models of the optical properties of the materials.
 
-In the application definition we provide a minimum set of description elements allowing for a reproducible recording of ellipsometry measurements. 
+This application definition is an extension of :ref:`NXoptical_spectroscopy`. It provide a minimum set of description elements allowing for a reproducible recording of ellipsometry measurements. 
 
 
 Application Definitions
@@ -26,6 +53,27 @@ We created one application definition:
 
     :ref:`NXellipsometry`:
        A general application definition for ellipsometry measurements, including complex systems up to variable angle spectroscopic ellipsometry. 
+
+
+.. _Raman1:
+
+Raman NXoptical_spectroscopy
+##############
+
+Raman spectroscopy is an optical characterization method by measuring elastic light scattering. In this way phonon characteristics are measured for a extreme broad range of samples: gasses, liquids, solids, glasses, crystals. 
+
+The application definition provides an extension of :ref:`NXoptical_spectroscopy` to cover required or relevant data from Raman scattering experiments.
+
+
+Application Definitions
+-----------------------
+
+We created one application definition:
+
+    :ref:`NXraman`:
+       A general application definition for Raman measurements.
+
+
 
 
 Dispersive Material

--- a/manual/source/index.rst
+++ b/manual/source/index.rst
@@ -14,7 +14,7 @@ https://www.nexusformat.org/
     nexus-index
     em-structure
     mpes-structure
-    ellipsometry-structure
+    optical-spectroscopy
     apm-structure
     transport-structure
     sts-structure

--- a/manual/source/index.rst
+++ b/manual/source/index.rst
@@ -14,7 +14,7 @@ https://www.nexusformat.org/
     nexus-index
     em-structure
     mpes-structure
-    optical-spectroscopy
+    optical-spectroscopy-structure
     apm-structure
     transport-structure
     sts-structure

--- a/manual/source/optical-spectroscopy-structure.rst
+++ b/manual/source/optical-spectroscopy-structure.rst
@@ -1,4 +1,4 @@
-.. _Ellipsometry-Structure-Fairmat:
+.. _Optical-Spectroscopy-Structure-Fairmat:
 
 ====================
 Optical spectroscopy

--- a/manual/source/optical-spectroscopy-structure.rst
+++ b/manual/source/optical-spectroscopy-structure.rst
@@ -4,6 +4,18 @@
 Optical spectroscopy
 ====================
 
+.. index::
+   OpticalSpec1
+   Ellipsometry1
+   Raman1
+   DispersiveMaterial1
+
+.. _OpticalSpec1:
+
+Optical Spectroscopy
+##############
+
+
 
 
 Application Definitions
@@ -23,6 +35,9 @@ We created one application definition:
 
 
 
+
+.. _Ellipsometry1:
+
 Ellipsometry
 ############
 
@@ -36,9 +51,11 @@ Application Definitions
 
 We created one application definition:
 
-
+    :ref:`NXellipsometry`:
        A general application definition for ellipsometry measurements, including complex systems up to variable angle spectroscopic ellipsometry. 
 
+
+.. _Raman1:
 
 Raman spectroscopy
 ##################

--- a/manual/source/optical-spectroscopy-structure.rst
+++ b/manual/source/optical-spectroscopy-structure.rst
@@ -13,7 +13,7 @@ Optical spectroscopy
 .. _OpticalSpec1:
 
 Optical Spectroscopy
-##############
+####################
 
 
 

--- a/manual/source/optical-spectroscopy-structure.rst
+++ b/manual/source/optical-spectroscopy-structure.rst
@@ -57,7 +57,7 @@ We created one application definition:
 
 .. _Raman1:
 
-Raman NXoptical_spectroscopy
+Raman spectroscopy
 ##############
 
 Raman spectroscopy is an optical characterization method by measuring elastic light scattering. In this way phonon characteristics are measured for a extreme broad range of samples: gasses, liquids, solids, glasses, crystals. 

--- a/manual/source/optical-spectroscopy-structure.rst
+++ b/manual/source/optical-spectroscopy-structure.rst
@@ -4,18 +4,6 @@
 Optical spectroscopy
 ====================
 
-.. index::
-   OpticalSpec1
-   Ellipsometry1
-   Raman1
-   DispersiveMaterial1
-
-.. _OpticalSpec1:
-
-Optical Spectroscopy
-##############
-
-
 
 
 Application Definitions
@@ -35,11 +23,8 @@ We created one application definition:
 
 
 
-
-.. _Ellipsometry1:
-
 Ellipsometry
-##############
+############
 
 Ellipsometry is an optical characterization method to describe optical properties of interfaces and thickness of films. The measurements are based on determining how the polarization state of light changes upon transmission and reflection. Interpretation is based on Fresnel equations and numerical models of the optical properties of the materials.
 
@@ -51,14 +36,12 @@ Application Definitions
 
 We created one application definition:
 
-    :ref:`NXellipsometry`:
+
        A general application definition for ellipsometry measurements, including complex systems up to variable angle spectroscopic ellipsometry. 
 
 
-.. _Raman1:
-
 Raman spectroscopy
-##############
+##################
 
 Raman spectroscopy is an optical characterization method by measuring elastic light scattering. In this way phonon characteristics are measured for a extreme broad range of samples: gasses, liquids, solids, glasses, crystals. 
 


### PR DESCRIPTION
This shall update the webpage, which is accessible for users via the TOC on the left of on the page: https://fairmat-nfdi.github.io/nexus_definitions/index.html# under optical spectroscopy.

any notes regarding general optical spectroscopy or Raman were not present.

Have to test if the links are messed up, as i renamed a .rst file from ellipsometry-structure to optical-spectroscopy-structure.
