### PR TITLE
Fix nymaType, NXidentifier, NXcomponent instead of NXobject where nee…

### DIFF
--- a/contributed_definitions/NXafm.nxdl.xml
+++ b/contributed_definitions/NXafm.nxdl.xml
@@ -45,6 +45,7 @@
                 <item value="non-contact mode"/>
                 <item value="Kelvin probe"/>
                 <item value="electric force"/>
+                <item value="lateral force mode"/>
             </enumeration>
         </field>
         <group name="experiment_instrument" type="NXinstrument">

--- a/contributed_definitions/NXafm.nxdl.xml
+++ b/contributed_definitions/NXafm.nxdl.xml
@@ -206,7 +206,7 @@
                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </field>
-            <group name="cantilever_oscillator" type="NXobject" optional="true">
+            <group name="cantilever_oscillator" type="NXcomponent" optional="true">
                 <doc>
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/cantilever_spm/cantilever_oscillator

--- a/contributed_definitions/NXafm.nxdl.xml
+++ b/contributed_definitions/NXafm.nxdl.xml
@@ -39,7 +39,7 @@
             <doc>
                 The mode of the scan.
             </doc>
-            <enumeration>
+            <enumeration open="true">
                 <item value="contact mode"/>
                 <item value="tapping mode"/>
                 <item value="non-contact mode"/>
@@ -70,7 +70,7 @@
                       on the cantilever is reached. The measured force is used as an input of a PID feedback loop, and the output of
                       this loop controls the vertical position of the cantilever.
                 </doc>
-                <group name="cantilever_oscillator" type="NXobject" optional="true">
+                <group name="cantilever_oscillator" type="NXcomponent" optional="true">
                     <doc>
                         When a cantilever is oscillated close to its resonance, this describes the oscillator properties.
                         
@@ -113,7 +113,7 @@
                 </group>
                 <group name="tip_temp_sensor" type="NXsensor">
                     <doc>
-                        Link to the group ENTRY[entry]/experiment_instrument/cantilever_temperature.
+                        Link to the group ENTRY[entry]/experiment_instrument/tip_temp_sensor.
                     </doc>
                 </group>
             </group>
@@ -167,16 +167,67 @@
                 </doc>
             </group>
         </group>
-        <group name="reproducibility_indicators" type="NXobject">
+        <group name="reproducibility_indicators" type="NXobject" optional="true">
             <doc>
                 The group of indicators (links to the existing fields in different groups) that measure
                 the reproducibility of the experiment.
             </doc>
+            <field name="cantilever_tip_temp" type="NX_NUMBER" optional="true">
+                <doc>
+                    Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+                </doc>
+            </field>
+            <field name="cryo_bottom_temp" type="NX_NUMBER" optional="true">
+                <doc>
+                    Link to target:
+                    /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
+                </doc>
+            </field>
+            <field name="cryo_shield_temp" type="NX_NUMBER" optional="true">
+                <doc>
+                    Link to target:
+                    /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
+                </doc>
+            </field>
+            <group name="cantilever_oscillator" type="NXobject" optional="true">
+                <doc>
+                    Link to target: /ENTRY[entry]/experiment_instrument/cantilever_oscillator
+                </doc>
+            </group>
         </group>
         <group name="resolution_indicators" type="NXobject" optional="true">
             <doc>
                 The group of indicators (links to the existing fields in different groups) that
             </doc>
+            <group name="cantilever_tip_temp" type="NXsensor" optional="true">
+                <doc>
+                    Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+                </doc>
+            </group>
+            <group name="cryo_bottom_temp" type="NXsensor" optional="true">
+                <doc>
+                    Link to target:
+                    /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
+                </doc>
+            </group>
+            <group name="cryo_shield_temp" type="NXsensor" optional="true">
+                <doc>
+                    Link to target:
+                    /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
+                </doc>
+            </group>
+            <field name="oscillator_excitation" type="NX_NUMBER" optional="true">
+                <doc>
+                    Link to target: 
+                    /ENTRY[entry]/experiment_instrument/cantilever_oscillator/oscillator_excitation
+                </doc>
+            </field>
+            <field name="amplitude_excitation" type="NX_NUMBER" optional="true">
+                <doc>
+                    Link to target: 
+                    /ENTRY[entry]/experiment_instrument/cantilever_oscillator/phase_lock_loop/amplitude_excitation
+                </doc>
+            </field>
         </group>
     </group>
 </definition>

--- a/contributed_definitions/NXafm.nxdl.xml
+++ b/contributed_definitions/NXafm.nxdl.xml
@@ -103,17 +103,26 @@
                 </doc>
                 <group name="height_piezo_sensor" type="NXsensor">
                     <doc>
-                        Link to the group ENTRY[entry]/experiment_instrument/height_piezo_sensor.
+                        Link to the group
+                        ENTRY[entry]/experiment_instrument/height_piezo_sensor.
+                        
+                        Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                     </doc>
                 </group>
                 <group name="XY_piezo_sensor" type="NXsensor" nameType="specified">
                     <doc>
-                        Link to the group ENTRY[entry]/experiment_instrument/XY_piezo_sensor.
+                        Link to the group
+                        ENTRY[entry]/experiment_instrument/XY_piezo_sensor.
+                        
+                        Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                     </doc>
                 </group>
                 <group name="tip_temp_sensor" type="NXsensor">
                     <doc>
-                        Link to the group ENTRY[entry]/experiment_instrument/tip_temp_sensor.
+                        Link to the group
+                        ENTRY[entry]/experiment_instrument/tip_temp_sensor.
+                        
+                        Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                     </doc>
                 </group>
             </group>
@@ -167,65 +176,86 @@
                 </doc>
             </group>
         </group>
-        <group name="reproducibility_indicators" type="NXobject" optional="true">
+        <group name="reproducibility_indicators" type="NXcollection" optional="true">
             <doc>
                 The group of indicators (links to the existing fields in different groups) that measure
                 the reproducibility of the experiment.
             </doc>
             <field name="cantilever_tip_temp" type="NX_NUMBER" optional="true">
                 <doc>
-                    Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+                    Link to target:
+                    /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+                    
+                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                 </doc>
             </field>
             <field name="cryo_bottom_temp" type="NX_NUMBER" optional="true">
                 <doc>
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
+                    
+                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                 </doc>
             </field>
             <field name="cryo_shield_temp" type="NX_NUMBER" optional="true">
                 <doc>
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
+                    
+                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                 </doc>
             </field>
             <group name="cantilever_oscillator" type="NXobject" optional="true">
                 <doc>
-                    Link to target: /ENTRY[entry]/experiment_instrument/cantilever_oscillator
+                    Link to target:
+                    /ENTRY[entry]/experiment_instrument/cantilever_oscillator
+                    
+                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                 </doc>
             </group>
         </group>
-        <group name="resolution_indicators" type="NXobject" optional="true">
+        <group name="resolution_indicators" type="NXcollection" optional="true">
             <doc>
                 The group of indicators (links to the existing fields in different groups) that
             </doc>
             <group name="cantilever_tip_temp" type="NXsensor" optional="true">
                 <doc>
-                    Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+                    Link to target:
+                    /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+                    
+                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                 </doc>
             </group>
             <group name="cryo_bottom_temp" type="NXsensor" optional="true">
                 <doc>
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
+                    
+                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                 </doc>
             </group>
             <group name="cryo_shield_temp" type="NXsensor" optional="true">
                 <doc>
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
+                    
+                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                 </doc>
             </group>
             <field name="oscillator_excitation" type="NX_NUMBER" optional="true">
                 <doc>
-                    Link to target: 
+                    Link to target:
                     /ENTRY[entry]/experiment_instrument/cantilever_oscillator/oscillator_excitation
+                    
+                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                 </doc>
             </field>
             <field name="amplitude_excitation" type="NX_NUMBER" optional="true">
                 <doc>
-                    Link to target: 
+                    Link to target:
                     /ENTRY[entry]/experiment_instrument/cantilever_oscillator/phase_lock_loop/amplitude_excitation
+                    
+                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                 </doc>
             </field>
         </group>

--- a/contributed_definitions/NXafm.nxdl.xml
+++ b/contributed_definitions/NXafm.nxdl.xml
@@ -107,7 +107,7 @@
                         Link to the group
                         ENTRY[entry]/experiment_instrument/height_piezo_sensor.
                         
-                        Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                        Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                     </doc>
                 </group>
                 <group name="XY_piezo_sensor" type="NXsensor" nameType="specified">
@@ -115,7 +115,7 @@
                         Link to the group
                         ENTRY[entry]/experiment_instrument/XY_piezo_sensor.
                         
-                        Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                        Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                     </doc>
                 </group>
                 <group name="tip_temp_sensor" type="NXsensor">
@@ -123,7 +123,7 @@
                         Link to the group
                         ENTRY[entry]/experiment_instrument/tip_temp_sensor.
                         
-                        Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                        Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                     </doc>
                 </group>
             </group>
@@ -187,7 +187,7 @@
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
                     
-                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </field>
             <field name="cryo_bottom_temp" type="NX_NUMBER" optional="true">
@@ -195,7 +195,7 @@
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
                     
-                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </field>
             <field name="cryo_shield_temp" type="NX_NUMBER" optional="true">
@@ -203,15 +203,15 @@
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
                     
-                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </field>
             <group name="cantilever_oscillator" type="NXobject" optional="true">
                 <doc>
                     Link to target:
-                    /ENTRY[entry]/experiment_instrument/cantilever_oscillator
+                    /ENTRY[entry]/experiment_instrument/cantilever_spm/cantilever_oscillator
                     
-                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </group>
         </group>
@@ -224,7 +224,7 @@
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
                     
-                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </group>
             <group name="cryo_bottom_temp" type="NXsensor" optional="true">
@@ -232,7 +232,7 @@
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
                     
-                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </group>
             <group name="cryo_shield_temp" type="NXsensor" optional="true">
@@ -240,23 +240,23 @@
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
                     
-                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </group>
             <field name="oscillator_excitation" type="NX_NUMBER" optional="true">
                 <doc>
                     Link to target:
-                    /ENTRY[entry]/experiment_instrument/cantilever_oscillator/oscillator_excitation
+                    /ENTRY[entry]/experiment_instrument/cantilever_spm/cantilever_oscillator/oscillator_excitation
                     
-                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </field>
             <field name="amplitude_excitation" type="NX_NUMBER" optional="true">
                 <doc>
                     Link to target:
-                    /ENTRY[entry]/experiment_instrument/cantilever_oscillator/phase_lock_loop/amplitude_excitation
+                    /ENTRY[entry]/experiment_instrument/cantilever_spm/cantilever_oscillator/phase_lock_loop/amplitude_excitation
                     
-                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </field>
         </group>

--- a/contributed_definitions/NXamplifier.nxdl.xml
+++ b/contributed_definitions/NXamplifier.nxdl.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format
@@ -21,67 +21,67 @@
 #
 # For further information, see http://www.nexusformat.org
 -->
-<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" name="NXamplifier" extends="NXobject" type="group" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXamplifier" extends="NXcomponent" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
     <doc>
-         Base classed definition for amplifier devices.
+        Base classed definition for amplifier devices.
     </doc>
     <group name="hardware" type="NXfabrication">
         <doc>
-             (IC, device) (NXmanufacturer?)
+            (IC, device) (NXmanufacturer?)
         </doc>
     </group>
     <field name="num_of_channels" type="NX_NUMBER">
         <doc>
-             The number of preamplifier channels are assgined.
+            The number of preamplifier channels are assgined.
         </doc>
     </field>
     <field name="active_channels" type="NX_NUMBER">
         <doc>
-             The number of preamplifier channels are ready tp to be used. (array for active
-             channels)
+            The number of preamplifier channels are ready tp to be used. (array for active
+            channels)
         </doc>
     </field>
     <field name="openloop_amplification" type="NX_NUMBER">
         <doc>
-             The output signal does not go through a feedback loop to adjust the
-             amplification of the amplifier. (array for active channels)
+            The output signal does not go through a feedback loop to adjust the
+            amplification of the amplifier. (array for active channels)
         </doc>
     </field>
     <!--amplification(NX_NUMBER):
 doc: !!! The ratio of the amplitude of the output signal to the amplitude of the input signal. (array for active channels) # From google.-->
     <field name="signal_over_noise" type="NX_NUMBER">
         <doc>
-             The ratio of the amplitue of the useful signal to the amplitude of the noise in
-             the output signal of the amplifier. S/N=V_signal/V_noise. (array for active
-             channels)
+            The ratio of the amplitue of the useful signal to the amplitude of the noise in
+            the output signal of the amplifier. S/N=V_signal/V_noise. (array for active
+            channels)
         </doc>
     </field>
     <field name="crosstalk_factor" type="NX_NUMBER">
         <doc>
-             (if active &gt;1)
+            (if active &gt;1)
         </doc>
     </field>
     <field name="crosstalk_compensation" type="NX_BOOLEAN">
         <doc>
-             for reducing interferences between different signalling pathways
+            for reducing interferences between different signalling pathways
         </doc>
     </field>
     <field name="bandwidth" type="NX_NUMBER" units="NX_FREQUENCY">
         <doc>
-             The spectrum of frequency it can amplify, from its lowest to highest frequency
-             limits.
+            The spectrum of frequency it can amplify, from its lowest to highest frequency
+            limits.
         </doc>
     </field>
     <field name="low_pass" type="NX_NUMBER" units="NX_FREQUENCY">
         <doc>
-             Order and cut-off frequency of the low-pass filter applied on the demodulated
-             signals (X,Y). Cut-off frq (low pass filter) (foreach DemodulatorChannels)
+            Order and cut-off frequency of the low-pass filter applied on the demodulated
+            signals (X,Y). Cut-off frq (low pass filter) (foreach DemodulatorChannels)
         </doc>
     </field>
     <field name="hi_pass" type="NX_NUMBER" units="NX_FREQUENCY">
         <doc>
-             Order and cut-off frequency of the high-pass filter applied on the demodulation
-             signal. Cut-off frq (hi pass filter) (foreach DemodulatorChannels)
+            Order and cut-off frequency of the high-pass filter applied on the demodulation
+            signal. Cut-off frq (hi pass filter) (foreach DemodulatorChannels)
         </doc>
     </field>
     <!--voltage_amplifier_factor(NX_NUMBER):

--- a/contributed_definitions/NXbias_spectroscopy.nxdl.xml
+++ b/contributed_definitions/NXbias_spectroscopy.nxdl.xml
@@ -126,6 +126,12 @@ each other (e.g. spiral)-->
                 The time (at the last sweep) to settle for the last value of the sweep.
             </doc>
         </field>
+        <field name="settling_time" type="NX_NUMBER" units="NX_TIME">
+            <doc>
+                The time is taken to settle the bias voltage at the desired value. On each sweep usually, the system
+                takes time to settle the bias voltage at the next value.
+            </doc>
+        </field>
         <field name="max_slew_rate" type="NX_NUMBER" optional="true" units="NX_ANY">
             <doc>
                 The rate at which the amplifier responds to the voltage change

--- a/contributed_definitions/NXcantilever_spm.nxdl.xml
+++ b/contributed_definitions/NXcantilever_spm.nxdl.xml
@@ -26,7 +26,7 @@
         A base class to describe the cantilever used in Atomic Force Microscopy (AFM)
         techniques.
     </doc>
-    <group name="cantilever_oscillator" type="NXobject">
+    <group name="cantilever_oscillator" type="NXcomponent">
         <doc>
             Generally speaking, the cantilever resembles a simple harmonic oscillator.
             When the cantilever tip is close to the surface of the sample, an attractive or repulsive force appears between the cantilever and the sample, deforming the cantilever. The detector (typically a photodiode) measures this deformation and, therefore, the force acting on the cantilever.

--- a/contributed_definitions/NXcircuit.nxdl.xml
+++ b/contributed_definitions/NXcircuit.nxdl.xml
@@ -21,142 +21,142 @@
 #
 # For further information, see http://www.nexusformat.org
 -->
-<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXcircuit" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXcircuit" extends="NXcomponent" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
     <symbols>
         <doc>
-             Constant to be used in the definition: the number of channels of the
-             circuit board.
+            Constant to be used in the definition: the number of channels of the
+            circuit board.
         </doc>
         <symbol name="N_channel">
             <doc>
-                 number of channels of the circuit board.
+                number of channels of the circuit board.
             </doc>
         </symbol>
     </symbols>
     <doc>
-         Application definition for circuit devices.
-         
-         Electronic circuits are hardware components connecting several electronic components to achieve
-         specific functionality, e.g. amplifying a voltage or convert a voltage to binary numbers, etc.
+        Application definition for circuit devices.
+        
+        Electronic circuits are hardware components connecting several electronic components to achieve
+        specific functionality, e.g. amplifying a voltage or convert a voltage to binary numbers, etc.
     </doc>
     <group name="hardware" type="NXfabrication">
         <doc>
-             Hardware where the circuit is implanted; includes information about the hardware manufacturers and
-             type (e.g. part number)
-             All the elements below may be single numbers of an array of values with length N_channel
-             describing multiple input and output channels.
+            Hardware where the circuit is implanted; includes information about the hardware manufacturers and
+            type (e.g. part number)
+            All the elements below may be single numbers of an array of values with length N_channel
+            describing multiple input and output channels.
         </doc>
     </group>
     <field name="components">
         <doc>
-             List of components used in the circuit, e.g., resistors, capacitors, transistors or any
-             other complex components.
+            List of components used in the circuit, e.g., resistors, capacitors, transistors or any
+            other complex components.
         </doc>
     </field>
     <field name="connections">
         <doc>
-             Description of how components are interconnected, including connection points
-             and wiring.
+            Description of how components are interconnected, including connection points
+            and wiring.
         </doc>
     </field>
     <field name="power_source">
         <doc>
-             Details of the power source for the circuit, including voltage and current
-             ratings.
+            Details of the power source for the circuit, including voltage and current
+            ratings.
         </doc>
     </field>
     <field name="signal_type">
         <doc>
-             Type of signal (input signal) the circuit is designed to handle, e.g., analog,
-             digital, mixed-signal.
+            Type of signal (input signal) the circuit is designed to handle, e.g., analog,
+            digital, mixed-signal.
         </doc>
     </field>
     <!--should this be a min / max range?-->
     <field name="operating_frequency" type="NX_NUMBER" units="NX_FREQUENCY">
         <doc>
-             The operating frequency of the circuit, see also bandwidth below, which is possibly
-             centered around this frequency. However, not necessarily (e.g. running a 100 kHz bandwidth
-             amplifier at low, audio frequencies 1 - 20,000 Hz)
+            The operating frequency of the circuit, see also bandwidth below, which is possibly
+            centered around this frequency. However, not necessarily (e.g. running a 100 kHz bandwidth
+            amplifier at low, audio frequencies 1 - 20,000 Hz)
         </doc>
     </field>
     <!--we may need an NX_RESISTANCE defined-->
     <field name="input_impedance" type="NX_NUMBER" units="NX_ANY">
         <doc>
-             Input impedance of the circuit.
+            Input impedance of the circuit.
         </doc>
     </field>
     <field name="output_impedance" type="NX_NUMBER" units="NX_ANY">
         <doc>
-             Output impedance of the circuit.
+            Output impedance of the circuit.
         </doc>
     </field>
     <field name="gain" type="NX_NUMBER" units="NX_UNITLESS">
         <doc>
-             Gain of the circuit, if applicable, usually all instruments have a gain which might be
-             important or not.
+            Gain of the circuit, if applicable, usually all instruments have a gain which might be
+            important or not.
         </doc>
     </field>
     <field name="noise_level" type="NX_NUMBER" units="NX_ANY">
         <doc>
-             RMS noise level (in current or voltage) in the circuit in voltage or current.
+            RMS noise level (in current or voltage) in the circuit in voltage or current.
         </doc>
     </field>
     <field name="bandwidth" type="NX_NUMBER" units="NX_FREQUENCY">
         <doc>
-             The bandwidth of the frequency response of the circuit.
+            The bandwidth of the frequency response of the circuit.
         </doc>
     </field>
     <field name="temperature_range" type="NX_NUMBER" units="NX_ANY">
         <doc>
-             Operating temperature range of the circuit.
+            Operating temperature range of the circuit.
         </doc>
     </field>
     <group name="calibration" type="NXcalibration">
         <doc>
-             Calibration data for the circuit.
+            Calibration data for the circuit.
         </doc>
     </group>
     <field name="offset" type="NX_NUMBER" units="NX_ANY">
         <doc>
-             Offset value for current or voltage.
+            Offset value for current or voltage.
         </doc>
     </field>
     <field name="output_channels" type="NX_NUMBER">
         <doc>
-             Number of output channels collected to this circuit. Most probably N_channel.
+            Number of output channels collected to this circuit. Most probably N_channel.
         </doc>
     </field>
     <field name="output_signal" type="NX_NUMBER" units="NX_ANY">
         <doc>
-             Type of output signal, e.g., voltage, current, digital.
+            Type of output signal, e.g., voltage, current, digital.
         </doc>
     </field>
     <field name="power_consumption" type="NX_NUMBER" units="NX_ANY">
         <doc>
-             Power consumption of the circuit per unit time.
+            Power consumption of the circuit per unit time.
         </doc>
     </field>
     <field name="status_indicators">
         <doc>
-             Status indicators for the circuit, e.g., LEDs, display readouts.
+            Status indicators for the circuit, e.g., LEDs, display readouts.
         </doc>
     </field>
     <field name="protection_features" type="NX_CHAR">
         <doc>
-             Protection features built into the circuit, e.g., overvoltage protection,
-             thermal shutdown.
+            Protection features built into the circuit, e.g., overvoltage protection,
+            thermal shutdown.
         </doc>
     </field>
     <field name="acquisition_time" type="NX_NUMBER" units="NX_TIME">
         <doc>
-             Updated rate for several processes using the input signal, e.g., History Graph, the circuit
-             uses for any such process.
+            Updated rate for several processes using the input signal, e.g., History Graph, the circuit
+            uses for any such process.
         </doc>
     </field>
     <field name="output_slew_rate" type="NX_CHAR">
         <doc>
-             The rate at which the signal changes when ramping from the starting
-             value.
+            The rate at which the signal changes when ramping from the starting
+            value.
         </doc>
     </field>
 </definition>

--- a/contributed_definitions/NXlockin.nxdl.xml
+++ b/contributed_definitions/NXlockin.nxdl.xml
@@ -21,7 +21,7 @@
 #
 # For further information, see http://www.nexusformat.org
 -->
-<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXlockin" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXlockin" extends="NXamplifier" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
     <doc>
         A base class definition for a lock-in amplifier.
         
@@ -35,11 +35,6 @@
     <group name="hardware" type="NXfabrication">
         <doc>
             Hardware manufacturers and type (product number) of lock-in amplifier.
-        </doc>
-    </group>
-    <group type="NXamplifier">
-        <doc>
-            Description of the amplifier (after detection of the signal from the noise)
         </doc>
     </group>
     <field name="bias_divider">

--- a/contributed_definitions/NXpiezoelectric_material.nxdl.xml
+++ b/contributed_definitions/NXpiezoelectric_material.nxdl.xml
@@ -21,7 +21,7 @@
 #
 # For further information, see http://www.nexusformat.org
 -->
-<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXpiezoelectric_material" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXpiezoelectric_material" extends="NXcomponent" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
     <doc>
         Description and properties of the piezoelectric actuator materials.
         The piezoelectric actuator is usually composed of polycrystalline solids and

--- a/contributed_definitions/NXscan_control.nxdl.xml
+++ b/contributed_definitions/NXscan_control.nxdl.xml
@@ -136,7 +136,7 @@
             </doc>
         </field>
     </group>
-    <group name="cantilever_oscillator" type="NXcomponent" nameType="partial">
+    <group name="mesh_SCAN" type="NXobject" nameType="partial">
         <doc>
             For each dimension a range and a direction are chosen. When a scan along a dimension is done,
             a single step in the next dimension is taken, and then the scan in the previous dimension is

--- a/contributed_definitions/NXscan_control.nxdl.xml
+++ b/contributed_definitions/NXscan_control.nxdl.xml
@@ -136,7 +136,7 @@
             </doc>
         </field>
     </group>
-    <group name="mesh_SCAN" type="NXobject" nameType="partial">
+    <group name="cantilever_oscillator" type="NXcomponent" nameType="partial">
         <doc>
             For each dimension a range and a direction are chosen. When a scan along a dimension is done,
             a single step in the next dimension is taken, and then the scan in the previous dimension is

--- a/contributed_definitions/NXspm.nxdl.xml
+++ b/contributed_definitions/NXspm.nxdl.xml
@@ -70,14 +70,9 @@
                 forward, backward, or both (if scan is repeated).
             </doc>
         </field>
-        <field name="experiment_identifier" optional="true">
+        <field name="identifier_experiment" optional="true">
             <doc>
                 The identifiers for the experiment which should be unique at least in lab.
-            </doc>
-        </field>
-        <field name="experiment_description" optional="true">
-            <doc>
-                The description of the experiment like comments, ontes from from the experiment.
             </doc>
         </field>
         <group name="experiment_instrument" type="NXinstrument">
@@ -291,37 +286,6 @@
                     </doc>
                 </group>
             </group>
-            <group name="TEMPERATURE" type="NXsensor" nameType="any" optional="true">
-                <doc>
-                    A group handling the temperature such as cryo, shield and tip. For different
-                    type of temperature sensors repeat this group.
-                </doc>
-                <field name="temperature" type="NX_NUMBER" optional="true" units="NX_TEMPERATURE">
-                    <doc>
-                        The temperature of the sample.
-                    </doc>
-                </field>
-                <field name="CHANNEL_temp" type="NX_CHAR" nameType="partial" optional="true">
-                    <doc>
-                        The name of the channel to measure the temperature.
-                    </doc>
-                </field>
-                <group name="temperature_calibration" type="NXcalibration" optional="true">
-                    <doc>
-                        Calibration of the temperature measurement.
-                    </doc>
-                    <field name="coefficients" type="NX_NUMBER" units="NX_ANY">
-                        <doc>
-                            The coefficients of the calibration.
-                        </doc>
-                    </field>
-                </group>
-                <group name="TEMPERATURE_DATA" type="NXdata" nameType="any" optional="true">
-                    <doc>
-                        Data (e.g, record from SPM head temperature) from temperature sensor.
-                    </doc>
-                </group>
-            </group>
             <group name="bias_spectroscopy_environment" type="NXenvironment">
                 <doc>
                     To explain bias (sweep measurement) voltage applied to the sample.
@@ -419,6 +383,37 @@
                             </field>
                         </group>
                     </group>
+                </group>
+            </group>
+            <group name="TEMPERATURE" type="NXsensor" nameType="any" optional="true">
+                <doc>
+                    A group handling the temperature such as cryo, shield and tip. For different
+                    type of temperature sensors repeat this group.
+                </doc>
+                <field name="temperature" type="NX_NUMBER" optional="true" units="NX_TEMPERATURE">
+                    <doc>
+                        The temperature of the sample.
+                    </doc>
+                </field>
+                <field name="CHANNEL_temp" type="NX_CHAR" nameType="partial" optional="true">
+                    <doc>
+                        The name of the channel to measure the temperature.
+                    </doc>
+                </field>
+                <group name="temperature_calibration" type="NXcalibration" optional="true">
+                    <doc>
+                        Calibration of the temperature measurement.
+                    </doc>
+                    <field name="coefficients" type="NX_NUMBER" units="NX_ANY">
+                        <doc>
+                            The coefficients of the calibration.
+                        </doc>
+                    </field>
+                </group>
+                <group name="TEMPERATURE_DATA" type="NXdata" nameType="any" optional="true">
+                    <doc>
+                        Data (e.g, record from SPM head temperature) from temperature sensor.
+                    </doc>
                 </group>
             </group>
             <group name="sample_bias_votage" type="NXsensor" optional="true">

--- a/contributed_definitions/NXspm.nxdl.xml
+++ b/contributed_definitions/NXspm.nxdl.xml
@@ -213,17 +213,71 @@
                 <doc>
                     Information for current sensor.
                 </doc>
+                <field name="current" type="NX_NUMBER" units="NX_CURRENT">
+                    <doc>
+                        The dc current between tip and sample.
+                    </doc>
+                </field>
+                <field name="current_offset" type="NX_NUMBER" optional="true" units="NX_CURRENT">
+                    <doc>
+                        The offset in the tunneling current between tip and sample.
+                    </doc>
+                </field>
+                <group name="current_calibration" type="NXcalibration" optional="true">
+                    <doc>
+                        Calibration data of the current sensor.
+                    </doc>
+                    <field name="coefficients" type="NX_NUMBER" optional="true" units="NX_ANY">
+                        <doc>
+                            The coefficients of the calibration.
+                        </doc>
+                    </field>
+                </group>
                 <group type="NXamplifier" optional="true">
                     <doc>
                         An amplifier information for the input signal (e.g. from tip).
                     </doc>
+                    <field name="current_gain" type="NX_NUMBER" units="NX_UNITLESS" optional="true">
+                        <doc>
+                            The gain of the current sensor.
+                        </doc>
+                    </field>
                 </group>
             </group>
             <group name="voltage_sensor" type="NXsensor" optional="true">
                 <doc>
                     The sensor information for the voltage device.
                 </doc>
-                <group type="NXamplifier" optional="true"/>
+                <field name="voltage" type="NX_NUMBER" units="NX_VOLTAGE">
+                    <doc>
+                        The dc voltage between tip and sample.
+                    </doc>
+                </field>
+                <field name="voltage_offset" type="NX_NUMBER" optional="true" units="NX_VOLTAGE">
+                    <doc>
+                        The offset in the tunneling voltage between tip and sample.
+                    </doc>
+                </field>
+                <group name="voltage_calibration" type="NXcalibration" optional="true">
+                    <doc>
+                        Calibration data of the voltage sensor.
+                    </doc>
+                    <field name="coefficients" type="NX_NUMBER" optional="true" units="NX_ANY">
+                        <doc>
+                            The coefficients of the calibration.
+                        </doc>
+                    </field>
+                </group>
+                <group type="NXamplifier" optional="true">
+                    <doc>
+                        An amplifier information for the input signal (e.g. from tip).
+                    </doc>
+                    <field name="voltage_gain" type="NX_NUMBER" units="NX_UNITLESS" optional="true">
+                        <doc>
+                            The gain of the voltage sensor.
+                        </doc>
+                    </field>
+                </group>
             </group>
             <group name="piezo_sensor" type="NXsensor">
                 <doc>
@@ -283,6 +337,37 @@
                 <group name="piezo_material" type="NXpiezoelectric_material" optional="true">
                     <doc>
                         The material description and properties of the piezoelectric scanner materials.
+                    </doc>
+                </group>
+            </group>
+            <group name="TEMPERATURE" type="NXsensor" nameType="any" optional="true">
+                <doc>
+                    A group handling the temperature such as cryo, shield and tip. For different
+                    type of temperature sensors repeat this group.
+                </doc>
+                <field name="temperature" type="NX_NUMBER" optional="true" units="NX_TEMPERATURE">
+                    <doc>
+                        The temperature of the sample.
+                    </doc>
+                </field>
+                <field name="CHANNEL_temp" type="NX_CHAR" nameType="partial" optional="true">
+                    <doc>
+                        The name of the channel to measure the temperature.
+                    </doc>
+                </field>
+                <group name="temperature_calibration" type="NXcalibration" optional="true">
+                    <doc>
+                        Calibration of the temperature measurement.
+                    </doc>
+                    <field name="coefficients" type="NX_NUMBER" units="NX_ANY">
+                        <doc>
+                            The coefficients of the calibration.
+                        </doc>
+                    </field>
+                </group>
+                <group name="TEMPERATURE_DATA" type="NXdata" nameType="any" optional="true">
+                    <doc>
+                        Data (e.g, record from SPM head temperature) from temperature sensor.
                     </doc>
                 </group>
             </group>
@@ -383,37 +468,6 @@
                             </field>
                         </group>
                     </group>
-                </group>
-            </group>
-            <group name="TEMPERATURE" type="NXsensor" nameType="any" optional="true">
-                <doc>
-                    A group handling the temperature such as cryo, shield and tip. For different
-                    type of temperature sensors repeat this group.
-                </doc>
-                <field name="temperature" type="NX_NUMBER" optional="true" units="NX_TEMPERATURE">
-                    <doc>
-                        The temperature of the sample.
-                    </doc>
-                </field>
-                <field name="CHANNEL_temp" type="NX_CHAR" nameType="partial" optional="true">
-                    <doc>
-                        The name of the channel to measure the temperature.
-                    </doc>
-                </field>
-                <group name="temperature_calibration" type="NXcalibration" optional="true">
-                    <doc>
-                        Calibration of the temperature measurement.
-                    </doc>
-                    <field name="coefficients" type="NX_NUMBER" units="NX_ANY">
-                        <doc>
-                            The coefficients of the calibration.
-                        </doc>
-                    </field>
-                </group>
-                <group name="TEMPERATURE_DATA" type="NXdata" nameType="any" optional="true">
-                    <doc>
-                        Data (e.g, record from SPM head temperature) from temperature sensor.
-                    </doc>
                 </group>
             </group>
             <group name="sample_bias_votage" type="NXsensor" optional="true">

--- a/contributed_definitions/NXspm.nxdl.xml
+++ b/contributed_definitions/NXspm.nxdl.xml
@@ -178,19 +178,25 @@
                 <group name="current_sensor" type="NXsensor" optional="true">
                     <doc>
                         This is a link to the current_sensor under the instrument group:
-                        entry/experiment_instrument/current_sensor.
+                        ENTRY[entry]/experiment_instrument/current_sensor.
+                        
+                        Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the `exact` name of the NXentry group.
                     </doc>
                 </group>
                 <group name="voltage_sensor" type="NXsensor" optional="true">
                     <doc>
                         This is a link to the voltage_sensor under the instrument group:
-                        entry/experiment_instrument/voltage_sensor.
+                        ENTRY[entry]/experiment_instrument/voltage_sensor.
+                        
+                        Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the `exact` name of the NXentry group.
                     </doc>
                 </group>
                 <group name="piezo_sensor" type="NXsensor" optional="true">
                     <doc>
                         This is a link to the piezo_sensor under the instrument group:
-                        entry/experiment_instrument/piezo_sensor.
+                        ENTRY[entry]/experiment_instrument/piezo_sensor.
+                        
+                        Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the `exact` name of the NXentry group.
                     </doc>
                 </group>
                 <group type="NXscan_control">
@@ -467,13 +473,13 @@
                 </group>
             </group>
         </group>
-        <group name="reproducibility_indicators" type="NXobject">
+        <group name="reproducibility_indicators" type="NXcollection">
             <doc>
                 The group of indicators (links to the existing fields in different groups) that measure
                 the reproducibility of the experiment.
             </doc>
         </group>
-        <group name="resolution_indicators" type="NXobject" optional="true">
+        <group name="resolution_indicators" type="NXcollection" optional="true">
             <doc>
                 The group of indicators (links to the existing fields in different groups) that
                 are used to measure the resolution of the experiment results.

--- a/contributed_definitions/NXspm.nxdl.xml
+++ b/contributed_definitions/NXspm.nxdl.xml
@@ -62,6 +62,7 @@
                 <item value="non-contact mode"/>
                 <item value="Kelvin probe"/>
                 <item value="electric force"/>
+                <item value="lateral force mode"/>
             </enumeration>
         </field>
         <field name="scan_type" optional="true">
@@ -215,7 +216,7 @@
                 </doc>
                 <field name="current" type="NX_NUMBER" units="NX_CURRENT">
                     <doc>
-                        The dc current between tip and sample.
+                        The DC current between tip and sample.
                     </doc>
                 </field>
                 <field name="current_offset" type="NX_NUMBER" optional="true" units="NX_CURRENT">
@@ -250,7 +251,7 @@
                 </doc>
                 <field name="voltage" type="NX_NUMBER" units="NX_VOLTAGE">
                     <doc>
-                        The dc voltage between tip and sample.
+                        The DC voltage between tip and sample.
                     </doc>
                 </field>
                 <field name="voltage_offset" type="NX_NUMBER" optional="true" units="NX_VOLTAGE">

--- a/contributed_definitions/NXspm.nxdl.xml
+++ b/contributed_definitions/NXspm.nxdl.xml
@@ -368,12 +368,6 @@
                             to study the change in the behavior of the sample or substance or environment due to change
                             in applied  bias voltage.
                         </doc>
-                        <field name="settling_time" type="NX_NUMBER" units="NX_TIME">
-                            <doc>
-                                The time is taken to settle the bias voltage at the desired value. On each sweep usually, the system
-                                takes time to settle the bias voltage at the next value.
-                            </doc>
-                        </field>
                         <group name="scan_region" type="NXobject">
                             <doc>
                                 The scan region (phase space or sub-phase space) is the region where the scan is

--- a/contributed_definitions/NXspm.nxdl.xml
+++ b/contributed_definitions/NXspm.nxdl.xml
@@ -54,6 +54,15 @@
                 For example, in STM, the scan mode could be constant height or constant current,
                 in AFM, the scan mode could be contact mode, tapping mode or non-contact mode.
             </doc>
+            <enumeration open="true">
+                <item value="constant height"/>
+                <item value="constant current"/>
+                <item value="contact mode"/>
+                <item value="tapping mode"/>
+                <item value="non-contact mode"/>
+                <item value="Kelvin probe"/>
+                <item value="electric force"/>
+            </enumeration>
         </field>
         <field name="scan_type" optional="true">
             <doc>

--- a/contributed_definitions/NXstm.nxdl.xml
+++ b/contributed_definitions/NXstm.nxdl.xml
@@ -31,7 +31,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
     <group type="NXentry">
         <field name="definition">
             <doc>
-                Name of the definition that is used for the application.
+                Name of the definition that is used for an STM technique.
             </doc>
             <enumeration>
                 <item value="NXstm"/>
@@ -39,7 +39,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
         </field>
         <field name="scan_mode">
             <doc>
-                The mode of the scan that is performed. Two commonly used ones are constant
+                The mode of the scan that is performed. Two commonly used modes  are constant
                 height mode and constant current mode.
             </doc>
             <enumeration>
@@ -74,14 +74,14 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                     The environment information for stm or sts experiment.
                 </doc>
                 <group type="NXscan_control">
+                    <!--TODO Check if nyaml works properly-->
                     <doc>
-                        The scan control information like scan region or phase space, type of scan
-                        (e.g. mesh, spiral, etc.), and scan speed, etc.
+                        The scan control information like scan region or phase space, e.g. pattern of scan
+                        (e.g. mesh, spiral, etc.), scanner speed, etc.
                     </doc>
                     <field name="scan_type">
                         <doc>
-                            The type of scan like mesh, spiral, etc. For STS experiment, the scan type is
-                            usually a single-point scan (trajectory scan).
+                            The type of scan like mesh, spiral, etc.
                         </doc>
                         <enumeration>
                             <item value="mesh"/>
@@ -94,19 +94,19 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                 <group name="tip_temp_sensor" type="NXsensor" optional="true">
                     <doc>
                         This group stands for the same concept as
-                        /ENTRY[entry]/experiment_instrument/tip_temperature
+                        /ENTRY[entry]/experiment_instrument/tip_temp_sensor
                     </doc>
                 </group>
                 <group name="cryo_temp_sensor" type="NXsensor" optional="true">
                     <doc>
                         This group stands for the same concept as
-                        /ENTRY[entry]/experiment_instrument/cryo_temperature
+                        /ENTRY[entry]/experiment_instrument/cryo_temp_sensor
                     </doc>
                 </group>
                 <group name="cryo_shield_temp_sensor" type="NXsensor" optional="true">
                     <doc>
                         This group stands for the same concept as
-                        /ENTRY[entry]/experiment_instrument/cryo_shield_temperature
+                        /ENTRY[entry]/experiment_instrument/cryo_shield_temp_sensor
                     </doc>
                 </group>
             </group>
@@ -127,7 +127,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
             </group>
             <group name="current_sensor" type="NXsensor">
                 <doc>
-                    The sensor information.
+                    The information current sensor for tip-sample current.
                 </doc>
                 <field name="current" type="NX_NUMBER" units="NX_CURRENT">
                     <doc>
@@ -170,7 +170,6 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                     <doc>
                         Setup and scan data for continuous measurement of bias-voltage on the subject of experiment
                         vs tunneling current from probe.
-                        Data from from this experiment can also be used to calculate the dI/dV spectra.
                     </doc>
                 </group>
             </group>
@@ -295,7 +294,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
             </field>
             <field name="current_offset" type="NX_NUMBER" optional="true">
                 <doc>
-                    The tunneling current between tip and sample after application of bias voltage.
+                    The offset in tunneling current between tip and sample after application of bias voltage.
                     link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
                 </doc>
             </field>
@@ -308,6 +307,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
             </field>
             <group name="bias_sweep" type="NXobject" optional="true">
                 <doc>
+                    Bias sweep measurement in bias spectroscopy.
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
                 </doc>
@@ -330,23 +330,23 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                 The group's concepts hold the link to the related concepts that define the
                 resolution of the STM experiment.
             </doc>
-            <group name="stm_head_temp" type="NXsensor" optional="true">
+            <field name="stm_head_temp" type="NX_NUMBER" optional="true">
                 <doc>
                     Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
                 </doc>
-            </group>
-            <group name="cryo_bottom_temp" type="NXsensor" optional="true">
+            </field>
+            <field name="cryo_bottom_temp" type="NX_NUMBER" optional="true">
                 <doc>
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
                 </doc>
-            </group>
-            <group name="cryo_shield_temp" type="NXsensor" optional="true">
+            </field>
+            <field name="cryo_shield_temp" type="NX_NUMBER" optional="true">
                 <doc>
                     Link to target:
-                    /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temperature
+                    /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
                 </doc>
-            </group>
+            </field>
             <group name="bias_sweep" type="NXobject" optional="true">
                 <doc>
                     Link to target:

--- a/contributed_definitions/NXstm.nxdl.xml
+++ b/contributed_definitions/NXstm.nxdl.xml
@@ -31,7 +31,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
     <group type="NXentry">
         <field name="definition">
             <doc>
-                Name of the definition that is used for an STM technique.
+                Name of the definition that is used for the STM technique.
             </doc>
             <enumeration>
                 <item value="NXstm"/>
@@ -74,7 +74,6 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                     The environment information for stm or sts experiment.
                 </doc>
                 <group type="NXscan_control">
-                    <!--TODO Check if nyaml works properly-->
                     <doc>
                         The scan control information like scan region or phase space, e.g. pattern of scan
                         (e.g. mesh, spiral, etc.), scanner speed, etc.
@@ -136,7 +135,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
             </group>
             <group name="current_sensor" type="NXsensor">
                 <doc>
-                    The information current sensor for tip-sample current.
+                    Current sensor for current between tip and sample.
                 </doc>
                 <field name="current" type="NX_NUMBER" units="NX_CURRENT">
                     <doc>

--- a/contributed_definitions/NXstm.nxdl.xml
+++ b/contributed_definitions/NXstm.nxdl.xml
@@ -290,7 +290,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                 </group>
             </group>
         </group>
-        <group name="reproducibility_indicators" type="NXobject" optional="true">
+        <group name="reproducibility_indicators" type="NXcollection" optional="true">
             <doc>
                 The group's concepts hold the link to the related concepts that define the
                 reproducibility of the STM experiment.
@@ -347,7 +347,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                 </doc>
             </field>
         </group>
-        <group name="resolution_indicators" type="NXobject" optional="true">
+        <group name="resolution_indicators" type="NXcollection" optional="true">
             <doc>
                 The group's concepts hold the link to the related concepts that define the
                 resolution of the STM experiment.

--- a/contributed_definitions/NXstm.nxdl.xml
+++ b/contributed_definitions/NXstm.nxdl.xml
@@ -95,18 +95,27 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                     <doc>
                         This group stands for the same concept as
                         /ENTRY[entry]/experiment_instrument/tip_temp_sensor
+                        
+                        
+                        Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                     </doc>
                 </group>
                 <group name="cryo_temp_sensor" type="NXsensor" optional="true">
                     <doc>
                         This group stands for the same concept as
                         /ENTRY[entry]/experiment_instrument/cryo_temp_sensor
+                        
+                        
+                        Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                     </doc>
                 </group>
                 <group name="cryo_shield_temp_sensor" type="NXsensor" optional="true">
                     <doc>
                         This group stands for the same concept as
                         /ENTRY[entry]/experiment_instrument/cryo_shield_temp_sensor
+                        
+                        
+                        Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                     </doc>
                 </group>
             </group>
@@ -290,19 +299,25 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                 <doc>
                     The tunneling current between tip and sample after application of bias voltage.
                     link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
+                    
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </field>
             <field name="current_offset" type="NX_NUMBER" optional="true">
                 <doc>
                     The offset in tunneling current between tip and sample after application of bias voltage.
-                    link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
+                    link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current_offset
+                    
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </field>
             <field name="current_gain" type="NX_NUMBER" optional="true">
                 <doc>
                     Proportional relationship between the probe output voltage and the actual
                     tunneling current when measuring the tunneling current.
-                    link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/amplifier/current_gain
+                    link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/AMPLIFIER[amplifier]/current_gain
+                    
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </field>
             <group name="bias_sweep" type="NXobject" optional="true">
@@ -310,18 +325,25 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                     Bias sweep measurement in bias spectroscopy.
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
+                    
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </group>
             <field name="modulation_signal_type" optional="true">
                 <doc>
                     This is the signal on which the modulation voltage or current will be added.
-                    link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
+                    link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal
+                    
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </field>
-            <field name="modulation_frequency" type="NX_NUMBER" optional="true">
+            <field name="reference_frequency" type="NX_NUMBER" optional="true">
                 <doc>
-                    The frequency of the sine modulation that is used to modulate the signal in lock-in.
-                    link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
+                    The frequency of the sine modulation that is used as a carrier signal of input signal in lock-in.
+                    
+                    link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/reference_frequency
+                    
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </field>
         </group>
@@ -360,7 +382,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                     modulation_signal_type
                 </doc>
             </field>
-            <field name="modulation_frequency" type="NX_NUMBER" optional="true">
+            <field name="reference_frequency" type="NX_NUMBER" optional="true">
                 <doc>
                     The frequency of the sine modulation that is used to modulate the signal in lock-in.
                     link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency

--- a/contributed_definitions/NXsts.nxdl.xml
+++ b/contributed_definitions/NXsts.nxdl.xml
@@ -28,8 +28,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
     <doc>
         An application definition to describe Scanning Tunneling Spectroscopy (STS).
         
-        The NXsts is duplication of NXspm and is considered as a proxy application definition
-        for Scanning Tunneling Spectroscopy (STS) technique.
+        The NXsts application definition extends the NXapm and is dedicated for Scanning Tunneling Spectroscopy (STS) technique.
     </doc>
     <group type="NXentry">
         <field name="definition">

--- a/contributed_definitions/NXsts.nxdl.xml
+++ b/contributed_definitions/NXsts.nxdl.xml
@@ -63,71 +63,11 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                 <doc>
                     Information for current sensor.
                 </doc>
-                <field name="current" type="NX_NUMBER" units="NX_CURRENT">
-                    <doc>
-                        The dc current between tip and sample.
-                    </doc>
-                </field>
-                <field name="current_offset" type="NX_NUMBER" optional="true" units="NX_CURRENT">
-                    <doc>
-                        The offset in the tunneling current between tip and sample.
-                    </doc>
-                </field>
-                <group name="current_calibration" type="NXcalibration" optional="true">
-                    <doc>
-                        Calibration data of the current sensor.
-                    </doc>
-                    <field name="coefficients" type="NX_NUMBER" optional="true" units="NX_ANY">
-                        <doc>
-                            The coefficients of the calibration.
-                        </doc>
-                    </field>
-                </group>
-                <group type="NXamplifier" optional="true">
-                    <doc>
-                        An amplifier information for the input signal (e.g. from tip).
-                    </doc>
-                    <field name="current_gain" type="NX_NUMBER" units="NX_UNITLESS" optional="true">
-                        <doc>
-                            The gain of the current sensor.
-                        </doc>
-                    </field>
-                </group>
             </group>
             <group name="voltage_sensor" type="NXsensor" optional="true">
                 <doc>
                     The sensor information for the voltage device.
                 </doc>
-                <field name="voltage" type="NX_NUMBER" units="NX_VOLTAGE">
-                    <doc>
-                        The dc voltage between tip and sample.
-                    </doc>
-                </field>
-                <field name="voltage_offset" type="NX_NUMBER" optional="true" units="NX_VOLTAGE">
-                    <doc>
-                        The offset in the tunneling voltage between tip and sample.
-                    </doc>
-                </field>
-                <group name="voltage_calibration" type="NXcalibration" optional="true">
-                    <doc>
-                        Calibration data of the voltage sensor.
-                    </doc>
-                    <field name="coefficients" type="NX_NUMBER" optional="true" units="NX_ANY">
-                        <doc>
-                            The coefficients of the calibration.
-                        </doc>
-                    </field>
-                </group>
-                <group type="NXamplifier" optional="true">
-                    <doc>
-                        An amplifier information for the input signal (e.g. from tip).
-                    </doc>
-                    <field name="voltage_gain" type="NX_NUMBER" units="NX_UNITLESS" optional="true">
-                        <doc>
-                            The gain of the voltage sensor.
-                        </doc>
-                    </field>
-                </group>
             </group>
             <group name="piezo_sensor" type="NXsensor">
                 <doc>
@@ -216,7 +156,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                     link to the target:
                     /ENTRY[entry]/experiment_instrument/current_sensor/current
                     
-                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </field>
             <field name="current_offset" type="NX_NUMBER" optional="true">
@@ -225,7 +165,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                     link to the target:
                     /ENTRY[entry]/experiment_instrument/current_sensor/current
                     
-                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </field>
             <field name="current_gain" type="NX_NUMBER" optional="true">
@@ -235,7 +175,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                     link to the target:
                     /ENTRY[entry]/experiment_instrument/current_sensor/amplifier/current_gain
                     
-                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </field>
             <group name="bias_sweep" type="NXobject" optional="true">
@@ -244,7 +184,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
                     
-                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </group>
             <field name="modulation_signal_type" optional="true">
@@ -253,16 +193,16 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                     link to the target:
                     /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
                     
-                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </field>
-            <field name="modulation_frequency" type="NX_NUMBER" optional="true">
+            <field name="reference_frequency" type="NX_NUMBER" optional="true">
                 <doc>
-                    The frequency of the sine modulation that is used to modulate the signal in lock-in.
+                    The frequency of the sine modulation that is used as carrier signal of input signal in lock-in.
                     link to the target:
-                    /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
+                    /ENTRY[entry]/experiment_instrument/lockin_amplifier/reference_frequency
                     
-                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </field>
         </group>
@@ -276,7 +216,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
                     
-                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </field>
             <field name="cryo_bottom_temp" type="NX_NUMBER" optional="true">
@@ -284,7 +224,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
                     
-                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </field>
             <field name="cryo_shield_temp" type="NX_NUMBER" optional="true">
@@ -292,7 +232,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
                     
-                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </field>
             <group name="bias_sweep" type="NXobject" optional="true">
@@ -300,7 +240,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
                     
-                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </group>
             <field name="modulation_signal_type" optional="true">
@@ -309,7 +249,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                     link to the target:
                     /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
                     
-                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+                    Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
                 </doc>
             </field>
             <field name="modulation_frequency" type="NX_NUMBER" optional="true">

--- a/contributed_definitions/NXsts.nxdl.xml
+++ b/contributed_definitions/NXsts.nxdl.xml
@@ -50,6 +50,302 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                 <item value="constant_spacing"/>
             </enumeration>
         </field>
+        <group name="experiment_instrument" type="NXinstrument">
+            <doc>
+                The instrument information.
+            </doc>
+            <group name="lockin_amplifier" type="NXlockin" optional="true">
+                <doc>
+                    The lock-in amplifier information.
+                </doc>
+            </group>
+            <group name="current_sensor" type="NXsensor" optional="true">
+                <doc>
+                    Information for current sensor.
+                </doc>
+                <field name="current" type="NX_NUMBER" units="NX_CURRENT">
+                    <doc>
+                        The dc current between tip and sample.
+                    </doc>
+                </field>
+                <field name="current_offset" type="NX_NUMBER" optional="true" units="NX_CURRENT">
+                    <doc>
+                        The offset in the tunneling current between tip and sample.
+                    </doc>
+                </field>
+                <group name="current_calibration" type="NXcalibration" optional="true">
+                    <doc>
+                        Calibration data of the current sensor.
+                    </doc>
+                    <field name="coefficients" type="NX_NUMBER" optional="true" units="NX_ANY">
+                        <doc>
+                            The coefficients of the calibration.
+                        </doc>
+                    </field>
+                </group>
+                <group type="NXamplifier" optional="true">
+                    <doc>
+                        An amplifier information for the input signal (e.g. from tip).
+                    </doc>
+                    <field name="current_gain" type="NX_NUMBER" units="NX_UNITLESS" optional="true">
+                        <doc>
+                            The gain of the current sensor.
+                        </doc>
+                    </field>
+                </group>
+            </group>
+            <group name="voltage_sensor" type="NXsensor" optional="true">
+                <doc>
+                    The sensor information for the voltage device.
+                </doc>
+                <field name="voltage" type="NX_NUMBER" units="NX_VOLTAGE">
+                    <doc>
+                        The dc voltage between tip and sample.
+                    </doc>
+                </field>
+                <field name="voltage_offset" type="NX_NUMBER" optional="true" units="NX_VOLTAGE">
+                    <doc>
+                        The offset in the tunneling voltage between tip and sample.
+                    </doc>
+                </field>
+                <group name="voltage_calibration" type="NXcalibration" optional="true">
+                    <doc>
+                        Calibration data of the voltage sensor.
+                    </doc>
+                    <field name="coefficients" type="NX_NUMBER" optional="true" units="NX_ANY">
+                        <doc>
+                            The coefficients of the calibration.
+                        </doc>
+                    </field>
+                </group>
+                <group type="NXamplifier" optional="true">
+                    <doc>
+                        An amplifier information for the input signal (e.g. from tip).
+                    </doc>
+                    <field name="voltage_gain" type="NX_NUMBER" units="NX_UNITLESS" optional="true">
+                        <doc>
+                            The gain of the voltage sensor.
+                        </doc>
+                    </field>
+                </group>
+            </group>
+            <group name="piezo_sensor" type="NXsensor">
+                <doc>
+                    The piezo sensor refers to the height (or Z) piezo sensor if nothing is
+                    mentioned along the X and Y directions.
+                </doc>
+                <field name="x" type="NX_NUMBER" units="NX_LENGTH">
+                    <doc>
+                        The x position of the piezo. In STS experiment, the piezo stays fixed at
+                        x,y and z and the the tunneling current is measured with respect to the
+                        bias voltage (sweep voltage).
+                    </doc>
+                </field>
+                <field name="y" type="NX_NUMBER" units="NX_LENGTH">
+                    <doc>
+                        The y position of the piezo.
+                    </doc>
+                </field>
+                <field name="z" type="NX_NUMBER" units="NX_LENGTH">
+                    <doc>
+                        The z position of the piezo.
+                    </doc>
+                </field>
+                <group name="piezo_configuration" type="NXpiezo_config_spm" optional="true">
+                    <doc>
+                        The piezo configuration information like piezoelectric calibration and material
+                        properties.
+                    </doc>
+                    <group name="calibration" type="NXcalibration" optional="true">
+                        <doc>
+                            Calibration of the piezo device.
+                        </doc>
+                    </group>
+                </group>
+                <group type="NXpositioner_spm">
+                    <doc>
+                        The positioner information like the position of the tip, the position of the
+                        sample, PID loop feedback etc.
+                    </doc>
+                    <group name="z_controller" type="NXpid_controller">
+                        <doc>
+                            The PID controller information for the z-axis.
+                        </doc>
+                        <field name="z" type="NX_NUMBER">
+                            <doc>
+                                To indicate the relative tip position z between tip and sample. The tip position
+                                can also be varied when the z_controller is not running.
+                            </doc>
+                        </field>
+                        <field name="controller_status" type="NX_BOOLEAN">
+                            <doc>
+                                Status if controller is active.
+                            </doc>
+                        </field>
+                    </group>
+                </group>
+                <group name="piezo_material" type="NXpiezoelectric_material" optional="true">
+                    <doc>
+                        The material description and properties of the piezoelectric scanner materials.
+                    </doc>
+                </group>
+            </group>
+            <group name="TEMPERATURE" type="NXsensor" nameType="any" optional="true">
+                <doc>
+                    A group handling the temperature such as cryo, shield and tip. For different
+                    type of temperature sensors repeat this group.
+                </doc>
+                <field name="temperature" type="NX_NUMBER" optional="true" units="NX_TEMPERATURE">
+                    <doc>
+                        The temperature of the sample.
+                    </doc>
+                </field>
+                <field name="CHANNEL_temp" type="NX_CHAR" nameType="partial" optional="true">
+                    <doc>
+                        The name of the channel to measure the temperature.
+                    </doc>
+                </field>
+                <group name="temperature_calibration" type="NXcalibration" optional="true">
+                    <doc>
+                        Calibration of the temperature measurement.
+                    </doc>
+                    <field name="coefficients" type="NX_NUMBER" units="NX_ANY">
+                        <doc>
+                            The coefficients of the calibration.
+                        </doc>
+                    </field>
+                </group>
+                <group name="TEMPERATURE_DATA" type="NXdata" nameType="any" optional="true">
+                    <doc>
+                        Data (e.g, record from SPM head temperature) from temperature sensor.
+                    </doc>
+                </group>
+            </group>
+            <group name="bias_spectroscopy_environment" type="NXenvironment">
+                <doc>
+                    To explain bias (sweep measurement) voltage applied to the sample.
+                </doc>
+                <group type="NXbias_spectroscopy">
+                    <doc>
+                        Setup and scan data for continuous measurement of bias-voltage on the subject of experiment
+                        vs tunneling current from probe.
+                    </doc>
+                    <group type="NXpositioner_spm" optional="true">
+                        <doc>
+                            The positioner information like the position of the tip, PID loop feedback etc.
+                        </doc>
+                        <group name="z_controller" type="NXpid_controller" optional="true">
+                            <doc>
+                                The PID controller information for the z-axis.
+                            </doc>
+                            <field name="z_average_time" type="NX_NUMBER" optional="true" units="NX_TIME">
+                                <doc>
+                                    The average time taken by the z-controller to stabilize the tip.
+                                </doc>
+                            </field>
+                            <field name="z_controller_time" type="NX_NUMBER" optional="true" units="NX_TIME">
+                                <doc>
+                                    The time taken by the z-controller to measure physical properties.
+                                </doc>
+                            </field>
+                            <field name="z_controller_hold" type="NX_BOOLEAN" optional="true">
+                                <doc>
+                                    The status of the controller to be held on the previous position, before going to the
+                                    next scan point or line to measure the physical properties.
+                                </doc>
+                            </field>
+                            <field name="record_final_z" type="NX_BOOLEAN" optional="true">
+                                <doc>
+                                    The status of the controller to record the final z position after the scan.
+                                </doc>
+                            </field>
+                        </group>
+                    </group>
+                    <group name="bias_sweep" type="NXbias_sweep">
+                        <doc>
+                            The bais voltage sweep is a common technique used on the substance or sample or environment
+                            to study the change in the behavior of the sample or substance or environment due to change
+                            in applied  bias voltage.
+                        </doc>
+                        <group name="scan_region" type="NXobject">
+                            <doc>
+                                The scan region (phase space or sub-phase space) is the region where the scan is
+                                performed.
+                            </doc>
+                            <field name="scan_offset_bias" type="NX_NUMBER" optional="true" units="NX_VOLTAGE">
+                                <doc>
+                                    The offset of the bias voltage for bias sweep.
+                                </doc>
+                            </field>
+                            <field name="scan_range_bias" type="NX_NUMBER" optional="true" units="NX_VOLTAGE">
+                                <doc>
+                                    The range of the scan is the length of the bias voltage over which the sweep
+                                    scan will be performed.
+                                </doc>
+                            </field>
+                            <field name="scan_start_bias" type="NX_NUMBER" units="NX_VOLTAGE">
+                                <doc>
+                                    The start of the bias scan voltage.
+                                </doc>
+                            </field>
+                            <field name="scan_end_bias" type="NX_NUMBER" units="NX_VOLTAGE">
+                                <doc>
+                                    The end of the bias scan voltage.
+                                </doc>
+                            </field>
+                        </group>
+                        <group name="linear_sweep" type="NXobject">
+                            <doc>
+                                The linear sweep is a type of scan where the bias voltage is swept
+                                linearly from the starting voltage to the ending voltage.
+                            </doc>
+                            <field name="scan_points_bias" type="NX_NUMBER">
+                                <doc>
+                                    The number of voltage points the sweep scan to be performed.
+                                </doc>
+                            </field>
+                            <field name="step_size_bias" type="NX_NUMBER" units="NX_VOLTAGE">
+                                <doc>
+                                    The step size of the sweep.
+                                    The step size is the difference between the two consecutive bias voltage during the sweep.
+                                </doc>
+                            </field>
+                            <field name="reset_bias" type="NX_BOOLEAN" optional="true">
+                                <doc>
+                                    The reset_bias is used to reset the bias voltage to the starting value after a
+                                    sweep is completed.
+                                </doc>
+                            </field>
+                        </group>
+                    </group>
+                </group>
+            </group>
+            <group name="sample_bias_votage" type="NXsensor" optional="true">
+                <doc>
+                    The DC bias voltage that is applied to the sample.
+                </doc>
+                <field name="bias_voltage" type="NX_NUMBER" units="NX_VOLTAGE">
+                    <doc>
+                        The bias voltage (DC) applied to the sample.
+                    </doc>
+                </field>
+                <field name="bias_offset" type="NX_NUMBER" optional="true" units="NX_VOLTAGE">
+                    <doc>
+                        Offset value of the bias voltage.
+                    </doc>
+                </field>
+                <group name="bias_calibration" type="NXcalibration" optional="true">
+                    <doc>
+                        Calibration of the bias voltage measurement (V/V).
+                    </doc>
+                    <field name="coefficients" type="NX_NUMBER" optional="true" units="NX_ANY">
+                        <doc>
+                            The coefficients of the calibration.
+                        </doc>
+                    </field>
+                </group>
+            </group>
+        </group>
         <group name="reproducibility_indicators" type="NXcollection" optional="true">
             <doc>
                 The group's concepts hold the link to the related concepts that define the

--- a/contributed_definitions/NXsts.nxdl.xml
+++ b/contributed_definitions/NXsts.nxdl.xml
@@ -50,7 +50,7 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                 <item value="constant_spacing"/>
             </enumeration>
         </field>
-        <group name="reproducibility_indicators" type="NXobject" optional="true">
+        <group name="reproducibility_indicators" type="NXcollection" optional="true">
             <doc>
                 The group's concepts hold the link to the related concepts that define the
                 reproducibility of the STM experiment.
@@ -58,20 +58,29 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
             <field name="current" type="NX_NUMBER" optional="true">
                 <doc>
                     The tunneling current between tip and sample after application of bias voltage.
-                    link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
+                    link to the target:
+                    /ENTRY[entry]/experiment_instrument/current_sensor/current
+                    
+                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                 </doc>
             </field>
             <field name="current_offset" type="NX_NUMBER" optional="true">
                 <doc>
                     The offset in tunneling current between tip and sample after application of bias voltage.
-                    link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
+                    link to the target:
+                    /ENTRY[entry]/experiment_instrument/current_sensor/current
+                    
+                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                 </doc>
             </field>
             <field name="current_gain" type="NX_NUMBER" optional="true">
                 <doc>
                     Proportional relationship between the probe output voltage and the actual
                     tunneling current when measuring the tunneling current.
-                    link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/amplifier/current_gain
+                    link to the target:
+                    /ENTRY[entry]/experiment_instrument/current_sensor/amplifier/current_gain
+                    
+                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                 </doc>
             </field>
             <group name="bias_sweep" type="NXobject" optional="true">
@@ -79,60 +88,80 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                     Bias sweep measurement in bias spectroscopy.
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
+                    
+                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                 </doc>
             </group>
             <field name="modulation_signal_type" optional="true">
                 <doc>
                     This is the signal on which the modulation voltage or current will be added.
-                    link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
+                    link to the target:
+                    /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
+                    
+                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                 </doc>
             </field>
             <field name="modulation_frequency" type="NX_NUMBER" optional="true">
                 <doc>
                     The frequency of the sine modulation that is used to modulate the signal in lock-in.
-                    link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
+                    link to the target:
+                    /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
+                    
+                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                 </doc>
             </field>
         </group>
-        <group name="resolution_indicators" type="NXobject" optional="true">
+        <group name="resolution_indicators" type="NXcollection" optional="true">
             <doc>
                 The group's concepts hold the link to the related concepts that define the
                 resolution of the STM experiment.
             </doc>
             <field name="tip_temp" type="NX_NUMBER" optional="true">
                 <doc>
-                    Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+                    Link to target:
+                    /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+                    
+                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                 </doc>
             </field>
             <field name="cryo_bottom_temp" type="NX_NUMBER" optional="true">
                 <doc>
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
+                    
+                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                 </doc>
             </field>
             <field name="cryo_shield_temp" type="NX_NUMBER" optional="true">
                 <doc>
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
+                    
+                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                 </doc>
             </field>
             <group name="bias_sweep" type="NXobject" optional="true">
                 <doc>
                     Link to target:
                     /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
+                    
+                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                 </doc>
             </group>
             <field name="modulation_signal_type" optional="true">
                 <doc>
                     This is the signal on which the modulation voltage or current will be added.
-                    link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
-                    modulation_signal_type
+                    link to the target:
+                    /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
+                    
+                    Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
                 </doc>
             </field>
             <field name="modulation_frequency" type="NX_NUMBER" optional="true">
                 <doc>
-                    The frequency of the sine modulation that is used to modulate the signal in
-                    lock-in.
+                    The frequency of the sine modulation that is used to modulate the signal in lock-in.
+                    link to the target:
+                    /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
                 </doc>
             </field>
         </group>

--- a/contributed_definitions/NXsts.nxdl.xml
+++ b/contributed_definitions/NXsts.nxdl.xml
@@ -131,94 +131,66 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
             </group>
             <group name="piezo_sensor" type="NXsensor">
                 <doc>
-                    The piezo sensor refers to the height (or Z) piezo sensor if nothing is
-                    mentioned along the X and Y directions.
+                    The sensor information for the piezo device.
                 </doc>
-                <field name="x" type="NX_NUMBER" units="NX_LENGTH">
-                    <doc>
-                        The x position of the piezo. In STS experiment, the piezo stays fixed at
-                        x,y and z and the the tunneling current is measured with respect to the
-                        bias voltage (sweep voltage).
-                    </doc>
-                </field>
-                <field name="y" type="NX_NUMBER" units="NX_LENGTH">
-                    <doc>
-                        The y position of the piezo.
-                    </doc>
-                </field>
-                <field name="z" type="NX_NUMBER" units="NX_LENGTH">
-                    <doc>
-                        The z position of the piezo.
-                    </doc>
-                </field>
                 <group name="piezo_configuration" type="NXpiezo_config_spm" optional="true">
                     <doc>
-                        The piezo configuration information like piezoelectric calibration and material
-                        properties.
+                        The piezo configuration information like piezoelectric device calibration and
+                        material properties.
                     </doc>
                     <group name="calibration" type="NXcalibration" optional="true">
                         <doc>
                             Calibration of the piezo device.
                         </doc>
-                    </group>
-                </group>
-                <group type="NXpositioner_spm">
-                    <doc>
-                        The positioner information like the position of the tip, the position of the
-                        sample, PID loop feedback etc.
-                    </doc>
-                    <group name="z_controller" type="NXpid_controller">
-                        <doc>
-                            The PID controller information for the z-axis.
-                        </doc>
-                        <field name="z" type="NX_NUMBER">
+                        <field name="second_order_correction_N" type="NX_NUMBER" nameType="partial" optional="true" units="NX_ANY">
                             <doc>
-                                To indicate the relative tip position z between tip and sample. The tip position
-                                can also be varied when the z_controller is not running.
+                                The N (substring) denotes X and Y directions. The 2nd order piezo
+                                compensate the error for that axis. The following equation shows the
+                                interpretation of the 2nd order correction parameters,
+                                For the X-piezo: "Ux = 1/cx · X + cxx · X2"
+                                with units: "[V] = [V/m] · [m] + [V/m2] · [m2]"
+                                where cx is the calibration of the piezo X and cxx is the 2nd order
+                                correction. The unit for such the second-order correction is (V/m^2).
                             </doc>
                         </field>
-                        <field name="controller_status" type="NX_BOOLEAN">
+                        <field name="calibration_type" type="NX_CHAR" optional="true">
                             <doc>
-                                Status if controller is active.
+                                The name of the calibration type, sometimes it is called
+                                e.g active calibration, passive calibration.
+                            </doc>
+                        </field>
+                        <field name="calibration_coefficient_N" type="NX_NUMBER" nameType="partial" optional="true" units="NX_ANY">
+                            <doc>
+                                The calibration coefficient is the ratio of the actual distance moved by the piezo to
+                                the voltage applied to the piezo. It is also called first-order correction.
+                            </doc>
+                        </field>
+                        <field name="drift_N" type="NX_NUMBER" nameType="partial" optional="true" units="NX_ANY">
+                            <doc>
+                                Set up the settings to enable or disable the drift compensation.
+                            </doc>
+                        </field>
+                        <field name="drift_correction_status" type="NX_BOOLEAN" optional="true">
+                            <doc>
+                                Whether the drift has been corrected in case there is a deviation in the
+                                drift.
+                            </doc>
+                        </field>
+                        <field name="tilt_N" type="NX_NUMBER" nameType="partial" optional="true" units="NX_ANGLE">
+                            <doc>
+                                The N (substring) denotes X and Y directions, and for both directions
+                                tilt needs to be adjusted according to the actual surface.
+                            </doc>
+                        </field>
+                        <field name="hv_gain_N" type="NX_NUMBER" nameType="partial">
+                            <doc>
+                                The N (substring) denotes X or Y or Z. In some systems,
+                                there is an HV gain readout feature. For these systems,
+                                the HV gain should be automatically adjusted whenever
+                                the gain is changed at the high voltage amplifier.
                             </doc>
                         </field>
                     </group>
-                </group>
-                <group name="piezo_material" type="NXpiezoelectric_material" optional="true">
-                    <doc>
-                        The material description and properties of the piezoelectric scanner materials.
-                    </doc>
-                </group>
-            </group>
-            <group name="TEMPERATURE" type="NXsensor" nameType="any" optional="true">
-                <doc>
-                    A group handling the temperature such as cryo, shield and tip. For different
-                    type of temperature sensors repeat this group.
-                </doc>
-                <field name="temperature" type="NX_NUMBER" optional="true" units="NX_TEMPERATURE">
-                    <doc>
-                        The temperature of the sample.
-                    </doc>
-                </field>
-                <field name="CHANNEL_temp" type="NX_CHAR" nameType="partial" optional="true">
-                    <doc>
-                        The name of the channel to measure the temperature.
-                    </doc>
-                </field>
-                <group name="temperature_calibration" type="NXcalibration" optional="true">
-                    <doc>
-                        Calibration of the temperature measurement.
-                    </doc>
-                    <field name="coefficients" type="NX_NUMBER" units="NX_ANY">
-                        <doc>
-                            The coefficients of the calibration.
-                        </doc>
-                    </field>
-                </group>
-                <group name="TEMPERATURE_DATA" type="NXdata" nameType="any" optional="true">
-                    <doc>
-                        Data (e.g, record from SPM head temperature) from temperature sensor.
-                    </doc>
                 </group>
             </group>
             <group name="bias_spectroscopy_environment" type="NXenvironment">
@@ -230,119 +202,6 @@ TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and
                         Setup and scan data for continuous measurement of bias-voltage on the subject of experiment
                         vs tunneling current from probe.
                     </doc>
-                    <group type="NXpositioner_spm" optional="true">
-                        <doc>
-                            The positioner information like the position of the tip, PID loop feedback etc.
-                        </doc>
-                        <group name="z_controller" type="NXpid_controller" optional="true">
-                            <doc>
-                                The PID controller information for the z-axis.
-                            </doc>
-                            <field name="z_average_time" type="NX_NUMBER" optional="true" units="NX_TIME">
-                                <doc>
-                                    The average time taken by the z-controller to stabilize the tip.
-                                </doc>
-                            </field>
-                            <field name="z_controller_time" type="NX_NUMBER" optional="true" units="NX_TIME">
-                                <doc>
-                                    The time taken by the z-controller to measure physical properties.
-                                </doc>
-                            </field>
-                            <field name="z_controller_hold" type="NX_BOOLEAN" optional="true">
-                                <doc>
-                                    The status of the controller to be held on the previous position, before going to the
-                                    next scan point or line to measure the physical properties.
-                                </doc>
-                            </field>
-                            <field name="record_final_z" type="NX_BOOLEAN" optional="true">
-                                <doc>
-                                    The status of the controller to record the final z position after the scan.
-                                </doc>
-                            </field>
-                        </group>
-                    </group>
-                    <group name="bias_sweep" type="NXbias_sweep">
-                        <doc>
-                            The bais voltage sweep is a common technique used on the substance or sample or environment
-                            to study the change in the behavior of the sample or substance or environment due to change
-                            in applied  bias voltage.
-                        </doc>
-                        <group name="scan_region" type="NXobject">
-                            <doc>
-                                The scan region (phase space or sub-phase space) is the region where the scan is
-                                performed.
-                            </doc>
-                            <field name="scan_offset_bias" type="NX_NUMBER" optional="true" units="NX_VOLTAGE">
-                                <doc>
-                                    The offset of the bias voltage for bias sweep.
-                                </doc>
-                            </field>
-                            <field name="scan_range_bias" type="NX_NUMBER" optional="true" units="NX_VOLTAGE">
-                                <doc>
-                                    The range of the scan is the length of the bias voltage over which the sweep
-                                    scan will be performed.
-                                </doc>
-                            </field>
-                            <field name="scan_start_bias" type="NX_NUMBER" units="NX_VOLTAGE">
-                                <doc>
-                                    The start of the bias scan voltage.
-                                </doc>
-                            </field>
-                            <field name="scan_end_bias" type="NX_NUMBER" units="NX_VOLTAGE">
-                                <doc>
-                                    The end of the bias scan voltage.
-                                </doc>
-                            </field>
-                        </group>
-                        <group name="linear_sweep" type="NXobject">
-                            <doc>
-                                The linear sweep is a type of scan where the bias voltage is swept
-                                linearly from the starting voltage to the ending voltage.
-                            </doc>
-                            <field name="scan_points_bias" type="NX_NUMBER">
-                                <doc>
-                                    The number of voltage points the sweep scan to be performed.
-                                </doc>
-                            </field>
-                            <field name="step_size_bias" type="NX_NUMBER" units="NX_VOLTAGE">
-                                <doc>
-                                    The step size of the sweep.
-                                    The step size is the difference between the two consecutive bias voltage during the sweep.
-                                </doc>
-                            </field>
-                            <field name="reset_bias" type="NX_BOOLEAN" optional="true">
-                                <doc>
-                                    The reset_bias is used to reset the bias voltage to the starting value after a
-                                    sweep is completed.
-                                </doc>
-                            </field>
-                        </group>
-                    </group>
-                </group>
-            </group>
-            <group name="sample_bias_votage" type="NXsensor" optional="true">
-                <doc>
-                    The DC bias voltage that is applied to the sample.
-                </doc>
-                <field name="bias_voltage" type="NX_NUMBER" units="NX_VOLTAGE">
-                    <doc>
-                        The bias voltage (DC) applied to the sample.
-                    </doc>
-                </field>
-                <field name="bias_offset" type="NX_NUMBER" optional="true" units="NX_VOLTAGE">
-                    <doc>
-                        Offset value of the bias voltage.
-                    </doc>
-                </field>
-                <group name="bias_calibration" type="NXcalibration" optional="true">
-                    <doc>
-                        Calibration of the bias voltage measurement (V/V).
-                    </doc>
-                    <field name="coefficients" type="NX_NUMBER" optional="true" units="NX_ANY">
-                        <doc>
-                            The coefficients of the calibration.
-                        </doc>
-                    </field>
                 </group>
             </group>
         </group>

--- a/contributed_definitions/NXsts.nxdl.xml
+++ b/contributed_definitions/NXsts.nxdl.xml
@@ -26,19 +26,115 @@ https://thesis.library.caltech.edu/1943/4/03chapter3.pdf
 TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and NXafm-->
 <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXsts" extends="NXspm" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
     <doc>
-         An application definition to describe Scanning Tunneling Spectroscopy (STS).
-         
-         The NXsts is duplication of NXspm and is considered as a proxy application definition
-         for Scanning Tunneling Spectroscopy (STS) technique.
+        An application definition to describe Scanning Tunneling Spectroscopy (STS).
+        
+        The NXsts is duplication of NXspm and is considered as a proxy application definition
+        for Scanning Tunneling Spectroscopy (STS) technique.
     </doc>
     <group type="NXentry">
         <field name="definition">
             <doc>
-                 Name of the definition that is used for the application.
+                Name of the definition that is used for the application.
             </doc>
             <enumeration>
                 <item value="NXsts"/>
             </enumeration>
         </field>
+        <field name="scan_mode">
+            <doc>
+                The mode between the tip and sample of the tunneling spectroscopy experiment.
+            </doc>
+            <enumeration open="true">
+                <item value="constant_height"/>
+                <item value="constant_current"/>
+                <item value="constant_spacing"/>
+            </enumeration>
+        </field>
+        <group name="reproducibility_indicators" type="NXobject" optional="true">
+            <doc>
+                The group's concepts hold the link to the related concepts that define the
+                reproducibility of the STM experiment.
+            </doc>
+            <field name="current" type="NX_NUMBER" optional="true">
+                <doc>
+                    The tunneling current between tip and sample after application of bias voltage.
+                    link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
+                </doc>
+            </field>
+            <field name="current_offset" type="NX_NUMBER" optional="true">
+                <doc>
+                    The offset in tunneling current between tip and sample after application of bias voltage.
+                    link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
+                </doc>
+            </field>
+            <field name="current_gain" type="NX_NUMBER" optional="true">
+                <doc>
+                    Proportional relationship between the probe output voltage and the actual
+                    tunneling current when measuring the tunneling current.
+                    link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/amplifier/current_gain
+                </doc>
+            </field>
+            <group name="bias_sweep" type="NXobject" optional="true">
+                <doc>
+                    Bias sweep measurement in bias spectroscopy.
+                    Link to target:
+                    /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
+                </doc>
+            </group>
+            <field name="modulation_signal_type" optional="true">
+                <doc>
+                    This is the signal on which the modulation voltage or current will be added.
+                    link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
+                </doc>
+            </field>
+            <field name="modulation_frequency" type="NX_NUMBER" optional="true">
+                <doc>
+                    The frequency of the sine modulation that is used to modulate the signal in lock-in.
+                    link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
+                </doc>
+            </field>
+        </group>
+        <group name="resolution_indicators" type="NXobject" optional="true">
+            <doc>
+                The group's concepts hold the link to the related concepts that define the
+                resolution of the STM experiment.
+            </doc>
+            <field name="tip_temp" type="NX_NUMBER" optional="true">
+                <doc>
+                    Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+                </doc>
+            </field>
+            <field name="cryo_bottom_temp" type="NX_NUMBER" optional="true">
+                <doc>
+                    Link to target:
+                    /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
+                </doc>
+            </field>
+            <field name="cryo_shield_temp" type="NX_NUMBER" optional="true">
+                <doc>
+                    Link to target:
+                    /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
+                </doc>
+            </field>
+            <group name="bias_sweep" type="NXobject" optional="true">
+                <doc>
+                    Link to target:
+                    /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
+                </doc>
+            </group>
+            <field name="modulation_signal_type" optional="true">
+                <doc>
+                    This is the signal on which the modulation voltage or current will be added.
+                    link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
+                    modulation_signal_type
+                </doc>
+            </field>
+            <field name="modulation_frequency" type="NX_NUMBER" optional="true">
+                <doc>
+                    The frequency of the sine modulation that is used to modulate the signal in
+                    lock-in.
+                </doc>
+            </field>
+        </group>
     </group>
 </definition>

--- a/contributed_definitions/NXxrd_pan.nxdl.xml
+++ b/contributed_definitions/NXxrd_pan.nxdl.xml
@@ -23,23 +23,23 @@
 -->
 <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXxrd_pan" extends="NXxrd" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
     <doc>
-         NXxrd_pan is a specialisation of NXxrd with extra properties
-         for the PANalytical XRD data format.
+        NXxrd_pan is a specialisation of NXxrd with extra properties
+        for the PANalytical XRD data format.
     </doc>
     <group type="NXentry">
         <field name="data_file" optional="true">
             <doc>
-                 Name of the data file.
+                Name of the data file.
             </doc>
         </field>
         <field name="measurement_type">
             <doc>
-                 Type of measurement.
+                Type of measurement.
             </doc>
         </field>
         <field name="definition">
             <doc>
-                 Official NeXus NXDL schema to which this file conforms.
+                Official NeXus NXDL schema to which this file conforms.
             </doc>
             <enumeration>
                 <item value="NXxrd_pan"/>
@@ -47,10 +47,10 @@
         </field>
         <field name="method">
             <doc>
-                 Method used to collect the data
-                 default='X-Ray Diffraction (XRD)'
+                Method used to collect the data
+                default='X-Ray Diffraction (XRD)'
             </doc>
-            <enumeration>
+            <enumeration open="true">
                 <item value="X-Ray Diffraction (XRD)"/>
             </enumeration>
         </field>
@@ -59,9 +59,9 @@
             <group type="NXsource">
                 <field name="xray_tube_material">
                     <doc>
-                         Type of the X-ray tube.
+                        Type of the X-ray tube.
                     </doc>
-                    <enumeration>
+                    <enumeration open="true">
                         <item value="Cu"/>
                         <item value="Cr"/>
                         <item value="Mo"/>
@@ -73,70 +73,70 @@
                 </field>
                 <field name="xray_tube_current" type="NX_FLOAT" units="NX_CURRENT">
                     <doc>
-                         Current of the X-ray tube.
+                        Current of the X-ray tube.
                     </doc>
                 </field>
                 <field name="xray_tube_voltage" type="NX_FLOAT" units="NX_VOLTAGE">
                     <doc>
-                         Voltage of the X-ray tube.
+                        Voltage of the X-ray tube.
                     </doc>
                 </field>
                 <!--Unicode for alpha : \u03b1-->
                 <field name="k_alpha_one" type="NX_FLOAT" units="NX_WAVELENGTH">
                     <doc>
-                         Wavelength of the K\u03b1 1 line.
+                        Wavelength of the K\u03b1 1 line.
                     </doc>
                     <attribute name="units">
-                        <enumeration>
+                        <enumeration open="true">
                             <item value="angstrom"/>
                         </enumeration>
                     </attribute>
                 </field>
                 <field name="k_alpha_two" type="NX_FLOAT" units="NX_WAVELENGTH">
                     <doc>
-                         Wavelength of the K\u03b1 2 line.
+                        Wavelength of the K\u03b1 2 line.
                     </doc>
                     <attribute name="units">
-                        <enumeration>
+                        <enumeration open="true">
                             <item value="angstrom"/>
                         </enumeration>
                     </attribute>
                 </field>
                 <field name="ratio_k_alphatwo_k_alphaone" type="NX_FLOAT" units="NX_DIMENSIONLESS">
                     <doc>
-                         K\u03b1 2/K\u03b1 1 intensity ratio.
+                        K\u03b1 2/K\u03b1 1 intensity ratio.
                     </doc>
                 </field>
                 <field name="kbeta" type="NX_FLOAT" optional="true" units="NX_WAVELENGTH">
                     <doc>
-                         Wavelength of the K\u00df line.
+                        Wavelength of the K\u00df line.
                     </doc>
                     <attribute name="units">
-                        <enumeration>
+                        <enumeration open="true">
                             <item value="angstrom"/>
                         </enumeration>
                     </attribute>
                 </field>
                 <field name="source_peak_wavelength" type="NX_FLOAT" optional="true" units="NX_WAVELENGTH">
                     <doc>
-                         Wavelength of the X-ray source. Used to convert from 2-theta to Q.
+                        Wavelength of the X-ray source. Used to convert from 2-theta to Q.
                     </doc>
                 </field>
             </group>
             <group type="NXdetector">
                 <field name="scan_axis">
                     <doc>
-                         Axis scanned.
+                        Axis scanned.
                     </doc>
                 </field>
                 <field name="scan_mode">
                     <doc>
-                         Mode of scan.
+                        Mode of scan.
                     </doc>
                 </field>
                 <field name="integration_time" type="NX_FLOAT" optional="true" units="NX_TIME">
                     <doc>
-                         Integration time per channel.
+                        Integration time per channel.
                     </doc>
                 </field>
             </group>
@@ -147,76 +147,76 @@ incident_beam(NXbeam):
 defracted_beam(NXbeam):-->
         <group name="experiment_config" type="NXobject" optional="true">
             <doc>
-                 Collect user inputs e.g. name or path of the input file.
+                Collect user inputs e.g. name or path of the input file.
             </doc>
             <group name="two_theta" type="NXobject">
                 <field name="start" type="NX_FLOAT" units="NX_ANGLE">
                     <doc>
-                         Starting value of the diffraction angle.
+                        Starting value of the diffraction angle.
                     </doc>
                 </field>
                 <field name="end" type="NX_FLOAT" units="NX_ANGLE">
                     <doc>
-                         Ending value of the diffraction angle.
+                        Ending value of the diffraction angle.
                     </doc>
                 </field>
                 <field name="step" type="NX_FLOAT" units="NX_ANGLE">
                     <doc>
-                         Minimum step size in-between two diffraction angles.
+                        Minimum step size in-between two diffraction angles.
                     </doc>
                 </field>
             </group>
             <group name="omega" type="NXobject">
                 <field name="start" type="NX_FLOAT" units="NX_ANGLE">
                     <doc>
-                         Starting value of the incident angle.
+                        Starting value of the incident angle.
                     </doc>
                 </field>
                 <field name="end" type="NX_FLOAT" units="NX_ANGLE">
                     <doc>
-                         Ending value of the incident angle.
+                        Ending value of the incident angle.
                     </doc>
                 </field>
                 <field name="step" type="NX_FLOAT" units="NX_ANGLE">
                     <doc>
-                         Minimum step size in the between two incident angles.
+                        Minimum step size in the between two incident angles.
                     </doc>
                 </field>
             </group>
             <field name="beam_attenuation_factors">
                 <doc>
-                     Beam attenuation factors over the path.
+                    Beam attenuation factors over the path.
                 </doc>
             </field>
             <field name="goniometer_x" type="NX_FLOAT" optional="true" units="NX_LENGTH">
                 <doc>
-                     Goniometer position X.
+                    Goniometer position X.
                 </doc>
             </field>
             <field name="goniometer_y" type="NX_FLOAT" optional="true" units="NX_LENGTH">
                 <doc>
-                     Goniometer position Y.
+                    Goniometer position Y.
                 </doc>
             </field>
             <field name="goniometer_z" type="NX_FLOAT" optional="true" units="NX_LENGTH">
                 <doc>
-                     Goniometer position Z
+                    Goniometer position Z
                 </doc>
             </field>
             <field name="count_time" type="NX_FLOAT" units="NX_TIME">
                 <doc>
-                     Total time of count.
+                    Total time of count.
                 </doc>
             </field>
         </group>
         <group name="experiment_result" type="NXdata">
             <doc>
-                 All experiment results data such as scattering angle (2theta),
-                 intensity, incident angle, scattering vector, etc will be stored here.
+                All experiment results data such as scattering angle (2theta),
+                intensity, incident angle, scattering vector, etc will be stored here.
             </doc>
             <field name="intensity" type="NX_FLOAT">
                 <doc>
-                     Number of scattered electrons per unit time.
+                    Number of scattered electrons per unit time.
                 </doc>
                 <dimensions rank="1">
                     <dim index="1" value="nDet"/>
@@ -224,7 +224,7 @@ defracted_beam(NXbeam):-->
             </field>
             <field name="two_theta" type="NX_FLOAT" units="NX_ANGLE">
                 <doc>
-                     Two-theta (scattering angle) of the diffractogram.
+                    Two-theta (scattering angle) of the diffractogram.
                 </doc>
                 <dimensions rank="1">
                     <dim index="1" value="nDet"/>
@@ -232,7 +232,7 @@ defracted_beam(NXbeam):-->
             </field>
             <field name="omega" type="NX_FLOAT" optional="true" units="NX_ANGLE">
                 <doc>
-                     Incident angle of the diffractogram.
+                    Incident angle of the diffractogram.
                 </doc>
                 <dimensions rank="1">
                     <dim index="1" value="nDet"/>
@@ -240,7 +240,7 @@ defracted_beam(NXbeam):-->
             </field>
             <field name="phi" type="NX_FLOAT" optional="true" units="NX_ANGLE">
                 <doc>
-                     The phi range of the diffractogram.
+                    The phi range of the diffractogram.
                 </doc>
                 <dimensions rank="1">
                     <dim index="1" value="nDet"/>
@@ -248,7 +248,7 @@ defracted_beam(NXbeam):-->
             </field>
             <field name="chi" type="NX_FLOAT" optional="true" units="NX_ANGLE">
                 <doc>
-                     The chi range of the diffractogram
+                    The chi range of the diffractogram
                 </doc>
                 <dimensions rank="1">
                     <dim index="1" value="nDet"/>
@@ -256,78 +256,78 @@ defracted_beam(NXbeam):-->
             </field>
             <field name="q_parallel" type="NX_FLOAT" optional="true" units="NX_ANY">
                 <doc>
-                     The scattering vector component, which is parallel to the sample surface.
+                    The scattering vector component, which is parallel to the sample surface.
                 </doc>
             </field>
             <field name="q_perpendicular" type="NX_FLOAT" optional="true" units="NX_ANY">
                 <doc>
-                     The scattering vector component, which is perpendicular to the sample surface.
+                    The scattering vector component, which is perpendicular to the sample surface.
                 </doc>
             </field>
             <field name="q_norm" type="NX_FLOAT" optional="true" units="NX_ANY">
                 <doc>
-                     The norm value of the scattering vector, q. The scattering vector is defined as a
-                     difference between the incident and scattered wave vectors.
-                     For details: https://en.wikipedia.org/wiki/Powder_diffraction
-                     and https://theory.labster.com/scattering-vector/
+                    The norm value of the scattering vector, q. The scattering vector is defined as a
+                    difference between the incident and scattered wave vectors.
+                    For details: https://en.wikipedia.org/wiki/Powder_diffraction
+                    and https://theory.labster.com/scattering-vector/
                 </doc>
             </field>
         </group>
         <group name="q_data" type="NXdata" optional="true">
             <doc>
-                 The desired view for scattering vectors.
+                The desired view for scattering vectors.
             </doc>
             <field name="q" type="NX_FLOAT" optional="true">
                 <doc>
-                     This concept corresponds to the norm value of the scattering vector(q).
-                     The concept is the same as 'q_norm' of 'experiment_result'
-                     and should be linked to /entry[ENTRY]/experiment_result/q_norm.
+                    This concept corresponds to the norm value of the scattering vector(q).
+                    The concept is the same as 'q_norm' of 'experiment_result'
+                    and should be linked to /entry[ENTRY]/experiment_result/q_norm.
                 </doc>
             </field>
             <field name="intensity" type="NX_FLOAT" optional="true">
                 <doc>
-                     Number of scattered electrons per unit time at each scattering vector (q) value.
-                     The concept is the same as the 'intensity' of experiment_result
-                     and should be linked to /entry[ENTRY]/experiment_result/intensity.
+                    Number of scattered electrons per unit time at each scattering vector (q) value.
+                    The concept is the same as the 'intensity' of experiment_result
+                    and should be linked to /entry[ENTRY]/experiment_result/intensity.
                 </doc>
             </field>
             <field name="q_parallel" type="NX_FLOAT" optional="true">
                 <doc>
-                     The scattering vector (q) component, which is parallel to the sample surface.
-                     This component is used in the Reciprocal Space Mapping (RSM) technique of
-                     X-ray diffraction method.
-                     
-                     The concept is the same as 'q_parallel' of experiment_result,
-                     and should be linked to /entry[ENTRY]/experiment_result/q_parallel.
+                    The scattering vector (q) component, which is parallel to the sample surface.
+                    This component is used in the Reciprocal Space Mapping (RSM) technique of
+                    X-ray diffraction method.
+                    
+                    The concept is the same as 'q_parallel' of experiment_result,
+                    and should be linked to /entry[ENTRY]/experiment_result/q_parallel.
                 </doc>
             </field>
             <field name="q_perpendicular" type="NX_FLOAT" optional="true">
                 <doc>
-                     The scattering vector component, which is perpendicular to the sample surface.
-                     
-                     The concept is the same as  'q_perpendicular' of experiment_result,
-                     and should be linked to /entry[ENTRY]/experiment_result/q_perpendicular.
+                    The scattering vector component, which is perpendicular to the sample surface.
+                    
+                    The concept is the same as  'q_perpendicular' of experiment_result,
+                    and should be linked to /entry[ENTRY]/experiment_result/q_perpendicular.
                 </doc>
             </field>
         </group>
         <group type="NXsample" optional="true">
             <doc>
-                 Description on sample.
+                Description on sample.
             </doc>
             <field name="sample_mode">
                 <doc>
-                     Mode of sample.
+                    Mode of sample.
                 </doc>
             </field>
             <field name="sample_id">
                 <doc>
-                     Id of sample.
+                    Id of sample.
                 </doc>
             </field>
             <field name="sample_name">
                 <doc>
-                     Usually in xrd sample are being analysed, but sample might be identified by
-                     assumed name or given name.
+                    Usually in xrd sample are being analysed, but sample might be identified by
+                    assumed name or given name.
                 </doc>
             </field>
         </group>

--- a/contributed_definitions/nyaml/NXafm.yaml
+++ b/contributed_definitions/nyaml/NXafm.yaml
@@ -146,7 +146,7 @@ NXafm(NXspm):
           /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
           
           Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
-      cantilever_oscillator(NXobject):
+      cantilever_oscillator(NXcomponent):
         exists: optional
         doc: |
           Link to target:
@@ -194,7 +194,7 @@ NXafm(NXspm):
           Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# b121f6ef172cda9fdc8d1b6682ef63af6cbc74d810489a52609411bfd298293c
+# ab4a292c2b94704fd9a295e422c63d90ebdaf3ea6732b1ec3acffba981692fcc
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -403,7 +403,7 @@ NXafm(NXspm):
 #                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </field>
-#             <group name="cantilever_oscillator" type="NXobject" optional="true">
+#             <group name="cantilever_oscillator" type="NXcomponent" optional="true">
 #                 <doc>
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/cantilever_spm/cantilever_oscillator

--- a/contributed_definitions/nyaml/NXafm.yaml
+++ b/contributed_definitions/nyaml/NXafm.yaml
@@ -14,7 +14,7 @@ NXafm(NXspm):
         The mode of the scan.
       enumeration:
         open_enum: true
-        items: [contact mode, tapping mode, non-contact mode, Kelvin probe, electric force]
+        items: [contact mode, tapping mode, non-contact mode, Kelvin probe, electric force, lateral force mode]
     experiment_instrument(NXinstrument):
       doc: |
         The group explains the core instruments' setup of the AFM experiment as well as the environment of the corresponding
@@ -194,7 +194,7 @@ NXafm(NXspm):
           Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# b3a8e762084a097285c2adf8e6021ae9d4efa352795f9e24e5de9ab1479ce457
+# 285156c4f5f9022b85926bb1db895a6251cb55ced819ab0cf9df353c41dd3f7c
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -242,6 +242,7 @@ NXafm(NXspm):
 #                 <item value="non-contact mode"/>
 #                 <item value="Kelvin probe"/>
 #                 <item value="electric force"/>
+#                 <item value="lateral force mode"/>
 #             </enumeration>
 #         </field>
 #         <group name="experiment_instrument" type="NXinstrument">

--- a/contributed_definitions/nyaml/NXafm.yaml
+++ b/contributed_definitions/nyaml/NXafm.yaml
@@ -66,14 +66,23 @@ NXafm(NXspm):
           The environment information.
         height_piezo_sensor(NXsensor):
           doc: |
-            Link to the group ENTRY[entry]/experiment_instrument/height_piezo_sensor.
+            Link to the group
+            ENTRY[entry]/experiment_instrument/height_piezo_sensor.
+            
+            Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
         XY_piezo_sensor(NXsensor):
           nameType: specified
           doc: |
-            Link to the group ENTRY[entry]/experiment_instrument/XY_piezo_sensor.
+            Link to the group
+            ENTRY[entry]/experiment_instrument/XY_piezo_sensor.
+            
+            Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
         tip_temp_sensor(NXsensor):
           doc: |
-            Link to the group ENTRY[entry]/experiment_instrument/tip_temp_sensor.
+            Link to the group
+            ENTRY[entry]/experiment_instrument/tip_temp_sensor.
+            
+            Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
       height_piezo_sensor(NXsensor):
         exists: optional
         doc: |
@@ -111,7 +120,7 @@ NXafm(NXspm):
         exists: optional
         doc: |
           The temperature of the scan environment or tip of the cantilever.
-    reproducibility_indicators(NXobject):
+    reproducibility_indicators(NXcollection):
       exists: optional
       doc: |
         The group of indicators (links to the existing fields in different groups) that measure
@@ -119,52 +128,73 @@ NXafm(NXspm):
       cantilever_tip_temp(NX_NUMBER):
         exists: optional
         doc: |
-          Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+          Link to target:
+          /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+          
+          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
       cryo_bottom_temp(NX_NUMBER):
         exists: optional
         doc: |
           Link to target:
           /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
+          
+          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
       cryo_shield_temp(NX_NUMBER):
         exists: optional
         doc: |
           Link to target:
           /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
+          
+          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
       cantilever_oscillator(NXobject):
         exists: optional
         doc: |
-          Link to target: /ENTRY[entry]/experiment_instrument/cantilever_oscillator
-    resolution_indicators(NXobject):
+          Link to target:
+          /ENTRY[entry]/experiment_instrument/cantilever_oscillator
+          
+          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+    resolution_indicators(NXcollection):
       exists: optional
       doc: |
         The group of indicators (links to the existing fields in different groups) that
       cantilever_tip_temp(NXsensor):
         exists: optional
         doc: |
-          Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+          Link to target:
+          /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+          
+          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
       cryo_bottom_temp(NXsensor):
         exists: optional
         doc: |
           Link to target:
           /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
+          
+          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
       cryo_shield_temp(NXsensor):
         exists: optional
         doc: |
           Link to target:
           /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
+          
+          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
       oscillator_excitation(NX_NUMBER):
         exists: optional
         doc: |
           Link to target:
           /ENTRY[entry]/experiment_instrument/cantilever_oscillator/oscillator_excitation
+          
+          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
       amplitude_excitation(NX_NUMBER):
         exists: optional
         doc: |
           Link to target:
           /ENTRY[entry]/experiment_instrument/cantilever_oscillator/phase_lock_loop/amplitude_excitation
+          
+          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 46a922b5d9e50849298dce7bb09f14958296d731c0a698b46b6b7e59f59ce839
+# b3a8e762084a097285c2adf8e6021ae9d4efa352795f9e24e5de9ab1479ce457
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -270,17 +300,26 @@ NXafm(NXspm):
 #                 </doc>
 #                 <group name="height_piezo_sensor" type="NXsensor">
 #                     <doc>
-#                         Link to the group ENTRY[entry]/experiment_instrument/height_piezo_sensor.
+#                         Link to the group
+#                         ENTRY[entry]/experiment_instrument/height_piezo_sensor.
+#                         
+#                         Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                     </doc>
 #                 </group>
 #                 <group name="XY_piezo_sensor" type="NXsensor" nameType="specified">
 #                     <doc>
-#                         Link to the group ENTRY[entry]/experiment_instrument/XY_piezo_sensor.
+#                         Link to the group
+#                         ENTRY[entry]/experiment_instrument/XY_piezo_sensor.
+#                         
+#                         Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                     </doc>
 #                 </group>
 #                 <group name="tip_temp_sensor" type="NXsensor">
 #                     <doc>
-#                         Link to the group ENTRY[entry]/experiment_instrument/tip_temp_sensor.
+#                         Link to the group
+#                         ENTRY[entry]/experiment_instrument/tip_temp_sensor.
+#                         
+#                         Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                     </doc>
 #                 </group>
 #             </group>
@@ -334,65 +373,86 @@ NXafm(NXspm):
 #                 </doc>
 #             </group>
 #         </group>
-#         <group name="reproducibility_indicators" type="NXobject" optional="true">
+#         <group name="reproducibility_indicators" type="NXcollection" optional="true">
 #             <doc>
 #                 The group of indicators (links to the existing fields in different groups) that measure
 #                 the reproducibility of the experiment.
 #             </doc>
 #             <field name="cantilever_tip_temp" type="NX_NUMBER" optional="true">
 #                 <doc>
-#                     Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+#                     Link to target:
+#                     /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+#                     
+#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                 </doc>
 #             </field>
 #             <field name="cryo_bottom_temp" type="NX_NUMBER" optional="true">
 #                 <doc>
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
+#                     
+#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                 </doc>
 #             </field>
 #             <field name="cryo_shield_temp" type="NX_NUMBER" optional="true">
 #                 <doc>
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
+#                     
+#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                 </doc>
 #             </field>
 #             <group name="cantilever_oscillator" type="NXobject" optional="true">
 #                 <doc>
-#                     Link to target: /ENTRY[entry]/experiment_instrument/cantilever_oscillator
+#                     Link to target:
+#                     /ENTRY[entry]/experiment_instrument/cantilever_oscillator
+#                     
+#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                 </doc>
 #             </group>
 #         </group>
-#         <group name="resolution_indicators" type="NXobject" optional="true">
+#         <group name="resolution_indicators" type="NXcollection" optional="true">
 #             <doc>
 #                 The group of indicators (links to the existing fields in different groups) that
 #             </doc>
 #             <group name="cantilever_tip_temp" type="NXsensor" optional="true">
 #                 <doc>
-#                     Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+#                     Link to target:
+#                     /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+#                     
+#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                 </doc>
 #             </group>
 #             <group name="cryo_bottom_temp" type="NXsensor" optional="true">
 #                 <doc>
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
+#                     
+#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                 </doc>
 #             </group>
 #             <group name="cryo_shield_temp" type="NXsensor" optional="true">
 #                 <doc>
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
+#                     
+#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                 </doc>
 #             </group>
 #             <field name="oscillator_excitation" type="NX_NUMBER" optional="true">
 #                 <doc>
-#                     Link to target: 
+#                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/cantilever_oscillator/oscillator_excitation
+#                     
+#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                 </doc>
 #             </field>
 #             <field name="amplitude_excitation" type="NX_NUMBER" optional="true">
 #                 <doc>
-#                     Link to target: 
+#                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/cantilever_oscillator/phase_lock_loop/amplitude_excitation
+#                     
+#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                 </doc>
 #             </field>
 #         </group>

--- a/contributed_definitions/nyaml/NXafm.yaml
+++ b/contributed_definitions/nyaml/NXafm.yaml
@@ -12,7 +12,9 @@ NXafm(NXspm):
     scan_mode:
       doc: |
         The mode of the scan.
-      enumeration: [contact mode, tapping mode, non-contact mode, Kelvin probe, electric force]
+      enumeration:
+        open_enum: true
+        items: [contact mode, tapping mode, non-contact mode, Kelvin probe, electric force]
     experiment_instrument(NXinstrument):
       doc: |
         The group explains the core instruments' setup of the AFM experiment as well as the environment of the corresponding
@@ -34,7 +36,7 @@ NXafm(NXspm):
             In a typical AFM scan cantilever moves toward the surface of the sample until a user-defined value of force acting
             on the cantilever is reached. The measured force is used as an input of a PID feedback loop, and the output of
             this loop controls the vertical position of the cantilever.
-        cantilever_oscillator(NXobject):
+        cantilever_oscillator(NXcomponent):
           exists: optional
           doc: |
             When a cantilever is oscillated close to its resonance, this describes the oscillator properties.
@@ -71,7 +73,7 @@ NXafm(NXspm):
             Link to the group ENTRY[entry]/experiment_instrument/XY_piezo_sensor.
         tip_temp_sensor(NXsensor):
           doc: |
-            Link to the group ENTRY[entry]/experiment_instrument/cantilever_temperature.
+            Link to the group ENTRY[entry]/experiment_instrument/tip_temp_sensor.
       height_piezo_sensor(NXsensor):
         exists: optional
         doc: |
@@ -110,16 +112,59 @@ NXafm(NXspm):
         doc: |
           The temperature of the scan environment or tip of the cantilever.
     reproducibility_indicators(NXobject):
+      exists: optional
       doc: |
         The group of indicators (links to the existing fields in different groups) that measure
         the reproducibility of the experiment.
+      cantilever_tip_temp(NX_NUMBER):
+        exists: optional
+        doc: |
+          Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+      cryo_bottom_temp(NX_NUMBER):
+        exists: optional
+        doc: |
+          Link to target:
+          /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
+      cryo_shield_temp(NX_NUMBER):
+        exists: optional
+        doc: |
+          Link to target:
+          /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
+      cantilever_oscillator(NXobject):
+        exists: optional
+        doc: |
+          Link to target: /ENTRY[entry]/experiment_instrument/cantilever_oscillator
     resolution_indicators(NXobject):
       exists: optional
       doc: |
         The group of indicators (links to the existing fields in different groups) that
+      cantilever_tip_temp(NXsensor):
+        exists: optional
+        doc: |
+          Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+      cryo_bottom_temp(NXsensor):
+        exists: optional
+        doc: |
+          Link to target:
+          /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
+      cryo_shield_temp(NXsensor):
+        exists: optional
+        doc: |
+          Link to target:
+          /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
+      oscillator_excitation(NX_NUMBER):
+        exists: optional
+        doc: |
+          Link to target:
+          /ENTRY[entry]/experiment_instrument/cantilever_oscillator/oscillator_excitation
+      amplitude_excitation(NX_NUMBER):
+        exists: optional
+        doc: |
+          Link to target:
+          /ENTRY[entry]/experiment_instrument/cantilever_oscillator/phase_lock_loop/amplitude_excitation
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 7ce97049396964826e30ad4b7ec4439b47ca9f2a9a641ae8f4fadeeb9b094a12
+# 46a922b5d9e50849298dce7bb09f14958296d731c0a698b46b6b7e59f59ce839
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -161,7 +206,7 @@ NXafm(NXspm):
 #             <doc>
 #                 The mode of the scan.
 #             </doc>
-#             <enumeration>
+#             <enumeration open="true">
 #                 <item value="contact mode"/>
 #                 <item value="tapping mode"/>
 #                 <item value="non-contact mode"/>
@@ -192,7 +237,7 @@ NXafm(NXspm):
 #                       on the cantilever is reached. The measured force is used as an input of a PID feedback loop, and the output of
 #                       this loop controls the vertical position of the cantilever.
 #                 </doc>
-#                 <group name="cantilever_oscillator" type="NXobject" optional="true">
+#                 <group name="cantilever_oscillator" type="NXcomponent" optional="true">
 #                     <doc>
 #                         When a cantilever is oscillated close to its resonance, this describes the oscillator properties.
 #                         
@@ -235,7 +280,7 @@ NXafm(NXspm):
 #                 </group>
 #                 <group name="tip_temp_sensor" type="NXsensor">
 #                     <doc>
-#                         Link to the group ENTRY[entry]/experiment_instrument/cantilever_temperature.
+#                         Link to the group ENTRY[entry]/experiment_instrument/tip_temp_sensor.
 #                     </doc>
 #                 </group>
 #             </group>
@@ -289,16 +334,67 @@ NXafm(NXspm):
 #                 </doc>
 #             </group>
 #         </group>
-#         <group name="reproducibility_indicators" type="NXobject">
+#         <group name="reproducibility_indicators" type="NXobject" optional="true">
 #             <doc>
 #                 The group of indicators (links to the existing fields in different groups) that measure
 #                 the reproducibility of the experiment.
 #             </doc>
+#             <field name="cantilever_tip_temp" type="NX_NUMBER" optional="true">
+#                 <doc>
+#                     Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+#                 </doc>
+#             </field>
+#             <field name="cryo_bottom_temp" type="NX_NUMBER" optional="true">
+#                 <doc>
+#                     Link to target:
+#                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
+#                 </doc>
+#             </field>
+#             <field name="cryo_shield_temp" type="NX_NUMBER" optional="true">
+#                 <doc>
+#                     Link to target:
+#                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
+#                 </doc>
+#             </field>
+#             <group name="cantilever_oscillator" type="NXobject" optional="true">
+#                 <doc>
+#                     Link to target: /ENTRY[entry]/experiment_instrument/cantilever_oscillator
+#                 </doc>
+#             </group>
 #         </group>
 #         <group name="resolution_indicators" type="NXobject" optional="true">
 #             <doc>
 #                 The group of indicators (links to the existing fields in different groups) that
 #             </doc>
+#             <group name="cantilever_tip_temp" type="NXsensor" optional="true">
+#                 <doc>
+#                     Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+#                 </doc>
+#             </group>
+#             <group name="cryo_bottom_temp" type="NXsensor" optional="true">
+#                 <doc>
+#                     Link to target:
+#                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
+#                 </doc>
+#             </group>
+#             <group name="cryo_shield_temp" type="NXsensor" optional="true">
+#                 <doc>
+#                     Link to target:
+#                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
+#                 </doc>
+#             </group>
+#             <field name="oscillator_excitation" type="NX_NUMBER" optional="true">
+#                 <doc>
+#                     Link to target: 
+#                     /ENTRY[entry]/experiment_instrument/cantilever_oscillator/oscillator_excitation
+#                 </doc>
+#             </field>
+#             <field name="amplitude_excitation" type="NX_NUMBER" optional="true">
+#                 <doc>
+#                     Link to target: 
+#                     /ENTRY[entry]/experiment_instrument/cantilever_oscillator/phase_lock_loop/amplitude_excitation
+#                 </doc>
+#             </field>
 #         </group>
 #     </group>
 # </definition>

--- a/contributed_definitions/nyaml/NXafm.yaml
+++ b/contributed_definitions/nyaml/NXafm.yaml
@@ -69,20 +69,20 @@ NXafm(NXspm):
             Link to the group
             ENTRY[entry]/experiment_instrument/height_piezo_sensor.
             
-            Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+            Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
         XY_piezo_sensor(NXsensor):
           nameType: specified
           doc: |
             Link to the group
             ENTRY[entry]/experiment_instrument/XY_piezo_sensor.
             
-            Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+            Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
         tip_temp_sensor(NXsensor):
           doc: |
             Link to the group
             ENTRY[entry]/experiment_instrument/tip_temp_sensor.
             
-            Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+            Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       height_piezo_sensor(NXsensor):
         exists: optional
         doc: |
@@ -131,28 +131,28 @@ NXafm(NXspm):
           Link to target:
           /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
           
-          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       cryo_bottom_temp(NX_NUMBER):
         exists: optional
         doc: |
           Link to target:
           /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
           
-          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       cryo_shield_temp(NX_NUMBER):
         exists: optional
         doc: |
           Link to target:
           /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
           
-          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       cantilever_oscillator(NXobject):
         exists: optional
         doc: |
           Link to target:
-          /ENTRY[entry]/experiment_instrument/cantilever_oscillator
+          /ENTRY[entry]/experiment_instrument/cantilever_spm/cantilever_oscillator
           
-          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
     resolution_indicators(NXcollection):
       exists: optional
       doc: |
@@ -163,38 +163,38 @@ NXafm(NXspm):
           Link to target:
           /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
           
-          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       cryo_bottom_temp(NXsensor):
         exists: optional
         doc: |
           Link to target:
           /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
           
-          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       cryo_shield_temp(NXsensor):
         exists: optional
         doc: |
           Link to target:
           /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
           
-          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       oscillator_excitation(NX_NUMBER):
         exists: optional
         doc: |
           Link to target:
-          /ENTRY[entry]/experiment_instrument/cantilever_oscillator/oscillator_excitation
+          /ENTRY[entry]/experiment_instrument/cantilever_spm/cantilever_oscillator/oscillator_excitation
           
-          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       amplitude_excitation(NX_NUMBER):
         exists: optional
         doc: |
           Link to target:
-          /ENTRY[entry]/experiment_instrument/cantilever_oscillator/phase_lock_loop/amplitude_excitation
+          /ENTRY[entry]/experiment_instrument/cantilever_spm/cantilever_oscillator/phase_lock_loop/amplitude_excitation
           
-          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 285156c4f5f9022b85926bb1db895a6251cb55ced819ab0cf9df353c41dd3f7c
+# b121f6ef172cda9fdc8d1b6682ef63af6cbc74d810489a52609411bfd298293c
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -304,7 +304,7 @@ NXafm(NXspm):
 #                         Link to the group
 #                         ENTRY[entry]/experiment_instrument/height_piezo_sensor.
 #                         
-#                         Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                         Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                     </doc>
 #                 </group>
 #                 <group name="XY_piezo_sensor" type="NXsensor" nameType="specified">
@@ -312,7 +312,7 @@ NXafm(NXspm):
 #                         Link to the group
 #                         ENTRY[entry]/experiment_instrument/XY_piezo_sensor.
 #                         
-#                         Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                         Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                     </doc>
 #                 </group>
 #                 <group name="tip_temp_sensor" type="NXsensor">
@@ -320,7 +320,7 @@ NXafm(NXspm):
 #                         Link to the group
 #                         ENTRY[entry]/experiment_instrument/tip_temp_sensor.
 #                         
-#                         Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                         Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                     </doc>
 #                 </group>
 #             </group>
@@ -384,7 +384,7 @@ NXafm(NXspm):
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
 #                     
-#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </field>
 #             <field name="cryo_bottom_temp" type="NX_NUMBER" optional="true">
@@ -392,7 +392,7 @@ NXafm(NXspm):
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
 #                     
-#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </field>
 #             <field name="cryo_shield_temp" type="NX_NUMBER" optional="true">
@@ -400,15 +400,15 @@ NXafm(NXspm):
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
 #                     
-#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </field>
 #             <group name="cantilever_oscillator" type="NXobject" optional="true">
 #                 <doc>
 #                     Link to target:
-#                     /ENTRY[entry]/experiment_instrument/cantilever_oscillator
+#                     /ENTRY[entry]/experiment_instrument/cantilever_spm/cantilever_oscillator
 #                     
-#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </group>
 #         </group>
@@ -421,7 +421,7 @@ NXafm(NXspm):
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
 #                     
-#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </group>
 #             <group name="cryo_bottom_temp" type="NXsensor" optional="true">
@@ -429,7 +429,7 @@ NXafm(NXspm):
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
 #                     
-#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </group>
 #             <group name="cryo_shield_temp" type="NXsensor" optional="true">
@@ -437,23 +437,23 @@ NXafm(NXspm):
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
 #                     
-#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </group>
 #             <field name="oscillator_excitation" type="NX_NUMBER" optional="true">
 #                 <doc>
 #                     Link to target:
-#                     /ENTRY[entry]/experiment_instrument/cantilever_oscillator/oscillator_excitation
+#                     /ENTRY[entry]/experiment_instrument/cantilever_spm/cantilever_oscillator/oscillator_excitation
 #                     
-#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </field>
 #             <field name="amplitude_excitation" type="NX_NUMBER" optional="true">
 #                 <doc>
 #                     Link to target:
-#                     /ENTRY[entry]/experiment_instrument/cantilever_oscillator/phase_lock_loop/amplitude_excitation
+#                     /ENTRY[entry]/experiment_instrument/cantilever_spm/cantilever_oscillator/phase_lock_loop/amplitude_excitation
 #                     
-#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </field>
 #         </group>

--- a/contributed_definitions/nyaml/NXamplifier.yaml
+++ b/contributed_definitions/nyaml/NXamplifier.yaml
@@ -2,7 +2,7 @@ category: base
 doc: |
   Base classed definition for amplifier devices.
 type: group
-NXamplifier(NXobject):
+NXamplifier(NXcomponent):
   hardware(NXfabrication):
     doc: |
       (IC, device) (NXmanufacturer?)
@@ -53,8 +53,8 @@ NXamplifier(NXobject):
   # doc: !!! Reduces the effect of capacitive crosstalk in the circuit on experimental results.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 16ef5b7fc979cc0c049aa7a38d898c3a35b058f98046d7657a43e2cd3fac4c1f
-# <?xml version="1.0" encoding="UTF-8"?>
+# 712d67c340eb1258bc1b68666618e6464af7185c06b92cea3d98647c6947722f
+# <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
 # # NeXus - Neutron and X-ray Common Data Format
@@ -77,67 +77,67 @@ NXamplifier(NXobject):
 # #
 # # For further information, see http://www.nexusformat.org
 # -->
-# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" name="NXamplifier" extends="NXobject" type="group" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXamplifier" extends="NXcomponent" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
 #     <doc>
-#          Base classed definition for amplifier devices.
+#         Base classed definition for amplifier devices.
 #     </doc>
 #     <group name="hardware" type="NXfabrication">
 #         <doc>
-#              (IC, device) (NXmanufacturer?)
+#             (IC, device) (NXmanufacturer?)
 #         </doc>
 #     </group>
 #     <field name="num_of_channels" type="NX_NUMBER">
 #         <doc>
-#              The number of preamplifier channels are assgined.
+#             The number of preamplifier channels are assgined.
 #         </doc>
 #     </field>
 #     <field name="active_channels" type="NX_NUMBER">
 #         <doc>
-#              The number of preamplifier channels are ready tp to be used. (array for active
-#              channels)
+#             The number of preamplifier channels are ready tp to be used. (array for active
+#             channels)
 #         </doc>
 #     </field>
 #     <field name="openloop_amplification" type="NX_NUMBER">
 #         <doc>
-#              The output signal does not go through a feedback loop to adjust the
-#              amplification of the amplifier. (array for active channels)
+#             The output signal does not go through a feedback loop to adjust the
+#             amplification of the amplifier. (array for active channels)
 #         </doc>
 #     </field>
 #     <!--amplification(NX_NUMBER):
 # doc: !!! The ratio of the amplitude of the output signal to the amplitude of the input signal. (array for active channels) # From google.-->
 #     <field name="signal_over_noise" type="NX_NUMBER">
 #         <doc>
-#              The ratio of the amplitue of the useful signal to the amplitude of the noise in
-#              the output signal of the amplifier. S/N=V_signal/V_noise. (array for active
-#              channels)
+#             The ratio of the amplitue of the useful signal to the amplitude of the noise in
+#             the output signal of the amplifier. S/N=V_signal/V_noise. (array for active
+#             channels)
 #         </doc>
 #     </field>
 #     <field name="crosstalk_factor" type="NX_NUMBER">
 #         <doc>
-#              (if active &gt;1)
+#             (if active &gt;1)
 #         </doc>
 #     </field>
 #     <field name="crosstalk_compensation" type="NX_BOOLEAN">
 #         <doc>
-#              for reducing interferences between different signalling pathways
+#             for reducing interferences between different signalling pathways
 #         </doc>
 #     </field>
 #     <field name="bandwidth" type="NX_NUMBER" units="NX_FREQUENCY">
 #         <doc>
-#              The spectrum of frequency it can amplify, from its lowest to highest frequency
-#              limits.
+#             The spectrum of frequency it can amplify, from its lowest to highest frequency
+#             limits.
 #         </doc>
 #     </field>
 #     <field name="low_pass" type="NX_NUMBER" units="NX_FREQUENCY">
 #         <doc>
-#              Order and cut-off frequency of the low-pass filter applied on the demodulated
-#              signals (X,Y). Cut-off frq (low pass filter) (foreach DemodulatorChannels)
+#             Order and cut-off frequency of the low-pass filter applied on the demodulated
+#             signals (X,Y). Cut-off frq (low pass filter) (foreach DemodulatorChannels)
 #         </doc>
 #     </field>
 #     <field name="hi_pass" type="NX_NUMBER" units="NX_FREQUENCY">
 #         <doc>
-#              Order and cut-off frequency of the high-pass filter applied on the demodulation
-#              signal. Cut-off frq (hi pass filter) (foreach DemodulatorChannels)
+#             Order and cut-off frequency of the high-pass filter applied on the demodulation
+#             signal. Cut-off frq (hi pass filter) (foreach DemodulatorChannels)
 #         </doc>
 #     </field>
 #     <!--voltage_amplifier_factor(NX_NUMBER):

--- a/contributed_definitions/nyaml/NXbias_spectroscopy.yaml
+++ b/contributed_definitions/nyaml/NXbias_spectroscopy.yaml
@@ -92,6 +92,11 @@ NXbias_spectroscopy(NXobject):
       doc: |
         The time is taken to settle the bias voltage at the desired value.
         The time (at the last sweep) to settle for the last value of the sweep.
+    settling_time(NX_NUMBER):
+      unit: NX_TIME
+      doc: |
+        The time is taken to settle the bias voltage at the desired value. On each sweep usually, the system
+        takes time to settle the bias voltage at the next value.
     max_slew_rate(NX_NUMBER):
       exists: optional
       unit: NX_ANY
@@ -155,7 +160,7 @@ NXbias_spectroscopy(NXobject):
           The data that comes from scanning the area.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# ce82fca45f4b9d70ad9bf3c0c95e4b81cc06395739e8f158b443edc6550d4bed
+# 45ed5ff63cf100d3077aeca4e6f3c21b8232bcd2edfde96b7b0363f0d74bbdfa
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -282,6 +287,12 @@ NXbias_spectroscopy(NXobject):
 #             <doc>
 #                 The time is taken to settle the bias voltage at the desired value.
 #                 The time (at the last sweep) to settle for the last value of the sweep.
+#             </doc>
+#         </field>
+#         <field name="settling_time" type="NX_NUMBER" units="NX_TIME">
+#             <doc>
+#                 The time is taken to settle the bias voltage at the desired value. On each sweep usually, the system
+#                 takes time to settle the bias voltage at the next value.
 #             </doc>
 #         </field>
 #         <field name="max_slew_rate" type="NX_NUMBER" optional="true" units="NX_ANY">

--- a/contributed_definitions/nyaml/NXcantilever_spm.yaml
+++ b/contributed_definitions/nyaml/NXcantilever_spm.yaml
@@ -4,7 +4,7 @@ doc: |
   techniques.
 type: group
 NXcantilever_spm(NXobject):
-  cantilever_oscillator(NXobject):
+  cantilever_oscillator(NXcomponent):
     doc: |
       Generally speaking, the cantilever resembles a simple harmonic oscillator.
       When the cantilever tip is close to the surface of the sample, an attractive or repulsive force appears between the cantilever and the sample, deforming the cantilever. The detector (typically a photodiode) measures this deformation and, therefore, the force acting on the cantilever.
@@ -111,7 +111,7 @@ NXcantilever_spm(NXobject):
           The spring constant coefficient of the cantilever.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 0bb179697bd3f260d94d8d9a8f4f2e30c0ea17f1d42f56ed12207897b7f3e976
+# 277ae828acc870a26bb6da52b47997648a00bdf773e341a30209e5e419b7eb2d
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -140,7 +140,7 @@ NXcantilever_spm(NXobject):
 #         A base class to describe the cantilever used in Atomic Force Microscopy (AFM)
 #         techniques.
 #     </doc>
-#     <group name="cantilever_oscillator" type="NXobject">
+#     <group name="cantilever_oscillator" type="NXcomponent">
 #         <doc>
 #             Generally speaking, the cantilever resembles a simple harmonic oscillator.
 #             When the cantilever tip is close to the surface of the sample, an attractive or repulsive force appears between the cantilever and the sample, deforming the cantilever. The detector (typically a photodiode) measures this deformation and, therefore, the force acting on the cantilever.

--- a/contributed_definitions/nyaml/NXcircuit.yaml
+++ b/contributed_definitions/nyaml/NXcircuit.yaml
@@ -11,7 +11,7 @@ symbols:
   N_channel: |
     number of channels of the circuit board.
 type: group
-NXcircuit(NXobject):
+NXcircuit(NXcomponent):
   hardware(NXfabrication):
     doc: |
       Hardware where the circuit is implanted; includes information about the hardware manufacturers and
@@ -105,7 +105,7 @@ NXcircuit(NXobject):
       value.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# a9455117da8b441d29ef1660d4c789c8d044ced52dacd958c0a82ca13594cee0
+# 0354df665f0472e82c72fe2a66dc6d31749f36bfc9d1ac2302192f406d297b75
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -129,142 +129,142 @@ NXcircuit(NXobject):
 # #
 # # For further information, see http://www.nexusformat.org
 # -->
-# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXcircuit" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXcircuit" extends="NXcomponent" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
 #     <symbols>
 #         <doc>
-#              Constant to be used in the definition: the number of channels of the
-#              circuit board.
+#             Constant to be used in the definition: the number of channels of the
+#             circuit board.
 #         </doc>
 #         <symbol name="N_channel">
 #             <doc>
-#                  number of channels of the circuit board.
+#                 number of channels of the circuit board.
 #             </doc>
 #         </symbol>
 #     </symbols>
 #     <doc>
-#          Application definition for circuit devices.
-#          
-#          Electronic circuits are hardware components connecting several electronic components to achieve
-#          specific functionality, e.g. amplifying a voltage or convert a voltage to binary numbers, etc.
+#         Application definition for circuit devices.
+#         
+#         Electronic circuits are hardware components connecting several electronic components to achieve
+#         specific functionality, e.g. amplifying a voltage or convert a voltage to binary numbers, etc.
 #     </doc>
 #     <group name="hardware" type="NXfabrication">
 #         <doc>
-#              Hardware where the circuit is implanted; includes information about the hardware manufacturers and
-#              type (e.g. part number)
-#              All the elements below may be single numbers of an array of values with length N_channel
-#              describing multiple input and output channels.
+#             Hardware where the circuit is implanted; includes information about the hardware manufacturers and
+#             type (e.g. part number)
+#             All the elements below may be single numbers of an array of values with length N_channel
+#             describing multiple input and output channels.
 #         </doc>
 #     </group>
 #     <field name="components">
 #         <doc>
-#              List of components used in the circuit, e.g., resistors, capacitors, transistors or any
-#              other complex components.
+#             List of components used in the circuit, e.g., resistors, capacitors, transistors or any
+#             other complex components.
 #         </doc>
 #     </field>
 #     <field name="connections">
 #         <doc>
-#              Description of how components are interconnected, including connection points
-#              and wiring.
+#             Description of how components are interconnected, including connection points
+#             and wiring.
 #         </doc>
 #     </field>
 #     <field name="power_source">
 #         <doc>
-#              Details of the power source for the circuit, including voltage and current
-#              ratings.
+#             Details of the power source for the circuit, including voltage and current
+#             ratings.
 #         </doc>
 #     </field>
 #     <field name="signal_type">
 #         <doc>
-#              Type of signal (input signal) the circuit is designed to handle, e.g., analog,
-#              digital, mixed-signal.
+#             Type of signal (input signal) the circuit is designed to handle, e.g., analog,
+#             digital, mixed-signal.
 #         </doc>
 #     </field>
 #     <!--should this be a min / max range?-->
 #     <field name="operating_frequency" type="NX_NUMBER" units="NX_FREQUENCY">
 #         <doc>
-#              The operating frequency of the circuit, see also bandwidth below, which is possibly
-#              centered around this frequency. However, not necessarily (e.g. running a 100 kHz bandwidth
-#              amplifier at low, audio frequencies 1 - 20,000 Hz)
+#             The operating frequency of the circuit, see also bandwidth below, which is possibly
+#             centered around this frequency. However, not necessarily (e.g. running a 100 kHz bandwidth
+#             amplifier at low, audio frequencies 1 - 20,000 Hz)
 #         </doc>
 #     </field>
 #     <!--we may need an NX_RESISTANCE defined-->
 #     <field name="input_impedance" type="NX_NUMBER" units="NX_ANY">
 #         <doc>
-#              Input impedance of the circuit.
+#             Input impedance of the circuit.
 #         </doc>
 #     </field>
 #     <field name="output_impedance" type="NX_NUMBER" units="NX_ANY">
 #         <doc>
-#              Output impedance of the circuit.
+#             Output impedance of the circuit.
 #         </doc>
 #     </field>
 #     <field name="gain" type="NX_NUMBER" units="NX_UNITLESS">
 #         <doc>
-#              Gain of the circuit, if applicable, usually all instruments have a gain which might be
-#              important or not.
+#             Gain of the circuit, if applicable, usually all instruments have a gain which might be
+#             important or not.
 #         </doc>
 #     </field>
 #     <field name="noise_level" type="NX_NUMBER" units="NX_ANY">
 #         <doc>
-#              RMS noise level (in current or voltage) in the circuit in voltage or current.
+#             RMS noise level (in current or voltage) in the circuit in voltage or current.
 #         </doc>
 #     </field>
 #     <field name="bandwidth" type="NX_NUMBER" units="NX_FREQUENCY">
 #         <doc>
-#              The bandwidth of the frequency response of the circuit.
+#             The bandwidth of the frequency response of the circuit.
 #         </doc>
 #     </field>
 #     <field name="temperature_range" type="NX_NUMBER" units="NX_ANY">
 #         <doc>
-#              Operating temperature range of the circuit.
+#             Operating temperature range of the circuit.
 #         </doc>
 #     </field>
 #     <group name="calibration" type="NXcalibration">
 #         <doc>
-#              Calibration data for the circuit.
+#             Calibration data for the circuit.
 #         </doc>
 #     </group>
 #     <field name="offset" type="NX_NUMBER" units="NX_ANY">
 #         <doc>
-#              Offset value for current or voltage.
+#             Offset value for current or voltage.
 #         </doc>
 #     </field>
 #     <field name="output_channels" type="NX_NUMBER">
 #         <doc>
-#              Number of output channels collected to this circuit. Most probably N_channel.
+#             Number of output channels collected to this circuit. Most probably N_channel.
 #         </doc>
 #     </field>
 #     <field name="output_signal" type="NX_NUMBER" units="NX_ANY">
 #         <doc>
-#              Type of output signal, e.g., voltage, current, digital.
+#             Type of output signal, e.g., voltage, current, digital.
 #         </doc>
 #     </field>
 #     <field name="power_consumption" type="NX_NUMBER" units="NX_ANY">
 #         <doc>
-#              Power consumption of the circuit per unit time.
+#             Power consumption of the circuit per unit time.
 #         </doc>
 #     </field>
 #     <field name="status_indicators">
 #         <doc>
-#              Status indicators for the circuit, e.g., LEDs, display readouts.
+#             Status indicators for the circuit, e.g., LEDs, display readouts.
 #         </doc>
 #     </field>
 #     <field name="protection_features" type="NX_CHAR">
 #         <doc>
-#              Protection features built into the circuit, e.g., overvoltage protection,
-#              thermal shutdown.
+#             Protection features built into the circuit, e.g., overvoltage protection,
+#             thermal shutdown.
 #         </doc>
 #     </field>
 #     <field name="acquisition_time" type="NX_NUMBER" units="NX_TIME">
 #         <doc>
-#              Updated rate for several processes using the input signal, e.g., History Graph, the circuit
-#              uses for any such process.
+#             Updated rate for several processes using the input signal, e.g., History Graph, the circuit
+#             uses for any such process.
 #         </doc>
 #     </field>
 #     <field name="output_slew_rate" type="NX_CHAR">
 #         <doc>
-#              The rate at which the signal changes when ramping from the starting
-#              value.
+#             The rate at which the signal changes when ramping from the starting
+#             value.
 #         </doc>
 #     </field>
 # </definition>

--- a/contributed_definitions/nyaml/NXlockin.yaml
+++ b/contributed_definitions/nyaml/NXlockin.yaml
@@ -9,13 +9,10 @@ doc: |
   This method extracts the amplitude and phase shift of the current signal to the reference.
   The reference signal might be created by a generator built-in into the lock-in amplifier.
 type: group
-NXlockin(NXobject):
+NXlockin(NXamplifier):
   hardware(NXfabrication):
     doc: |
       Hardware manufacturers and type (product number) of lock-in amplifier.
-  (NXamplifier):
-    doc: |
-      Description of the amplifier (after detection of the signal from the noise)
   bias_divider:
     doc: |
       Bias divider for lock-in channel if if has.
@@ -122,7 +119,7 @@ NXlockin(NXobject):
       Ratio of output signal amplitude to input signal amplitue (V/V).
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 2e4a2083f48fb1b21f298f3c49187c785d39741e83a733ae619de05c45ba434f
+# dd81d0d2c4db94ce01b4bafb249f583e61747fcc44903f1cb719628cc68c35e4
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -146,7 +143,7 @@ NXlockin(NXobject):
 # #
 # # For further information, see http://www.nexusformat.org
 # -->
-# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXlockin" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXlockin" extends="NXamplifier" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
 #     <doc>
 #         A base class definition for a lock-in amplifier.
 #         
@@ -160,11 +157,6 @@ NXlockin(NXobject):
 #     <group name="hardware" type="NXfabrication">
 #         <doc>
 #             Hardware manufacturers and type (product number) of lock-in amplifier.
-#         </doc>
-#     </group>
-#     <group type="NXamplifier">
-#         <doc>
-#             Description of the amplifier (after detection of the signal from the noise)
 #         </doc>
 #     </group>
 #     <field name="bias_divider">

--- a/contributed_definitions/nyaml/NXpiezoelectric_material.yaml
+++ b/contributed_definitions/nyaml/NXpiezoelectric_material.yaml
@@ -4,7 +4,7 @@ doc: |
   The piezoelectric actuator is usually composed of polycrystalline solids and
   attached at the head of the tip or cantilever. The material deforms when the external electric field is applied.
 type: group
-NXpiezoelectric_material(NXobject):
+NXpiezoelectric_material(NXcomponent):
   
   # Online links:
   # 1. ttps://www.ulprospector.com/knowledge/2689/pe-piezoelectric-materials/#:~:text=piezoelectric ceramics, such as lithium,as polyvinylidene fluoride (PVDF).
@@ -82,7 +82,7 @@ NXpiezoelectric_material(NXobject):
       viscous state.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 3c006a01f003b1b56a0f0de361f20a9fd21b9a234352fd024f89bce7564728b2
+# 58dd09294e7570de992386b4533dde3d5f2ffe498a0b52d8eb30d55018fa4371
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -106,7 +106,7 @@ NXpiezoelectric_material(NXobject):
 # #
 # # For further information, see http://www.nexusformat.org
 # -->
-# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXpiezoelectric_material" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXpiezoelectric_material" extends="NXcomponent" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
 #     <doc>
 #         Description and properties of the piezoelectric actuator materials.
 #         The piezoelectric actuator is usually composed of polycrystalline solids and

--- a/contributed_definitions/nyaml/NXscan_control.yaml
+++ b/contributed_definitions/nyaml/NXscan_control.yaml
@@ -96,7 +96,7 @@ NXscan_control(NXobject):
         Note: The scan_offset and scan_range are equivalent to the scan_start and scan_end.
         
         For N-dimensional, it is a list of N numbers.
-  mesh_SCAN(NXobject):
+  cantilever_oscillator(NXcomponent):
     nameType: partial
     doc: |
       For each dimension a range and a direction are chosen. When a scan along a dimension is done,
@@ -501,7 +501,7 @@ NXscan_control(NXobject):
         duplicate this NXdata group for each.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 491b37f072af78bb287d8af2c9b2e97ad1cf116f6ebcda56c760e0de0f9bff44
+# f6958ca782f4645ee7995d4d8dcdf17f86d337accf1644807a069dac0204d7c3
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -640,7 +640,7 @@ NXscan_control(NXobject):
 #             </doc>
 #         </field>
 #     </group>
-#     <group name="mesh_SCAN" type="NXobject" nameType="partial">
+#     <group name="cantilever_oscillator" type="NXcomponent" nameType="partial">
 #         <doc>
 #             For each dimension a range and a direction are chosen. When a scan along a dimension is done,
 #             a single step in the next dimension is taken, and then the scan in the previous dimension is

--- a/contributed_definitions/nyaml/NXscan_control.yaml
+++ b/contributed_definitions/nyaml/NXscan_control.yaml
@@ -96,7 +96,7 @@ NXscan_control(NXobject):
         Note: The scan_offset and scan_range are equivalent to the scan_start and scan_end.
         
         For N-dimensional, it is a list of N numbers.
-  cantilever_oscillator(NXcomponent):
+  mesh_SCAN(NXobject):
     nameType: partial
     doc: |
       For each dimension a range and a direction are chosen. When a scan along a dimension is done,

--- a/contributed_definitions/nyaml/NXspm.yaml
+++ b/contributed_definitions/nyaml/NXspm.yaml
@@ -117,17 +117,23 @@ NXspm(NXsensor_scan):
           exists: optional
           doc: |
             This is a link to the current_sensor under the instrument group:
-            entry/experiment_instrument/current_sensor.
+            ENTRY[entry]/experiment_instrument/current_sensor.
+            
+            Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the `exact` name of the NXentry group.
         voltage_sensor(NXsensor):
           exists: optional
           doc: |
             This is a link to the voltage_sensor under the instrument group:
-            entry/experiment_instrument/voltage_sensor.
+            ENTRY[entry]/experiment_instrument/voltage_sensor.
+            
+            Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the `exact` name of the NXentry group.
         piezo_sensor(NXsensor):
           exists: optional
           doc: |
             This is a link to the piezo_sensor under the instrument group:
-            entry/experiment_instrument/piezo_sensor.
+            ENTRY[entry]/experiment_instrument/piezo_sensor.
+            
+            Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the `exact` name of the NXentry group.
         (NXscan_control):
           doc: |
             The scan control information like scan region or phase space, type of scan (e.g.
@@ -347,18 +353,18 @@ NXspm(NXsensor_scan):
         sample_bias_voltage(NXsensor):
           doc: |
             Link to the sample_bias_voltage sensor under the instrument.
-    reproducibility_indicators(NXobject):
+    reproducibility_indicators(NXcollection):
       doc: |
         The group of indicators (links to the existing fields in different groups) that measure
         the reproducibility of the experiment.
-    resolution_indicators(NXobject):
+    resolution_indicators(NXcollection):
       exists: optional
       doc: |
         The group of indicators (links to the existing fields in different groups) that
         are used to measure the resolution of the experiment results.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# c74499951f12d14fd6da3574cdb1494acfd9e81d73fea3aeddf4e0473db584e2
+# a4b0aa177a1d76c064f71a68f5995835af69178c72be88b8224130addd4cebf2
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -539,19 +545,25 @@ NXspm(NXsensor_scan):
 #                 <group name="current_sensor" type="NXsensor" optional="true">
 #                     <doc>
 #                         This is a link to the current_sensor under the instrument group:
-#                         entry/experiment_instrument/current_sensor.
+#                         ENTRY[entry]/experiment_instrument/current_sensor.
+#                         
+#                         Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the `exact` name of the NXentry group.
 #                     </doc>
 #                 </group>
 #                 <group name="voltage_sensor" type="NXsensor" optional="true">
 #                     <doc>
 #                         This is a link to the voltage_sensor under the instrument group:
-#                         entry/experiment_instrument/voltage_sensor.
+#                         ENTRY[entry]/experiment_instrument/voltage_sensor.
+#                         
+#                         Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the `exact` name of the NXentry group.
 #                     </doc>
 #                 </group>
 #                 <group name="piezo_sensor" type="NXsensor" optional="true">
 #                     <doc>
 #                         This is a link to the piezo_sensor under the instrument group:
-#                         entry/experiment_instrument/piezo_sensor.
+#                         ENTRY[entry]/experiment_instrument/piezo_sensor.
+#                         
+#                         Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the `exact` name of the NXentry group.
 #                     </doc>
 #                 </group>
 #                 <group type="NXscan_control">
@@ -828,13 +840,13 @@ NXspm(NXsensor_scan):
 #                 </group>
 #             </group>
 #         </group>
-#         <group name="reproducibility_indicators" type="NXobject">
+#         <group name="reproducibility_indicators" type="NXcollection">
 #             <doc>
 #                 The group of indicators (links to the existing fields in different groups) that measure
 #                 the reproducibility of the experiment.
 #             </doc>
 #         </group>
-#         <group name="resolution_indicators" type="NXobject" optional="true">
+#         <group name="resolution_indicators" type="NXcollection" optional="true">
 #             <doc>
 #                 The group of indicators (links to the existing fields in different groups) that
 #                 are used to measure the resolution of the experiment results.

--- a/contributed_definitions/nyaml/NXspm.yaml
+++ b/contributed_definitions/nyaml/NXspm.yaml
@@ -145,16 +145,64 @@ NXspm(NXsensor_scan):
         exists: optional
         doc: |
           Information for current sensor.
+        current(NX_NUMBER):
+          unit: NX_CURRENT
+          doc: |
+            The dc current between tip and sample.
+        current_offset(NX_NUMBER):
+          exists: optional
+          unit: NX_CURRENT
+          doc: |
+            The offset in the tunneling current between tip and sample.
+        current_calibration(NXcalibration):
+          exists: optional
+          doc: |
+            Calibration data of the current sensor.
+          coefficients(NX_NUMBER):
+            exists: optional
+            unit: NX_ANY
+            doc: |
+              The coefficients of the calibration.
         (NXamplifier):
           exists: optional
           doc: |
             An amplifier information for the input signal (e.g. from tip).
+          current_gain(NX_NUMBER):
+            unit: NX_UNITLESS
+            exists: optional
+            doc: |
+              The gain of the current sensor.
       voltage_sensor(NXsensor):
         exists: optional
         doc: |
           The sensor information for the voltage device.
+        voltage(NX_NUMBER):
+          unit: NX_VOLTAGE
+          doc: |
+            The dc voltage between tip and sample.
+        voltage_offset(NX_NUMBER):
+          exists: optional
+          unit: NX_VOLTAGE
+          doc: |
+            The offset in the tunneling voltage between tip and sample.
+        voltage_calibration(NXcalibration):
+          exists: optional
+          doc: |
+            Calibration data of the voltage sensor.
+          coefficients(NX_NUMBER):
+            exists: optional
+            unit: NX_ANY
+            doc: |
+              The coefficients of the calibration.
         (NXamplifier):
           exists: optional
+          doc: |
+            An amplifier information for the input signal (e.g. from tip).
+          voltage_gain(NX_NUMBER):
+            unit: NX_UNITLESS
+            exists: optional
+            doc: |
+              The gain of the voltage sensor.
       piezo_sensor(NXsensor):
         doc: |
           The piezo sensor refers to the height (or Z) piezo sensor if nothing is
@@ -200,6 +248,35 @@ NXspm(NXsensor_scan):
           exists: optional
           doc: |
             The material description and properties of the piezoelectric scanner materials.
+      TEMPERATURE(NXsensor):
+        nameType: any
+        exists: optional
+        doc: |
+          A group handling the temperature such as cryo, shield and tip. For different
+          type of temperature sensors repeat this group.
+        temperature(NX_NUMBER):
+          exists: optional
+          unit: NX_TEMPERATURE
+          doc: |
+            The temperature of the sample.
+        CHANNEL_temp(NX_CHAR):
+          nameType: partial
+          exists: optional
+          doc: |
+            The name of the channel to measure the temperature.
+        temperature_calibration(NXcalibration):
+          exists: optional
+          doc: |
+            Calibration of the temperature measurement.
+          coefficients(NX_NUMBER):
+            unit: NX_ANY
+            doc: |
+              The coefficients of the calibration.
+        TEMPERATURE_DATA(NXdata):
+          nameType: any
+          exists: optional
+          doc: |
+            Data (e.g, record from SPM head temperature) from temperature sensor.
       bias_spectroscopy_environment(NXenvironment):
         doc: |
           To explain bias (sweep measurement) voltage applied to the sample.
@@ -279,35 +356,6 @@ NXspm(NXsensor_scan):
                 doc: |
                   The reset_bias is used to reset the bias voltage to the starting value after a
                   sweep is completed.
-      TEMPERATURE(NXsensor):
-        nameType: any
-        exists: optional
-        doc: |
-          A group handling the temperature such as cryo, shield and tip. For different
-          type of temperature sensors repeat this group.
-        temperature(NX_NUMBER):
-          exists: optional
-          unit: NX_TEMPERATURE
-          doc: |
-            The temperature of the sample.
-        CHANNEL_temp(NX_CHAR):
-          nameType: partial
-          exists: optional
-          doc: |
-            The name of the channel to measure the temperature.
-        temperature_calibration(NXcalibration):
-          exists: optional
-          doc: |
-            Calibration of the temperature measurement.
-          coefficients(NX_NUMBER):
-            unit: NX_ANY
-            doc: |
-              The coefficients of the calibration.
-        TEMPERATURE_DATA(NXdata):
-          nameType: any
-          exists: optional
-          doc: |
-            Data (e.g, record from SPM head temperature) from temperature sensor.
       sample_bias_votage(NXsensor):
         exists: optional
         doc: |
@@ -355,7 +403,7 @@ NXspm(NXsensor_scan):
         are used to measure the resolution of the experiment results.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 3453ddc435ceeaef9d821d08636a6a982a899820ec2fe9cda10f67625df013c1
+# ffaacda639b8d9f7fb530ef7543e07771c392f0c8844712364785c64b013a3e2
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -571,17 +619,71 @@ NXspm(NXsensor_scan):
 #                 <doc>
 #                     Information for current sensor.
 #                 </doc>
+#                 <field name="current" type="NX_NUMBER" units="NX_CURRENT">
+#                     <doc>
+#                         The dc current between tip and sample.
+#                     </doc>
+#                 </field>
+#                 <field name="current_offset" type="NX_NUMBER" optional="true" units="NX_CURRENT">
+#                     <doc>
+#                         The offset in the tunneling current between tip and sample.
+#                     </doc>
+#                 </field>
+#                 <group name="current_calibration" type="NXcalibration" optional="true">
+#                     <doc>
+#                         Calibration data of the current sensor.
+#                     </doc>
+#                     <field name="coefficients" type="NX_NUMBER" optional="true" units="NX_ANY">
+#                         <doc>
+#                             The coefficients of the calibration.
+#                         </doc>
+#                     </field>
+#                 </group>
 #                 <group type="NXamplifier" optional="true">
 #                     <doc>
 #                         An amplifier information for the input signal (e.g. from tip).
 #                     </doc>
+#                     <field name="current_gain" type="NX_NUMBER" units="NX_UNITLESS" optional="true">
+#                         <doc>
+#                             The gain of the current sensor.
+#                         </doc>
+#                     </field>
 #                 </group>
 #             </group>
 #             <group name="voltage_sensor" type="NXsensor" optional="true">
 #                 <doc>
 #                     The sensor information for the voltage device.
 #                 </doc>
-#                 <group type="NXamplifier" optional="true"/>
+#                 <field name="voltage" type="NX_NUMBER" units="NX_VOLTAGE">
+#                     <doc>
+#                         The dc voltage between tip and sample.
+#                     </doc>
+#                 </field>
+#                 <field name="voltage_offset" type="NX_NUMBER" optional="true" units="NX_VOLTAGE">
+#                     <doc>
+#                         The offset in the tunneling voltage between tip and sample.
+#                     </doc>
+#                 </field>
+#                 <group name="voltage_calibration" type="NXcalibration" optional="true">
+#                     <doc>
+#                         Calibration data of the voltage sensor.
+#                     </doc>
+#                     <field name="coefficients" type="NX_NUMBER" optional="true" units="NX_ANY">
+#                         <doc>
+#                             The coefficients of the calibration.
+#                         </doc>
+#                     </field>
+#                 </group>
+#                 <group type="NXamplifier" optional="true">
+#                     <doc>
+#                         An amplifier information for the input signal (e.g. from tip).
+#                     </doc>
+#                     <field name="voltage_gain" type="NX_NUMBER" units="NX_UNITLESS" optional="true">
+#                         <doc>
+#                             The gain of the voltage sensor.
+#                         </doc>
+#                     </field>
+#                 </group>
 #             </group>
 #             <group name="piezo_sensor" type="NXsensor">
 #                 <doc>
@@ -641,6 +743,37 @@ NXspm(NXsensor_scan):
 #                 <group name="piezo_material" type="NXpiezoelectric_material" optional="true">
 #                     <doc>
 #                         The material description and properties of the piezoelectric scanner materials.
+#                     </doc>
+#                 </group>
+#             </group>
+#             <group name="TEMPERATURE" type="NXsensor" nameType="any" optional="true">
+#                 <doc>
+#                     A group handling the temperature such as cryo, shield and tip. For different
+#                     type of temperature sensors repeat this group.
+#                 </doc>
+#                 <field name="temperature" type="NX_NUMBER" optional="true" units="NX_TEMPERATURE">
+#                     <doc>
+#                         The temperature of the sample.
+#                     </doc>
+#                 </field>
+#                 <field name="CHANNEL_temp" type="NX_CHAR" nameType="partial" optional="true">
+#                     <doc>
+#                         The name of the channel to measure the temperature.
+#                     </doc>
+#                 </field>
+#                 <group name="temperature_calibration" type="NXcalibration" optional="true">
+#                     <doc>
+#                         Calibration of the temperature measurement.
+#                     </doc>
+#                     <field name="coefficients" type="NX_NUMBER" units="NX_ANY">
+#                         <doc>
+#                             The coefficients of the calibration.
+#                         </doc>
+#                     </field>
+#                 </group>
+#                 <group name="TEMPERATURE_DATA" type="NXdata" nameType="any" optional="true">
+#                     <doc>
+#                         Data (e.g, record from SPM head temperature) from temperature sensor.
 #                     </doc>
 #                 </group>
 #             </group>
@@ -741,37 +874,6 @@ NXspm(NXsensor_scan):
 #                             </field>
 #                         </group>
 #                     </group>
-#                 </group>
-#             </group>
-#             <group name="TEMPERATURE" type="NXsensor" nameType="any" optional="true">
-#                 <doc>
-#                     A group handling the temperature such as cryo, shield and tip. For different
-#                     type of temperature sensors repeat this group.
-#                 </doc>
-#                 <field name="temperature" type="NX_NUMBER" optional="true" units="NX_TEMPERATURE">
-#                     <doc>
-#                         The temperature of the sample.
-#                     </doc>
-#                 </field>
-#                 <field name="CHANNEL_temp" type="NX_CHAR" nameType="partial" optional="true">
-#                     <doc>
-#                         The name of the channel to measure the temperature.
-#                     </doc>
-#                 </field>
-#                 <group name="temperature_calibration" type="NXcalibration" optional="true">
-#                     <doc>
-#                         Calibration of the temperature measurement.
-#                     </doc>
-#                     <field name="coefficients" type="NX_NUMBER" units="NX_ANY">
-#                         <doc>
-#                             The coefficients of the calibration.
-#                         </doc>
-#                     </field>
-#                 </group>
-#                 <group name="TEMPERATURE_DATA" type="NXdata" nameType="any" optional="true">
-#                     <doc>
-#                         Data (e.g, record from SPM head temperature) from temperature sensor.
-#                     </doc>
 #                 </group>
 #             </group>
 #             <group name="sample_bias_votage" type="NXsensor" optional="true">

--- a/contributed_definitions/nyaml/NXspm.yaml
+++ b/contributed_definitions/nyaml/NXspm.yaml
@@ -24,7 +24,7 @@ NXspm(NXsensor_scan):
         in AFM, the scan mode could be contact mode, tapping mode or non-contact mode.
       enumeration:
         open_enum: true
-        items: [constant height, constant current, contact mode, tapping mode, non-contact mode, Kelvin probe, electric force]
+        items: [constant height, constant current, contact mode, tapping mode, non-contact mode, Kelvin probe, electric force, lateral force mode]
     scan_type:
       exists: optional
       doc: |
@@ -148,7 +148,7 @@ NXspm(NXsensor_scan):
         current(NX_NUMBER):
           unit: NX_CURRENT
           doc: |
-            The dc current between tip and sample.
+            The DC current between tip and sample.
         current_offset(NX_NUMBER):
           exists: optional
           unit: NX_CURRENT
@@ -179,7 +179,7 @@ NXspm(NXsensor_scan):
         voltage(NX_NUMBER):
           unit: NX_VOLTAGE
           doc: |
-            The dc voltage between tip and sample.
+            The DC voltage between tip and sample.
         voltage_offset(NX_NUMBER):
           exists: optional
           unit: NX_VOLTAGE
@@ -403,7 +403,7 @@ NXspm(NXsensor_scan):
         are used to measure the resolution of the experiment results.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# ffaacda639b8d9f7fb530ef7543e07771c392f0c8844712364785c64b013a3e2
+# 1c6bf26009c2102ada1e1c4b845d052d8f1f4e4a38cb9b668a8cb12a70fb1c37
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -468,6 +468,7 @@ NXspm(NXsensor_scan):
 #                 <item value="non-contact mode"/>
 #                 <item value="Kelvin probe"/>
 #                 <item value="electric force"/>
+#                 <item value="lateral force mode"/>
 #             </enumeration>
 #         </field>
 #         <field name="scan_type" optional="true">
@@ -621,7 +622,7 @@ NXspm(NXsensor_scan):
 #                 </doc>
 #                 <field name="current" type="NX_NUMBER" units="NX_CURRENT">
 #                     <doc>
-#                         The dc current between tip and sample.
+#                         The DC current between tip and sample.
 #                     </doc>
 #                 </field>
 #                 <field name="current_offset" type="NX_NUMBER" optional="true" units="NX_CURRENT">
@@ -656,7 +657,7 @@ NXspm(NXsensor_scan):
 #                 </doc>
 #                 <field name="voltage" type="NX_NUMBER" units="NX_VOLTAGE">
 #                     <doc>
-#                         The dc voltage between tip and sample.
+#                         The DC voltage between tip and sample.
 #                     </doc>
 #                 </field>
 #                 <field name="voltage_offset" type="NX_NUMBER" optional="true" units="NX_VOLTAGE">

--- a/contributed_definitions/nyaml/NXspm.yaml
+++ b/contributed_definitions/nyaml/NXspm.yaml
@@ -272,11 +272,6 @@ NXspm(NXsensor_scan):
               The bais voltage sweep is a common technique used on the substance or sample or environment
               to study the change in the behavior of the sample or substance or environment due to change
               in applied  bias voltage.
-            settling_time(NX_NUMBER):
-              unit: NX_TIME
-              doc: |
-                The time is taken to settle the bias voltage at the desired value. On each sweep usually, the system
-                takes time to settle the bias voltage at the next value.
             scan_region(NXobject):
               doc: |
                 The scan region (phase space or sub-phase space) is the region where the scan is
@@ -364,7 +359,7 @@ NXspm(NXsensor_scan):
         are used to measure the resolution of the experiment results.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# a4b0aa177a1d76c064f71a68f5995835af69178c72be88b8224130addd4cebf2
+# 5606a3a4070587e38b1c5ab3de23155be8460dddcee919ca9fb67ad064c30162
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -735,12 +730,6 @@ NXspm(NXsensor_scan):
 #                             to study the change in the behavior of the sample or substance or environment due to change
 #                             in applied  bias voltage.
 #                         </doc>
-#                         <field name="settling_time" type="NX_NUMBER" units="NX_TIME">
-#                             <doc>
-#                                 The time is taken to settle the bias voltage at the desired value. On each sweep usually, the system
-#                                 takes time to settle the bias voltage at the next value.
-#                             </doc>
-#                         </field>
 #                         <group name="scan_region" type="NXobject">
 #                             <doc>
 #                                 The scan region (phase space or sub-phase space) is the region where the scan is

--- a/contributed_definitions/nyaml/NXspm.yaml
+++ b/contributed_definitions/nyaml/NXspm.yaml
@@ -22,6 +22,9 @@ NXspm(NXsensor_scan):
         The mode of the scan. The possible options depend on the type of experiment.
         For example, in STM, the scan mode could be constant height or constant current,
         in AFM, the scan mode could be contact mode, tapping mode or non-contact mode.
+      enumeration:
+        open_enum: true
+        items: [constant height, constant current, contact mode, tapping mode, non-contact mode, Kelvin probe, electric force]
     scan_type:
       exists: optional
       doc: |
@@ -355,7 +358,7 @@ NXspm(NXsensor_scan):
         are used to measure the resolution of the experiment results.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# b77e4035e2b6857170f2602796d13724f9d71f4d7f7dbf2ec204b80489ff4d51
+# c74499951f12d14fd6da3574cdb1494acfd9e81d73fea3aeddf4e0473db584e2
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -412,6 +415,15 @@ NXspm(NXsensor_scan):
 #                 For example, in STM, the scan mode could be constant height or constant current,
 #                 in AFM, the scan mode could be contact mode, tapping mode or non-contact mode.
 #             </doc>
+#             <enumeration open="true">
+#                 <item value="constant height"/>
+#                 <item value="constant current"/>
+#                 <item value="contact mode"/>
+#                 <item value="tapping mode"/>
+#                 <item value="non-contact mode"/>
+#                 <item value="Kelvin probe"/>
+#                 <item value="electric force"/>
+#             </enumeration>
 #         </field>
 #         <field name="scan_type" optional="true">
 #             <doc>

--- a/contributed_definitions/nyaml/NXspm.yaml
+++ b/contributed_definitions/nyaml/NXspm.yaml
@@ -30,14 +30,10 @@ NXspm(NXsensor_scan):
       doc: |
         The type of the scan. It mainly describes how scan probe moves in the scan region, e.g.
         forward, backward, or both (if scan is repeated).
-    experiment_identifier:
+    identifier_experiment:
       exists: optional
       doc: |
         The identifiers for the experiment which should be unique at least in lab.
-    experiment_description:
-      exists: optional
-      doc: |
-        The description of the experiment like comments, ontes from from the experiment.
     experiment_instrument(NXinstrument):
       doc: |
         The instrument information.
@@ -204,35 +200,6 @@ NXspm(NXsensor_scan):
           exists: optional
           doc: |
             The material description and properties of the piezoelectric scanner materials.
-      TEMPERATURE(NXsensor):
-        nameType: any
-        exists: optional
-        doc: |
-          A group handling the temperature such as cryo, shield and tip. For different
-          type of temperature sensors repeat this group.
-        temperature(NX_NUMBER):
-          exists: optional
-          unit: NX_TEMPERATURE
-          doc: |
-            The temperature of the sample.
-        CHANNEL_temp(NX_CHAR):
-          nameType: partial
-          exists: optional
-          doc: |
-            The name of the channel to measure the temperature.
-        temperature_calibration(NXcalibration):
-          exists: optional
-          doc: |
-            Calibration of the temperature measurement.
-          coefficients(NX_NUMBER):
-            unit: NX_ANY
-            doc: |
-              The coefficients of the calibration.
-        TEMPERATURE_DATA(NXdata):
-          nameType: any
-          exists: optional
-          doc: |
-            Data (e.g, record from SPM head temperature) from temperature sensor.
       bias_spectroscopy_environment(NXenvironment):
         doc: |
           To explain bias (sweep measurement) voltage applied to the sample.
@@ -312,6 +279,35 @@ NXspm(NXsensor_scan):
                 doc: |
                   The reset_bias is used to reset the bias voltage to the starting value after a
                   sweep is completed.
+      TEMPERATURE(NXsensor):
+        nameType: any
+        exists: optional
+        doc: |
+          A group handling the temperature such as cryo, shield and tip. For different
+          type of temperature sensors repeat this group.
+        temperature(NX_NUMBER):
+          exists: optional
+          unit: NX_TEMPERATURE
+          doc: |
+            The temperature of the sample.
+        CHANNEL_temp(NX_CHAR):
+          nameType: partial
+          exists: optional
+          doc: |
+            The name of the channel to measure the temperature.
+        temperature_calibration(NXcalibration):
+          exists: optional
+          doc: |
+            Calibration of the temperature measurement.
+          coefficients(NX_NUMBER):
+            unit: NX_ANY
+            doc: |
+              The coefficients of the calibration.
+        TEMPERATURE_DATA(NXdata):
+          nameType: any
+          exists: optional
+          doc: |
+            Data (e.g, record from SPM head temperature) from temperature sensor.
       sample_bias_votage(NXsensor):
         exists: optional
         doc: |
@@ -359,7 +355,7 @@ NXspm(NXsensor_scan):
         are used to measure the resolution of the experiment results.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 5606a3a4070587e38b1c5ab3de23155be8460dddcee919ca9fb67ad064c30162
+# 3453ddc435ceeaef9d821d08636a6a982a899820ec2fe9cda10f67625df013c1
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -432,14 +428,9 @@ NXspm(NXsensor_scan):
 #                 forward, backward, or both (if scan is repeated).
 #             </doc>
 #         </field>
-#         <field name="experiment_identifier" optional="true">
+#         <field name="identifier_experiment" optional="true">
 #             <doc>
 #                 The identifiers for the experiment which should be unique at least in lab.
-#             </doc>
-#         </field>
-#         <field name="experiment_description" optional="true">
-#             <doc>
-#                 The description of the experiment like comments, ontes from from the experiment.
 #             </doc>
 #         </field>
 #         <group name="experiment_instrument" type="NXinstrument">
@@ -653,37 +644,6 @@ NXspm(NXsensor_scan):
 #                     </doc>
 #                 </group>
 #             </group>
-#             <group name="TEMPERATURE" type="NXsensor" nameType="any" optional="true">
-#                 <doc>
-#                     A group handling the temperature such as cryo, shield and tip. For different
-#                     type of temperature sensors repeat this group.
-#                 </doc>
-#                 <field name="temperature" type="NX_NUMBER" optional="true" units="NX_TEMPERATURE">
-#                     <doc>
-#                         The temperature of the sample.
-#                     </doc>
-#                 </field>
-#                 <field name="CHANNEL_temp" type="NX_CHAR" nameType="partial" optional="true">
-#                     <doc>
-#                         The name of the channel to measure the temperature.
-#                     </doc>
-#                 </field>
-#                 <group name="temperature_calibration" type="NXcalibration" optional="true">
-#                     <doc>
-#                         Calibration of the temperature measurement.
-#                     </doc>
-#                     <field name="coefficients" type="NX_NUMBER" units="NX_ANY">
-#                         <doc>
-#                             The coefficients of the calibration.
-#                         </doc>
-#                     </field>
-#                 </group>
-#                 <group name="TEMPERATURE_DATA" type="NXdata" nameType="any" optional="true">
-#                     <doc>
-#                         Data (e.g, record from SPM head temperature) from temperature sensor.
-#                     </doc>
-#                 </group>
-#             </group>
 #             <group name="bias_spectroscopy_environment" type="NXenvironment">
 #                 <doc>
 #                     To explain bias (sweep measurement) voltage applied to the sample.
@@ -781,6 +741,37 @@ NXspm(NXsensor_scan):
 #                             </field>
 #                         </group>
 #                     </group>
+#                 </group>
+#             </group>
+#             <group name="TEMPERATURE" type="NXsensor" nameType="any" optional="true">
+#                 <doc>
+#                     A group handling the temperature such as cryo, shield and tip. For different
+#                     type of temperature sensors repeat this group.
+#                 </doc>
+#                 <field name="temperature" type="NX_NUMBER" optional="true" units="NX_TEMPERATURE">
+#                     <doc>
+#                         The temperature of the sample.
+#                     </doc>
+#                 </field>
+#                 <field name="CHANNEL_temp" type="NX_CHAR" nameType="partial" optional="true">
+#                     <doc>
+#                         The name of the channel to measure the temperature.
+#                     </doc>
+#                 </field>
+#                 <group name="temperature_calibration" type="NXcalibration" optional="true">
+#                     <doc>
+#                         Calibration of the temperature measurement.
+#                     </doc>
+#                     <field name="coefficients" type="NX_NUMBER" units="NX_ANY">
+#                         <doc>
+#                             The coefficients of the calibration.
+#                         </doc>
+#                     </field>
+#                 </group>
+#                 <group name="TEMPERATURE_DATA" type="NXdata" nameType="any" optional="true">
+#                     <doc>
+#                         Data (e.g, record from SPM head temperature) from temperature sensor.
+#                     </doc>
 #                 </group>
 #             </group>
 #             <group name="sample_bias_votage" type="NXsensor" optional="true">

--- a/contributed_definitions/nyaml/NXstm.yaml
+++ b/contributed_definitions/nyaml/NXstm.yaml
@@ -217,7 +217,7 @@ NXstm(NXspm):
               unit: NX_TIME
               doc: |
                 The switch-off delay of the controller from its stable point.
-    reproducibility_indicators(NXobject):
+    reproducibility_indicators(NXcollection):
       exists: optional
       doc: |
         The group's concepts hold the link to the related concepts that define the
@@ -267,7 +267,7 @@ NXstm(NXspm):
           link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/reference_frequency
           
           Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
-    resolution_indicators(NXobject):
+    resolution_indicators(NXcollection):
       exists: optional
       doc: |
         The group's concepts hold the link to the related concepts that define the
@@ -304,7 +304,7 @@ NXstm(NXspm):
           link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 624404ec77da4dcdb49cb56586a527c6c49ec550887b0d83fc563942cb1e1266
+# 308c0b6b1f277df41c94834cdaa2dafacbd8530c483a368903429ad3ca4f7243
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -597,7 +597,7 @@ NXstm(NXspm):
 #                 </group>
 #             </group>
 #         </group>
-#         <group name="reproducibility_indicators" type="NXobject" optional="true">
+#         <group name="reproducibility_indicators" type="NXcollection" optional="true">
 #             <doc>
 #                 The group's concepts hold the link to the related concepts that define the
 #                 reproducibility of the STM experiment.
@@ -654,7 +654,7 @@ NXstm(NXspm):
 #                 </doc>
 #             </field>
 #         </group>
-#         <group name="resolution_indicators" type="NXobject" optional="true">
+#         <group name="resolution_indicators" type="NXcollection" optional="true">
 #             <doc>
 #                 The group's concepts hold the link to the related concepts that define the
 #                 resolution of the STM experiment.

--- a/contributed_definitions/nyaml/NXstm.yaml
+++ b/contributed_definitions/nyaml/NXstm.yaml
@@ -9,11 +9,11 @@ NXstm(NXspm):
   (NXentry):
     definition:
       doc: |
-        Name of the definition that is used for the application.
+        Name of the definition that is used for an STM technique.
       enumeration: [NXstm]
     scan_mode:
       doc: |
-        The mode of the scan that is performed. Two commonly used ones are constant
+        The mode of the scan that is performed. Two commonly used modes  are constant
         height mode and constant current mode.
       enumeration: [constant height, constant current]
     experiment_instrument(NXinstrument):
@@ -38,29 +38,30 @@ NXstm(NXspm):
         doc: |
           The environment information for stm or sts experiment.
         (NXscan_control):
+          
+          # TODO Check if nyaml works properly
           doc: |
-            The scan control information like scan region or phase space, type of scan
-            (e.g. mesh, spiral, etc.), and scan speed, etc.
+            The scan control information like scan region or phase space, e.g. pattern of scan
+            (e.g. mesh, spiral, etc.), scanner speed, etc.
           scan_type:
             doc: |
-              The type of scan like mesh, spiral, etc. For STS experiment, the scan type is
-              usually a single-point scan (trajectory scan).
+              The type of scan like mesh, spiral, etc.
             enumeration: [mesh, trajectory, snake, spiral]
         tip_temp_sensor(NXsensor):
           exists: optional
           doc: |
             This group stands for the same concept as
-            /ENTRY[entry]/experiment_instrument/tip_temperature
+            /ENTRY[entry]/experiment_instrument/tip_temp_sensor
         cryo_temp_sensor(NXsensor):
           exists: optional
           doc: |
             This group stands for the same concept as
-            /ENTRY[entry]/experiment_instrument/cryo_temperature
+            /ENTRY[entry]/experiment_instrument/cryo_temp_sensor
         cryo_shield_temp_sensor(NXsensor):
           exists: optional
           doc: |
             This group stands for the same concept as
-            /ENTRY[entry]/experiment_instrument/cryo_shield_temperature
+            /ENTRY[entry]/experiment_instrument/cryo_shield_temp_sensor
       tip_temp_sensor(NXsensor):
         exists: optional
         doc: |
@@ -75,7 +76,7 @@ NXstm(NXspm):
           The temperature of the cryo shield.
       current_sensor(NXsensor):
         doc: |
-          The sensor information.
+          The information current sensor for tip-sample current.
         current(NX_NUMBER):
           unit: NX_CURRENT
           doc: |
@@ -112,7 +113,6 @@ NXstm(NXspm):
           doc: |
             Setup and scan data for continuous measurement of bias-voltage on the subject of experiment
             vs tunneling current from probe.
-            Data from from this experiment can also be used to calculate the dI/dV spectra.
       piezo_sensor(NXsensor):
         doc: |
           The sensor information for the piezo device.
@@ -221,7 +221,7 @@ NXstm(NXspm):
       current_offset(NX_NUMBER):
         exists: optional
         doc: |
-          The tunneling current between tip and sample after application of bias voltage.
+          The offset in tunneling current between tip and sample after application of bias voltage.
           link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
       current_gain(NX_NUMBER):
         exists: optional
@@ -232,6 +232,7 @@ NXstm(NXspm):
       bias_sweep(NXobject):
         exists: optional
         doc: |
+          Bias sweep measurement in bias spectroscopy.
           Link to target:
           /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
       modulation_signal_type:
@@ -249,20 +250,20 @@ NXstm(NXspm):
       doc: |
         The group's concepts hold the link to the related concepts that define the
         resolution of the STM experiment.
-      stm_head_temp(NXsensor):
+      stm_head_temp(NX_NUMBER):
         exists: optional
         doc: |
           Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
-      cryo_bottom_temp(NXsensor):
+      cryo_bottom_temp(NX_NUMBER):
         exists: optional
         doc: |
           Link to target:
           /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
-      cryo_shield_temp(NXsensor):
+      cryo_shield_temp(NX_NUMBER):
         exists: optional
         doc: |
           Link to target:
-          /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temperature
+          /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
       bias_sweep(NXobject):
         exists: optional
         doc: |
@@ -281,7 +282,7 @@ NXstm(NXspm):
           link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# c7e6f44a0fb8e385d24877045089e95c5beb9d6fbd8d133ffc4fe10e686a29bb
+# da00f2174466eb9c9371a0a3bab85968795854d9c8ad3817370b767ba74f053e
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -315,7 +316,7 @@ NXstm(NXspm):
 #     <group type="NXentry">
 #         <field name="definition">
 #             <doc>
-#                 Name of the definition that is used for the application.
+#                 Name of the definition that is used for an STM technique.
 #             </doc>
 #             <enumeration>
 #                 <item value="NXstm"/>
@@ -323,7 +324,7 @@ NXstm(NXspm):
 #         </field>
 #         <field name="scan_mode">
 #             <doc>
-#                 The mode of the scan that is performed. Two commonly used ones are constant
+#                 The mode of the scan that is performed. Two commonly used modes  are constant
 #                 height mode and constant current mode.
 #             </doc>
 #             <enumeration>
@@ -358,14 +359,14 @@ NXstm(NXspm):
 #                     The environment information for stm or sts experiment.
 #                 </doc>
 #                 <group type="NXscan_control">
+#                     <!--TODO Check if nyaml works properly-->
 #                     <doc>
-#                         The scan control information like scan region or phase space, type of scan
-#                         (e.g. mesh, spiral, etc.), and scan speed, etc.
+#                         The scan control information like scan region or phase space, e.g. pattern of scan
+#                         (e.g. mesh, spiral, etc.), scanner speed, etc.
 #                     </doc>
 #                     <field name="scan_type">
 #                         <doc>
-#                             The type of scan like mesh, spiral, etc. For STS experiment, the scan type is
-#                             usually a single-point scan (trajectory scan).
+#                             The type of scan like mesh, spiral, etc.
 #                         </doc>
 #                         <enumeration>
 #                             <item value="mesh"/>
@@ -378,19 +379,19 @@ NXstm(NXspm):
 #                 <group name="tip_temp_sensor" type="NXsensor" optional="true">
 #                     <doc>
 #                         This group stands for the same concept as
-#                         /ENTRY[entry]/experiment_instrument/tip_temperature
+#                         /ENTRY[entry]/experiment_instrument/tip_temp_sensor
 #                     </doc>
 #                 </group>
 #                 <group name="cryo_temp_sensor" type="NXsensor" optional="true">
 #                     <doc>
 #                         This group stands for the same concept as
-#                         /ENTRY[entry]/experiment_instrument/cryo_temperature
+#                         /ENTRY[entry]/experiment_instrument/cryo_temp_sensor
 #                     </doc>
 #                 </group>
 #                 <group name="cryo_shield_temp_sensor" type="NXsensor" optional="true">
 #                     <doc>
 #                         This group stands for the same concept as
-#                         /ENTRY[entry]/experiment_instrument/cryo_shield_temperature
+#                         /ENTRY[entry]/experiment_instrument/cryo_shield_temp_sensor
 #                     </doc>
 #                 </group>
 #             </group>
@@ -411,7 +412,7 @@ NXstm(NXspm):
 #             </group>
 #             <group name="current_sensor" type="NXsensor">
 #                 <doc>
-#                     The sensor information.
+#                     The information current sensor for tip-sample current.
 #                 </doc>
 #                 <field name="current" type="NX_NUMBER" units="NX_CURRENT">
 #                     <doc>
@@ -454,7 +455,6 @@ NXstm(NXspm):
 #                     <doc>
 #                         Setup and scan data for continuous measurement of bias-voltage on the subject of experiment
 #                         vs tunneling current from probe.
-#                         Data from from this experiment can also be used to calculate the dI/dV spectra.
 #                     </doc>
 #                 </group>
 #             </group>
@@ -579,7 +579,7 @@ NXstm(NXspm):
 #             </field>
 #             <field name="current_offset" type="NX_NUMBER" optional="true">
 #                 <doc>
-#                     The tunneling current between tip and sample after application of bias voltage.
+#                     The offset in tunneling current between tip and sample after application of bias voltage.
 #                     link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
 #                 </doc>
 #             </field>
@@ -592,6 +592,7 @@ NXstm(NXspm):
 #             </field>
 #             <group name="bias_sweep" type="NXobject" optional="true">
 #                 <doc>
+#                     Bias sweep measurement in bias spectroscopy.
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
 #                 </doc>
@@ -614,23 +615,23 @@ NXstm(NXspm):
 #                 The group's concepts hold the link to the related concepts that define the
 #                 resolution of the STM experiment.
 #             </doc>
-#             <group name="stm_head_temp" type="NXsensor" optional="true">
+#             <field name="stm_head_temp" type="NX_NUMBER" optional="true">
 #                 <doc>
 #                     Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
 #                 </doc>
-#             </group>
-#             <group name="cryo_bottom_temp" type="NXsensor" optional="true">
+#             </field>
+#             <field name="cryo_bottom_temp" type="NX_NUMBER" optional="true">
 #                 <doc>
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
 #                 </doc>
-#             </group>
-#             <group name="cryo_shield_temp" type="NXsensor" optional="true">
+#             </field>
+#             <field name="cryo_shield_temp" type="NX_NUMBER" optional="true">
 #                 <doc>
 #                     Link to target:
-#                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temperature
+#                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
 #                 </doc>
-#             </group>
+#             </field>
 #             <group name="bias_sweep" type="NXobject" optional="true">
 #                 <doc>
 #                     Link to target:

--- a/contributed_definitions/nyaml/NXstm.yaml
+++ b/contributed_definitions/nyaml/NXstm.yaml
@@ -52,16 +52,25 @@ NXstm(NXspm):
           doc: |
             This group stands for the same concept as
             /ENTRY[entry]/experiment_instrument/tip_temp_sensor
+            
+            
+            Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
         cryo_temp_sensor(NXsensor):
           exists: optional
           doc: |
             This group stands for the same concept as
             /ENTRY[entry]/experiment_instrument/cryo_temp_sensor
+            
+            
+            Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
         cryo_shield_temp_sensor(NXsensor):
           exists: optional
           doc: |
             This group stands for the same concept as
             /ENTRY[entry]/experiment_instrument/cryo_shield_temp_sensor
+            
+            
+            Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       tip_temp_sensor(NXsensor):
         exists: optional
         doc: |
@@ -218,33 +227,46 @@ NXstm(NXspm):
         doc: |
           The tunneling current between tip and sample after application of bias voltage.
           link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
+          
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       current_offset(NX_NUMBER):
         exists: optional
         doc: |
           The offset in tunneling current between tip and sample after application of bias voltage.
-          link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
+          link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current_offset
+          
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       current_gain(NX_NUMBER):
         exists: optional
         doc: |
           Proportional relationship between the probe output voltage and the actual
           tunneling current when measuring the tunneling current.
-          link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/amplifier/current_gain
+          link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/AMPLIFIER[amplifier]/current_gain
+          
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       bias_sweep(NXobject):
         exists: optional
         doc: |
           Bias sweep measurement in bias spectroscopy.
           Link to target:
           /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
+          
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       modulation_signal_type:
         exists: optional
         doc: |
           This is the signal on which the modulation voltage or current will be added.
-          link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
-      modulation_frequency(NX_NUMBER):
+          link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal
+          
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
+      reference_frequency(NX_NUMBER):
         exists: optional
         doc: |
-          The frequency of the sine modulation that is used to modulate the signal in lock-in.
-          link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
+          The frequency of the sine modulation that is used as a carrier signal of input signal in lock-in.
+          
+          link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/reference_frequency
+          
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
     resolution_indicators(NXobject):
       exists: optional
       doc: |
@@ -275,14 +297,14 @@ NXstm(NXspm):
           This is the signal on which the modulation voltage or current will be added.
           link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
           modulation_signal_type
-      modulation_frequency(NX_NUMBER):
+      reference_frequency(NX_NUMBER):
         exists: optional
         doc: |
           The frequency of the sine modulation that is used to modulate the signal in lock-in.
           link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# da00f2174466eb9c9371a0a3bab85968795854d9c8ad3817370b767ba74f053e
+# 624404ec77da4dcdb49cb56586a527c6c49ec550887b0d83fc563942cb1e1266
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -380,18 +402,27 @@ NXstm(NXspm):
 #                     <doc>
 #                         This group stands for the same concept as
 #                         /ENTRY[entry]/experiment_instrument/tip_temp_sensor
+#                         
+#                         
+#                         Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                     </doc>
 #                 </group>
 #                 <group name="cryo_temp_sensor" type="NXsensor" optional="true">
 #                     <doc>
 #                         This group stands for the same concept as
 #                         /ENTRY[entry]/experiment_instrument/cryo_temp_sensor
+#                         
+#                         
+#                         Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                     </doc>
 #                 </group>
 #                 <group name="cryo_shield_temp_sensor" type="NXsensor" optional="true">
 #                     <doc>
 #                         This group stands for the same concept as
 #                         /ENTRY[entry]/experiment_instrument/cryo_shield_temp_sensor
+#                         
+#                         
+#                         Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                     </doc>
 #                 </group>
 #             </group>
@@ -575,19 +606,25 @@ NXstm(NXspm):
 #                 <doc>
 #                     The tunneling current between tip and sample after application of bias voltage.
 #                     link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
+#                     
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </field>
 #             <field name="current_offset" type="NX_NUMBER" optional="true">
 #                 <doc>
 #                     The offset in tunneling current between tip and sample after application of bias voltage.
-#                     link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
+#                     link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current_offset
+#                     
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </field>
 #             <field name="current_gain" type="NX_NUMBER" optional="true">
 #                 <doc>
 #                     Proportional relationship between the probe output voltage and the actual
 #                     tunneling current when measuring the tunneling current.
-#                     link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/amplifier/current_gain
+#                     link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/AMPLIFIER[amplifier]/current_gain
+#                     
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </field>
 #             <group name="bias_sweep" type="NXobject" optional="true">
@@ -595,18 +632,25 @@ NXstm(NXspm):
 #                     Bias sweep measurement in bias spectroscopy.
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
+#                     
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </group>
 #             <field name="modulation_signal_type" optional="true">
 #                 <doc>
 #                     This is the signal on which the modulation voltage or current will be added.
-#                     link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
+#                     link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal
+#                     
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </field>
-#             <field name="modulation_frequency" type="NX_NUMBER" optional="true">
+#             <field name="reference_frequency" type="NX_NUMBER" optional="true">
 #                 <doc>
-#                     The frequency of the sine modulation that is used to modulate the signal in lock-in.
-#                     link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
+#                     The frequency of the sine modulation that is used as a carrier signal of input signal in lock-in.
+#                     
+#                     link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/reference_frequency
+#                     
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </field>
 #         </group>
@@ -645,7 +689,7 @@ NXstm(NXspm):
 #                     modulation_signal_type
 #                 </doc>
 #             </field>
-#             <field name="modulation_frequency" type="NX_NUMBER" optional="true">
+#             <field name="reference_frequency" type="NX_NUMBER" optional="true">
 #                 <doc>
 #                     The frequency of the sine modulation that is used to modulate the signal in lock-in.
 #                     link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency

--- a/contributed_definitions/nyaml/NXstm.yaml
+++ b/contributed_definitions/nyaml/NXstm.yaml
@@ -9,7 +9,7 @@ NXstm(NXspm):
   (NXentry):
     definition:
       doc: |
-        Name of the definition that is used for an STM technique.
+        Name of the definition that is used for the STM technique.
       enumeration: [NXstm]
     scan_mode:
       doc: |
@@ -38,8 +38,6 @@ NXstm(NXspm):
         doc: |
           The environment information for stm or sts experiment.
         (NXscan_control):
-          
-          # TODO Check if nyaml works properly
           doc: |
             The scan control information like scan region or phase space, e.g. pattern of scan
             (e.g. mesh, spiral, etc.), scanner speed, etc.
@@ -85,7 +83,7 @@ NXstm(NXspm):
           The temperature of the cryo shield.
       current_sensor(NXsensor):
         doc: |
-          The information current sensor for tip-sample current.
+          Current sensor for current between tip and sample.
         current(NX_NUMBER):
           unit: NX_CURRENT
           doc: |
@@ -304,7 +302,7 @@ NXstm(NXspm):
           link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 308c0b6b1f277df41c94834cdaa2dafacbd8530c483a368903429ad3ca4f7243
+# 2408501463015a5df08d90c4c0aa9fa4fec0de7c44625258b671a1a66323ac9b
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -338,7 +336,7 @@ NXstm(NXspm):
 #     <group type="NXentry">
 #         <field name="definition">
 #             <doc>
-#                 Name of the definition that is used for an STM technique.
+#                 Name of the definition that is used for the STM technique.
 #             </doc>
 #             <enumeration>
 #                 <item value="NXstm"/>
@@ -381,7 +379,6 @@ NXstm(NXspm):
 #                     The environment information for stm or sts experiment.
 #                 </doc>
 #                 <group type="NXscan_control">
-#                     <!--TODO Check if nyaml works properly-->
 #                     <doc>
 #                         The scan control information like scan region or phase space, e.g. pattern of scan
 #                         (e.g. mesh, spiral, etc.), scanner speed, etc.
@@ -443,7 +440,7 @@ NXstm(NXspm):
 #             </group>
 #             <group name="current_sensor" type="NXsensor">
 #                 <doc>
-#                     The information current sensor for tip-sample current.
+#                     Current sensor for current between tip and sample.
 #                 </doc>
 #                 <field name="current" type="NX_NUMBER" units="NX_CURRENT">
 #                     <doc>

--- a/contributed_definitions/nyaml/NXsts.yaml
+++ b/contributed_definitions/nyaml/NXsts.yaml
@@ -14,9 +14,87 @@ NXsts(NXspm):
       doc: |
         Name of the definition that is used for the application.
       enumeration: [NXsts]
+    scan_mode:
+      doc: |
+        The mode between the tip and sample of the tunneling spectroscopy experiment.
+      enumeration:
+        open_enum: true
+        items: [constant_height, constant_current, constant_spacing]
+    reproducibility_indicators(NXobject):
+      exists: optional
+      doc: |
+        The group's concepts hold the link to the related concepts that define the
+        reproducibility of the STM experiment.
+      current(NX_NUMBER):
+        exists: optional
+        doc: |
+          The tunneling current between tip and sample after application of bias voltage.
+          link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
+      current_offset(NX_NUMBER):
+        exists: optional
+        doc: |
+          The offset in tunneling current between tip and sample after application of bias voltage.
+          link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
+      current_gain(NX_NUMBER):
+        exists: optional
+        doc: |
+          Proportional relationship between the probe output voltage and the actual
+          tunneling current when measuring the tunneling current.
+          link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/amplifier/current_gain
+      bias_sweep(NXobject):
+        exists: optional
+        doc: |
+          Bias sweep measurement in bias spectroscopy.
+          Link to target:
+          /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
+      modulation_signal_type:
+        exists: optional
+        doc: |
+          This is the signal on which the modulation voltage or current will be added.
+          link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
+      modulation_frequency(NX_NUMBER):
+        exists: optional
+        doc: |
+          The frequency of the sine modulation that is used to modulate the signal in lock-in.
+          link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
+    resolution_indicators(NXobject):
+      exists: optional
+      doc: |
+        The group's concepts hold the link to the related concepts that define the
+        resolution of the STM experiment.
+      tip_temp(NX_NUMBER):
+        exists: optional
+        doc: |
+          Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+      cryo_bottom_temp(NX_NUMBER):
+        exists: optional
+        doc: |
+          Link to target:
+          /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
+      cryo_shield_temp(NX_NUMBER):
+        exists: optional
+        doc: |
+          Link to target:
+          /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
+      bias_sweep(NXobject):
+        exists: optional
+        doc: |
+          Link to target:
+          /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
+      modulation_signal_type:
+        exists: optional
+        doc: |
+          This is the signal on which the modulation voltage or current will be added.
+          link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
+          modulation_signal_type
+      modulation_frequency(NX_NUMBER):
+        exists: optional
+        doc: |
+          The frequency of the sine modulation that is used to modulate the signal in
+          lock-in.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 3c249fd275af32b4b2747ed7356a3175a5edca21b88516b1662e38723d33d052
+# 717e59f8af666f4e4217609f3c11f1ec7872dd4cf18fc17272cc6b116a241652
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -45,19 +123,115 @@ NXsts(NXspm):
 # TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and NXafm-->
 # <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXsts" extends="NXspm" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
 #     <doc>
-#          An application definition to describe Scanning Tunneling Spectroscopy (STS).
-#          
-#          The NXsts is duplication of NXspm and is considered as a proxy application definition
-#          for Scanning Tunneling Spectroscopy (STS) technique.
+#         An application definition to describe Scanning Tunneling Spectroscopy (STS).
+#         
+#         The NXsts is duplication of NXspm and is considered as a proxy application definition
+#         for Scanning Tunneling Spectroscopy (STS) technique.
 #     </doc>
 #     <group type="NXentry">
 #         <field name="definition">
 #             <doc>
-#                  Name of the definition that is used for the application.
+#                 Name of the definition that is used for the application.
 #             </doc>
 #             <enumeration>
 #                 <item value="NXsts"/>
 #             </enumeration>
 #         </field>
+#         <field name="scan_mode">
+#             <doc>
+#                 The mode between the tip and sample of the tunneling spectroscopy experiment.
+#             </doc>
+#             <enumeration open="true">
+#                 <item value="constant_height"/>
+#                 <item value="constant_current"/>
+#                 <item value="constant_spacing"/>
+#             </enumeration>
+#         </field>
+#         <group name="reproducibility_indicators" type="NXobject" optional="true">
+#             <doc>
+#                 The group's concepts hold the link to the related concepts that define the
+#                 reproducibility of the STM experiment.
+#             </doc>
+#             <field name="current" type="NX_NUMBER" optional="true">
+#                 <doc>
+#                     The tunneling current between tip and sample after application of bias voltage.
+#                     link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
+#                 </doc>
+#             </field>
+#             <field name="current_offset" type="NX_NUMBER" optional="true">
+#                 <doc>
+#                     The offset in tunneling current between tip and sample after application of bias voltage.
+#                     link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
+#                 </doc>
+#             </field>
+#             <field name="current_gain" type="NX_NUMBER" optional="true">
+#                 <doc>
+#                     Proportional relationship between the probe output voltage and the actual
+#                     tunneling current when measuring the tunneling current.
+#                     link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/amplifier/current_gain
+#                 </doc>
+#             </field>
+#             <group name="bias_sweep" type="NXobject" optional="true">
+#                 <doc>
+#                     Bias sweep measurement in bias spectroscopy.
+#                     Link to target:
+#                     /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
+#                 </doc>
+#             </group>
+#             <field name="modulation_signal_type" optional="true">
+#                 <doc>
+#                     This is the signal on which the modulation voltage or current will be added.
+#                     link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
+#                 </doc>
+#             </field>
+#             <field name="modulation_frequency" type="NX_NUMBER" optional="true">
+#                 <doc>
+#                     The frequency of the sine modulation that is used to modulate the signal in lock-in.
+#                     link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
+#                 </doc>
+#             </field>
+#         </group>
+#         <group name="resolution_indicators" type="NXobject" optional="true">
+#             <doc>
+#                 The group's concepts hold the link to the related concepts that define the
+#                 resolution of the STM experiment.
+#             </doc>
+#             <field name="tip_temp" type="NX_NUMBER" optional="true">
+#                 <doc>
+#                     Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+#                 </doc>
+#             </field>
+#             <field name="cryo_bottom_temp" type="NX_NUMBER" optional="true">
+#                 <doc>
+#                     Link to target:
+#                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
+#                 </doc>
+#             </field>
+#             <field name="cryo_shield_temp" type="NX_NUMBER" optional="true">
+#                 <doc>
+#                     Link to target:
+#                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
+#                 </doc>
+#             </field>
+#             <group name="bias_sweep" type="NXobject" optional="true">
+#                 <doc>
+#                     Link to target:
+#                     /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
+#                 </doc>
+#             </group>
+#             <field name="modulation_signal_type" optional="true">
+#                 <doc>
+#                     This is the signal on which the modulation voltage or current will be added.
+#                     link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
+#                     modulation_signal_type
+#                 </doc>
+#             </field>
+#             <field name="modulation_frequency" type="NX_NUMBER" optional="true">
+#                 <doc>
+#                     The frequency of the sine modulation that is used to modulate the signal in
+#                     lock-in.
+#                 </doc>
+#             </field>
+#         </group>
 #     </group>
 # </definition>

--- a/contributed_definitions/nyaml/NXsts.yaml
+++ b/contributed_definitions/nyaml/NXsts.yaml
@@ -2,8 +2,7 @@ category: application
 doc: |
   An application definition to describe Scanning Tunneling Spectroscopy (STS).
   
-  The NXsts is duplication of NXspm and is considered as a proxy application definition
-  for Scanning Tunneling Spectroscopy (STS) technique.
+  The NXsts application definition extends the NXapm and is dedicated for Scanning Tunneling Spectroscopy (STS) technique.
 
 # https://thesis.library.caltech.edu/1943/4/03chapter3.pdf
 # TODO: Replace rename NXenvironment to experiment_environment in NXstm, NXspm and NXafm
@@ -206,7 +205,7 @@ NXsts(NXspm):
           /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 2ead5e5cb59a6a9d26af025d23461e19a968be1f05e500692dedf80d3f2edb1b
+# 24db05a8cbe1431d49dea02f93295916d0a52f4288a8f2e8f75fd11e0144882e
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -237,8 +236,7 @@ NXsts(NXspm):
 #     <doc>
 #         An application definition to describe Scanning Tunneling Spectroscopy (STS).
 #         
-#         The NXsts is duplication of NXspm and is considered as a proxy application definition
-#         for Scanning Tunneling Spectroscopy (STS) technique.
+#         The NXsts application definition extends the NXapm and is dedicated for Scanning Tunneling Spectroscopy (STS) technique.
 #     </doc>
 #     <group type="NXentry">
 #         <field name="definition">

--- a/contributed_definitions/nyaml/NXsts.yaml
+++ b/contributed_definitions/nyaml/NXsts.yaml
@@ -91,78 +91,65 @@ NXsts(NXspm):
               The gain of the voltage sensor.
       piezo_sensor(NXsensor):
         doc: |
-          The piezo sensor refers to the height (or Z) piezo sensor if nothing is
-          mentioned along the X and Y directions.
-        x(NX_NUMBER):
-          unit: NX_LENGTH
-          doc: |
-            The x position of the piezo. In STS experiment, the piezo stays fixed at
-            x,y and z and the the tunneling current is measured with respect to the
-            bias voltage (sweep voltage).
-        y(NX_NUMBER):
-          unit: NX_LENGTH
-          doc: |
-            The y position of the piezo.
-        z(NX_NUMBER):
-          unit: NX_LENGTH
-          doc: |
-            The z position of the piezo.
+          The sensor information for the piezo device.
         piezo_configuration(NXpiezo_config_spm):
           exists: optional
           doc: |
-            The piezo configuration information like piezoelectric calibration and material
-            properties.
+            The piezo configuration information like piezoelectric device calibration and
+            material properties.
           calibration(NXcalibration):
             exists: optional
             doc: |
               Calibration of the piezo device.
-        (NXpositioner_spm):
-          doc: |
-            The positioner information like the position of the tip, the position of the
-            sample, PID loop feedback etc.
-          z_controller(NXpid_controller):
-            doc: |
-              The PID controller information for the z-axis.
-            z(NX_NUMBER):
+            second_order_correction_N(NX_NUMBER):
+              nameType: partial
+              exists: optional
+              unit: NX_ANY
               doc: |
-                To indicate the relative tip position z between tip and sample. The tip position
-                can also be varied when the z_controller is not running.
-            controller_status(NX_BOOLEAN):
+                The N (substring) denotes X and Y directions. The 2nd order piezo
+                compensate the error for that axis. The following equation shows the
+                interpretation of the 2nd order correction parameters,
+                For the X-piezo: "Ux = 1/cx · X + cxx · X2"
+                with units: "[V] = [V/m] · [m] + [V/m2] · [m2]"
+                where cx is the calibration of the piezo X and cxx is the 2nd order
+                correction. The unit for such the second-order correction is (V/m^2).
+            calibration_type(NX_CHAR):
+              exists: optional
               doc: |
-                Status if controller is active.
-        piezo_material(NXpiezoelectric_material):
-          exists: optional
-          doc: |
-            The material description and properties of the piezoelectric scanner materials.
-      TEMPERATURE(NXsensor):
-        nameType: any
-        exists: optional
-        doc: |
-          A group handling the temperature such as cryo, shield and tip. For different
-          type of temperature sensors repeat this group.
-        temperature(NX_NUMBER):
-          exists: optional
-          unit: NX_TEMPERATURE
-          doc: |
-            The temperature of the sample.
-        CHANNEL_temp(NX_CHAR):
-          nameType: partial
-          exists: optional
-          doc: |
-            The name of the channel to measure the temperature.
-        temperature_calibration(NXcalibration):
-          exists: optional
-          doc: |
-            Calibration of the temperature measurement.
-          coefficients(NX_NUMBER):
-            unit: NX_ANY
-            doc: |
-              The coefficients of the calibration.
-        TEMPERATURE_DATA(NXdata):
-          nameType: any
-          exists: optional
-          doc: |
-            Data (e.g, record from SPM head temperature) from temperature sensor.
+                The name of the calibration type, sometimes it is called
+                e.g active calibration, passive calibration.
+            calibration_coefficient_N(NX_NUMBER):
+              nameType: partial
+              exists: optional
+              unit: NX_ANY
+              doc: |
+                The calibration coefficient is the ratio of the actual distance moved by the piezo to
+                the voltage applied to the piezo. It is also called first-order correction.
+            drift_N(NX_NUMBER):
+              nameType: partial
+              exists: optional
+              unit: NX_ANY
+              doc: |
+                Set up the settings to enable or disable the drift compensation.
+            drift_correction_status(NX_BOOLEAN):
+              exists: optional
+              doc: |
+                Whether the drift has been corrected in case there is a deviation in the
+                drift.
+            tilt_N(NX_NUMBER):
+              nameType: partial
+              exists: optional
+              unit: NX_ANGLE
+              doc: |
+                The N (substring) denotes X and Y directions, and for both directions
+                tilt needs to be adjusted according to the actual surface.
+            hv_gain_N(NX_NUMBER):
+              nameType: partial
+              doc: |
+                The N (substring) denotes X or Y or Z. In some systems,
+                there is an HV gain readout feature. For these systems,
+                the HV gain should be automatically adjusted whenever
+                the gain is changed at the high voltage amplifier.
       bias_spectroscopy_environment(NXenvironment):
         doc: |
           To explain bias (sweep measurement) voltage applied to the sample.
@@ -170,100 +157,6 @@ NXsts(NXspm):
           doc: |
             Setup and scan data for continuous measurement of bias-voltage on the subject of experiment
             vs tunneling current from probe.
-          (NXpositioner_spm):
-            exists: optional
-            doc: |
-              The positioner information like the position of the tip, PID loop feedback etc.
-            z_controller(NXpid_controller):
-              exists: optional
-              doc: |
-                The PID controller information for the z-axis.
-              z_average_time(NX_NUMBER):
-                exists: optional
-                unit: NX_TIME
-                doc: |
-                  The average time taken by the z-controller to stabilize the tip.
-              z_controller_time(NX_NUMBER):
-                exists: optional
-                unit: NX_TIME
-                doc: |
-                  The time taken by the z-controller to measure physical properties.
-              z_controller_hold(NX_BOOLEAN):
-                exists: optional
-                doc: |
-                  The status of the controller to be held on the previous position, before going to the
-                  next scan point or line to measure the physical properties.
-              record_final_z(NX_BOOLEAN):
-                exists: optional
-                doc: |
-                  The status of the controller to record the final z position after the scan.
-          bias_sweep(NXbias_sweep):
-            doc: |
-              The bais voltage sweep is a common technique used on the substance or sample or environment
-              to study the change in the behavior of the sample or substance or environment due to change
-              in applied  bias voltage.
-            scan_region(NXobject):
-              doc: |
-                The scan region (phase space or sub-phase space) is the region where the scan is
-                performed.
-              scan_offset_bias(NX_NUMBER):
-                exists: optional
-                unit: NX_VOLTAGE
-                doc: |
-                  The offset of the bias voltage for bias sweep.
-              scan_range_bias(NX_NUMBER):
-                exists: optional
-                unit: NX_VOLTAGE
-                doc: |
-                  The range of the scan is the length of the bias voltage over which the sweep
-                  scan will be performed.
-              scan_start_bias(NX_NUMBER):
-                unit: NX_VOLTAGE
-                doc: |
-                  The start of the bias scan voltage.
-              scan_end_bias(NX_NUMBER):
-                unit: NX_VOLTAGE
-                doc: |
-                  The end of the bias scan voltage.
-            linear_sweep(NXobject):
-              doc: |
-                The linear sweep is a type of scan where the bias voltage is swept
-                linearly from the starting voltage to the ending voltage.
-              scan_points_bias(NX_NUMBER):
-                doc: |
-                  The number of voltage points the sweep scan to be performed.
-              step_size_bias(NX_NUMBER):
-                unit: NX_VOLTAGE
-                doc: |
-                  The step size of the sweep.
-                  The step size is the difference between the two consecutive bias voltage during the sweep.
-              reset_bias(NX_BOOLEAN):
-                exists: optional
-                doc: |
-                  The reset_bias is used to reset the bias voltage to the starting value after a
-                  sweep is completed.
-      sample_bias_votage(NXsensor):
-        exists: optional
-        doc: |
-          The DC bias voltage that is applied to the sample.
-        bias_voltage(NX_NUMBER):
-          unit: NX_VOLTAGE
-          doc: |
-            The bias voltage (DC) applied to the sample.
-        bias_offset(NX_NUMBER):
-          exists: optional
-          unit: NX_VOLTAGE
-          doc: |
-            Offset value of the bias voltage.
-        bias_calibration(NXcalibration):
-          exists: optional
-          doc: |
-            Calibration of the bias voltage measurement (V/V).
-          coefficients(NX_NUMBER):
-            exists: optional
-            unit: NX_ANY
-            doc: |
-              The coefficients of the calibration.
     reproducibility_indicators(NXcollection):
       exists: optional
       doc: |
@@ -367,7 +260,7 @@ NXsts(NXspm):
           /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# c7bec6ff8476e325ca186a85621a6b08e0200f14cba6b0be21cf468ed6c19d8a
+# c05bd78315499801ebbc5d76879bdd9140ad0fe6ee1a8a0acac6f942228c6ee0
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -501,94 +394,66 @@ NXsts(NXspm):
 #             </group>
 #             <group name="piezo_sensor" type="NXsensor">
 #                 <doc>
-#                     The piezo sensor refers to the height (or Z) piezo sensor if nothing is
-#                     mentioned along the X and Y directions.
+#                     The sensor information for the piezo device.
 #                 </doc>
-#                 <field name="x" type="NX_NUMBER" units="NX_LENGTH">
-#                     <doc>
-#                         The x position of the piezo. In STS experiment, the piezo stays fixed at
-#                         x,y and z and the the tunneling current is measured with respect to the
-#                         bias voltage (sweep voltage).
-#                     </doc>
-#                 </field>
-#                 <field name="y" type="NX_NUMBER" units="NX_LENGTH">
-#                     <doc>
-#                         The y position of the piezo.
-#                     </doc>
-#                 </field>
-#                 <field name="z" type="NX_NUMBER" units="NX_LENGTH">
-#                     <doc>
-#                         The z position of the piezo.
-#                     </doc>
-#                 </field>
 #                 <group name="piezo_configuration" type="NXpiezo_config_spm" optional="true">
 #                     <doc>
-#                         The piezo configuration information like piezoelectric calibration and material
-#                         properties.
+#                         The piezo configuration information like piezoelectric device calibration and
+#                         material properties.
 #                     </doc>
 #                     <group name="calibration" type="NXcalibration" optional="true">
 #                         <doc>
 #                             Calibration of the piezo device.
 #                         </doc>
-#                     </group>
-#                 </group>
-#                 <group type="NXpositioner_spm">
-#                     <doc>
-#                         The positioner information like the position of the tip, the position of the
-#                         sample, PID loop feedback etc.
-#                     </doc>
-#                     <group name="z_controller" type="NXpid_controller">
-#                         <doc>
-#                             The PID controller information for the z-axis.
-#                         </doc>
-#                         <field name="z" type="NX_NUMBER">
+#                         <field name="second_order_correction_N" type="NX_NUMBER" nameType="partial" optional="true" units="NX_ANY">
 #                             <doc>
-#                                 To indicate the relative tip position z between tip and sample. The tip position
-#                                 can also be varied when the z_controller is not running.
+#                                 The N (substring) denotes X and Y directions. The 2nd order piezo
+#                                 compensate the error for that axis. The following equation shows the
+#                                 interpretation of the 2nd order correction parameters,
+#                                 For the X-piezo: "Ux = 1/cx · X + cxx · X2"
+#                                 with units: "[V] = [V/m] · [m] + [V/m2] · [m2]"
+#                                 where cx is the calibration of the piezo X and cxx is the 2nd order
+#                                 correction. The unit for such the second-order correction is (V/m^2).
 #                             </doc>
 #                         </field>
-#                         <field name="controller_status" type="NX_BOOLEAN">
+#                         <field name="calibration_type" type="NX_CHAR" optional="true">
 #                             <doc>
-#                                 Status if controller is active.
+#                                 The name of the calibration type, sometimes it is called
+#                                 e.g active calibration, passive calibration.
+#                             </doc>
+#                         </field>
+#                         <field name="calibration_coefficient_N" type="NX_NUMBER" nameType="partial" optional="true" units="NX_ANY">
+#                             <doc>
+#                                 The calibration coefficient is the ratio of the actual distance moved by the piezo to
+#                                 the voltage applied to the piezo. It is also called first-order correction.
+#                             </doc>
+#                         </field>
+#                         <field name="drift_N" type="NX_NUMBER" nameType="partial" optional="true" units="NX_ANY">
+#                             <doc>
+#                                 Set up the settings to enable or disable the drift compensation.
+#                             </doc>
+#                         </field>
+#                         <field name="drift_correction_status" type="NX_BOOLEAN" optional="true">
+#                             <doc>
+#                                 Whether the drift has been corrected in case there is a deviation in the
+#                                 drift.
+#                             </doc>
+#                         </field>
+#                         <field name="tilt_N" type="NX_NUMBER" nameType="partial" optional="true" units="NX_ANGLE">
+#                             <doc>
+#                                 The N (substring) denotes X and Y directions, and for both directions
+#                                 tilt needs to be adjusted according to the actual surface.
+#                             </doc>
+#                         </field>
+#                         <field name="hv_gain_N" type="NX_NUMBER" nameType="partial">
+#                             <doc>
+#                                 The N (substring) denotes X or Y or Z. In some systems,
+#                                 there is an HV gain readout feature. For these systems,
+#                                 the HV gain should be automatically adjusted whenever
+#                                 the gain is changed at the high voltage amplifier.
 #                             </doc>
 #                         </field>
 #                     </group>
-#                 </group>
-#                 <group name="piezo_material" type="NXpiezoelectric_material" optional="true">
-#                     <doc>
-#                         The material description and properties of the piezoelectric scanner materials.
-#                     </doc>
-#                 </group>
-#             </group>
-#             <group name="TEMPERATURE" type="NXsensor" nameType="any" optional="true">
-#                 <doc>
-#                     A group handling the temperature such as cryo, shield and tip. For different
-#                     type of temperature sensors repeat this group.
-#                 </doc>
-#                 <field name="temperature" type="NX_NUMBER" optional="true" units="NX_TEMPERATURE">
-#                     <doc>
-#                         The temperature of the sample.
-#                     </doc>
-#                 </field>
-#                 <field name="CHANNEL_temp" type="NX_CHAR" nameType="partial" optional="true">
-#                     <doc>
-#                         The name of the channel to measure the temperature.
-#                     </doc>
-#                 </field>
-#                 <group name="temperature_calibration" type="NXcalibration" optional="true">
-#                     <doc>
-#                         Calibration of the temperature measurement.
-#                     </doc>
-#                     <field name="coefficients" type="NX_NUMBER" units="NX_ANY">
-#                         <doc>
-#                             The coefficients of the calibration.
-#                         </doc>
-#                     </field>
-#                 </group>
-#                 <group name="TEMPERATURE_DATA" type="NXdata" nameType="any" optional="true">
-#                     <doc>
-#                         Data (e.g, record from SPM head temperature) from temperature sensor.
-#                     </doc>
 #                 </group>
 #             </group>
 #             <group name="bias_spectroscopy_environment" type="NXenvironment">
@@ -600,119 +465,6 @@ NXsts(NXspm):
 #                         Setup and scan data for continuous measurement of bias-voltage on the subject of experiment
 #                         vs tunneling current from probe.
 #                     </doc>
-#                     <group type="NXpositioner_spm" optional="true">
-#                         <doc>
-#                             The positioner information like the position of the tip, PID loop feedback etc.
-#                         </doc>
-#                         <group name="z_controller" type="NXpid_controller" optional="true">
-#                             <doc>
-#                                 The PID controller information for the z-axis.
-#                             </doc>
-#                             <field name="z_average_time" type="NX_NUMBER" optional="true" units="NX_TIME">
-#                                 <doc>
-#                                     The average time taken by the z-controller to stabilize the tip.
-#                                 </doc>
-#                             </field>
-#                             <field name="z_controller_time" type="NX_NUMBER" optional="true" units="NX_TIME">
-#                                 <doc>
-#                                     The time taken by the z-controller to measure physical properties.
-#                                 </doc>
-#                             </field>
-#                             <field name="z_controller_hold" type="NX_BOOLEAN" optional="true">
-#                                 <doc>
-#                                     The status of the controller to be held on the previous position, before going to the
-#                                     next scan point or line to measure the physical properties.
-#                                 </doc>
-#                             </field>
-#                             <field name="record_final_z" type="NX_BOOLEAN" optional="true">
-#                                 <doc>
-#                                     The status of the controller to record the final z position after the scan.
-#                                 </doc>
-#                             </field>
-#                         </group>
-#                     </group>
-#                     <group name="bias_sweep" type="NXbias_sweep">
-#                         <doc>
-#                             The bais voltage sweep is a common technique used on the substance or sample or environment
-#                             to study the change in the behavior of the sample or substance or environment due to change
-#                             in applied  bias voltage.
-#                         </doc>
-#                         <group name="scan_region" type="NXobject">
-#                             <doc>
-#                                 The scan region (phase space or sub-phase space) is the region where the scan is
-#                                 performed.
-#                             </doc>
-#                             <field name="scan_offset_bias" type="NX_NUMBER" optional="true" units="NX_VOLTAGE">
-#                                 <doc>
-#                                     The offset of the bias voltage for bias sweep.
-#                                 </doc>
-#                             </field>
-#                             <field name="scan_range_bias" type="NX_NUMBER" optional="true" units="NX_VOLTAGE">
-#                                 <doc>
-#                                     The range of the scan is the length of the bias voltage over which the sweep
-#                                     scan will be performed.
-#                                 </doc>
-#                             </field>
-#                             <field name="scan_start_bias" type="NX_NUMBER" units="NX_VOLTAGE">
-#                                 <doc>
-#                                     The start of the bias scan voltage.
-#                                 </doc>
-#                             </field>
-#                             <field name="scan_end_bias" type="NX_NUMBER" units="NX_VOLTAGE">
-#                                 <doc>
-#                                     The end of the bias scan voltage.
-#                                 </doc>
-#                             </field>
-#                         </group>
-#                         <group name="linear_sweep" type="NXobject">
-#                             <doc>
-#                                 The linear sweep is a type of scan where the bias voltage is swept
-#                                 linearly from the starting voltage to the ending voltage.
-#                             </doc>
-#                             <field name="scan_points_bias" type="NX_NUMBER">
-#                                 <doc>
-#                                     The number of voltage points the sweep scan to be performed.
-#                                 </doc>
-#                             </field>
-#                             <field name="step_size_bias" type="NX_NUMBER" units="NX_VOLTAGE">
-#                                 <doc>
-#                                     The step size of the sweep.
-#                                     The step size is the difference between the two consecutive bias voltage during the sweep.
-#                                 </doc>
-#                             </field>
-#                             <field name="reset_bias" type="NX_BOOLEAN" optional="true">
-#                                 <doc>
-#                                     The reset_bias is used to reset the bias voltage to the starting value after a
-#                                     sweep is completed.
-#                                 </doc>
-#                             </field>
-#                         </group>
-#                     </group>
-#                 </group>
-#             </group>
-#             <group name="sample_bias_votage" type="NXsensor" optional="true">
-#                 <doc>
-#                     The DC bias voltage that is applied to the sample.
-#                 </doc>
-#                 <field name="bias_voltage" type="NX_NUMBER" units="NX_VOLTAGE">
-#                     <doc>
-#                         The bias voltage (DC) applied to the sample.
-#                     </doc>
-#                 </field>
-#                 <field name="bias_offset" type="NX_NUMBER" optional="true" units="NX_VOLTAGE">
-#                     <doc>
-#                         Offset value of the bias voltage.
-#                     </doc>
-#                 </field>
-#                 <group name="bias_calibration" type="NXcalibration" optional="true">
-#                     <doc>
-#                         Calibration of the bias voltage measurement (V/V).
-#                     </doc>
-#                     <field name="coefficients" type="NX_NUMBER" optional="true" units="NX_ANY">
-#                         <doc>
-#                             The coefficients of the calibration.
-#                         </doc>
-#                     </field>
 #                 </group>
 #             </group>
 #         </group>

--- a/contributed_definitions/nyaml/NXsts.yaml
+++ b/contributed_definitions/nyaml/NXsts.yaml
@@ -31,64 +31,10 @@ NXsts(NXspm):
         exists: optional
         doc: |
           Information for current sensor.
-        current(NX_NUMBER):
-          unit: NX_CURRENT
-          doc: |
-            The dc current between tip and sample.
-        current_offset(NX_NUMBER):
-          exists: optional
-          unit: NX_CURRENT
-          doc: |
-            The offset in the tunneling current between tip and sample.
-        current_calibration(NXcalibration):
-          exists: optional
-          doc: |
-            Calibration data of the current sensor.
-          coefficients(NX_NUMBER):
-            exists: optional
-            unit: NX_ANY
-            doc: |
-              The coefficients of the calibration.
-        (NXamplifier):
-          exists: optional
-          doc: |
-            An amplifier information for the input signal (e.g. from tip).
-          current_gain(NX_NUMBER):
-            unit: NX_UNITLESS
-            exists: optional
-            doc: |
-              The gain of the current sensor.
       voltage_sensor(NXsensor):
         exists: optional
         doc: |
           The sensor information for the voltage device.
-        voltage(NX_NUMBER):
-          unit: NX_VOLTAGE
-          doc: |
-            The dc voltage between tip and sample.
-        voltage_offset(NX_NUMBER):
-          exists: optional
-          unit: NX_VOLTAGE
-          doc: |
-            The offset in the tunneling voltage between tip and sample.
-        voltage_calibration(NXcalibration):
-          exists: optional
-          doc: |
-            Calibration data of the voltage sensor.
-          coefficients(NX_NUMBER):
-            exists: optional
-            unit: NX_ANY
-            doc: |
-              The coefficients of the calibration.
-        (NXamplifier):
-          exists: optional
-          doc: |
-            An amplifier information for the input signal (e.g. from tip).
-          voltage_gain(NX_NUMBER):
-            unit: NX_UNITLESS
-            exists: optional
-            doc: |
-              The gain of the voltage sensor.
       piezo_sensor(NXsensor):
         doc: |
           The sensor information for the piezo device.
@@ -169,7 +115,7 @@ NXsts(NXspm):
           link to the target:
           /ENTRY[entry]/experiment_instrument/current_sensor/current
           
-          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       current_offset(NX_NUMBER):
         exists: optional
         doc: |
@@ -177,7 +123,7 @@ NXsts(NXspm):
           link to the target:
           /ENTRY[entry]/experiment_instrument/current_sensor/current
           
-          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       current_gain(NX_NUMBER):
         exists: optional
         doc: |
@@ -186,7 +132,7 @@ NXsts(NXspm):
           link to the target:
           /ENTRY[entry]/experiment_instrument/current_sensor/amplifier/current_gain
           
-          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       bias_sweep(NXobject):
         exists: optional
         doc: |
@@ -194,7 +140,7 @@ NXsts(NXspm):
           Link to target:
           /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
           
-          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       modulation_signal_type:
         exists: optional
         doc: |
@@ -202,15 +148,15 @@ NXsts(NXspm):
           link to the target:
           /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
           
-          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
-      modulation_frequency(NX_NUMBER):
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
+      reference_frequency(NX_NUMBER):
         exists: optional
         doc: |
-          The frequency of the sine modulation that is used to modulate the signal in lock-in.
+          The frequency of the sine modulation that is used as carrier signal of input signal in lock-in.
           link to the target:
-          /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
+          /ENTRY[entry]/experiment_instrument/lockin_amplifier/reference_frequency
           
-          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
     resolution_indicators(NXcollection):
       exists: optional
       doc: |
@@ -222,28 +168,28 @@ NXsts(NXspm):
           Link to target:
           /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
           
-          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       cryo_bottom_temp(NX_NUMBER):
         exists: optional
         doc: |
           Link to target:
           /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
           
-          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       cryo_shield_temp(NX_NUMBER):
         exists: optional
         doc: |
           Link to target:
           /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
           
-          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       bias_sweep(NXobject):
         exists: optional
         doc: |
           Link to target:
           /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
           
-          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       modulation_signal_type:
         exists: optional
         doc: |
@@ -251,7 +197,7 @@ NXsts(NXspm):
           link to the target:
           /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
           
-          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+          Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
       modulation_frequency(NX_NUMBER):
         exists: optional
         doc: |
@@ -260,7 +206,7 @@ NXsts(NXspm):
           /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# c05bd78315499801ebbc5d76879bdd9140ad0fe6ee1a8a0acac6f942228c6ee0
+# 2ead5e5cb59a6a9d26af025d23461e19a968be1f05e500692dedf80d3f2edb1b
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -326,71 +272,11 @@ NXsts(NXspm):
 #                 <doc>
 #                     Information for current sensor.
 #                 </doc>
-#                 <field name="current" type="NX_NUMBER" units="NX_CURRENT">
-#                     <doc>
-#                         The dc current between tip and sample.
-#                     </doc>
-#                 </field>
-#                 <field name="current_offset" type="NX_NUMBER" optional="true" units="NX_CURRENT">
-#                     <doc>
-#                         The offset in the tunneling current between tip and sample.
-#                     </doc>
-#                 </field>
-#                 <group name="current_calibration" type="NXcalibration" optional="true">
-#                     <doc>
-#                         Calibration data of the current sensor.
-#                     </doc>
-#                     <field name="coefficients" type="NX_NUMBER" optional="true" units="NX_ANY">
-#                         <doc>
-#                             The coefficients of the calibration.
-#                         </doc>
-#                     </field>
-#                 </group>
-#                 <group type="NXamplifier" optional="true">
-#                     <doc>
-#                         An amplifier information for the input signal (e.g. from tip).
-#                     </doc>
-#                     <field name="current_gain" type="NX_NUMBER" units="NX_UNITLESS" optional="true">
-#                         <doc>
-#                             The gain of the current sensor.
-#                         </doc>
-#                     </field>
-#                 </group>
 #             </group>
 #             <group name="voltage_sensor" type="NXsensor" optional="true">
 #                 <doc>
 #                     The sensor information for the voltage device.
 #                 </doc>
-#                 <field name="voltage" type="NX_NUMBER" units="NX_VOLTAGE">
-#                     <doc>
-#                         The dc voltage between tip and sample.
-#                     </doc>
-#                 </field>
-#                 <field name="voltage_offset" type="NX_NUMBER" optional="true" units="NX_VOLTAGE">
-#                     <doc>
-#                         The offset in the tunneling voltage between tip and sample.
-#                     </doc>
-#                 </field>
-#                 <group name="voltage_calibration" type="NXcalibration" optional="true">
-#                     <doc>
-#                         Calibration data of the voltage sensor.
-#                     </doc>
-#                     <field name="coefficients" type="NX_NUMBER" optional="true" units="NX_ANY">
-#                         <doc>
-#                             The coefficients of the calibration.
-#                         </doc>
-#                     </field>
-#                 </group>
-#                 <group type="NXamplifier" optional="true">
-#                     <doc>
-#                         An amplifier information for the input signal (e.g. from tip).
-#                     </doc>
-#                     <field name="voltage_gain" type="NX_NUMBER" units="NX_UNITLESS" optional="true">
-#                         <doc>
-#                             The gain of the voltage sensor.
-#                         </doc>
-#                     </field>
-#                 </group>
 #             </group>
 #             <group name="piezo_sensor" type="NXsensor">
 #                 <doc>
@@ -479,7 +365,7 @@ NXsts(NXspm):
 #                     link to the target:
 #                     /ENTRY[entry]/experiment_instrument/current_sensor/current
 #                     
-#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </field>
 #             <field name="current_offset" type="NX_NUMBER" optional="true">
@@ -488,7 +374,7 @@ NXsts(NXspm):
 #                     link to the target:
 #                     /ENTRY[entry]/experiment_instrument/current_sensor/current
 #                     
-#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </field>
 #             <field name="current_gain" type="NX_NUMBER" optional="true">
@@ -498,7 +384,7 @@ NXsts(NXspm):
 #                     link to the target:
 #                     /ENTRY[entry]/experiment_instrument/current_sensor/amplifier/current_gain
 #                     
-#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </field>
 #             <group name="bias_sweep" type="NXobject" optional="true">
@@ -507,7 +393,7 @@ NXsts(NXspm):
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
 #                     
-#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </group>
 #             <field name="modulation_signal_type" optional="true">
@@ -516,16 +402,16 @@ NXsts(NXspm):
 #                     link to the target:
 #                     /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
 #                     
-#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </field>
-#             <field name="modulation_frequency" type="NX_NUMBER" optional="true">
+#             <field name="reference_frequency" type="NX_NUMBER" optional="true">
 #                 <doc>
-#                     The frequency of the sine modulation that is used to modulate the signal in lock-in.
+#                     The frequency of the sine modulation that is used as carrier signal of input signal in lock-in.
 #                     link to the target:
-#                     /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
+#                     /ENTRY[entry]/experiment_instrument/lockin_amplifier/reference_frequency
 #                     
-#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </field>
 #         </group>
@@ -539,7 +425,7 @@ NXsts(NXspm):
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
 #                     
-#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </field>
 #             <field name="cryo_bottom_temp" type="NX_NUMBER" optional="true">
@@ -547,7 +433,7 @@ NXsts(NXspm):
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
 #                     
-#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </field>
 #             <field name="cryo_shield_temp" type="NX_NUMBER" optional="true">
@@ -555,7 +441,7 @@ NXsts(NXspm):
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
 #                     
-#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </field>
 #             <group name="bias_sweep" type="NXobject" optional="true">
@@ -563,7 +449,7 @@ NXsts(NXspm):
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
 #                     
-#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </group>
 #             <field name="modulation_signal_type" optional="true">
@@ -572,7 +458,7 @@ NXsts(NXspm):
 #                     link to the target:
 #                     /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
 #                     
-#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+#                     Note: The group name written inside the square brackets (e.g. entry in ENTRY[entry]) would be the exact instance name of the base class (e.g. NXentry) in the nexus file.
 #                 </doc>
 #             </field>
 #             <field name="modulation_frequency" type="NX_NUMBER" optional="true">

--- a/contributed_definitions/nyaml/NXsts.yaml
+++ b/contributed_definitions/nyaml/NXsts.yaml
@@ -20,6 +20,250 @@ NXsts(NXspm):
       enumeration:
         open_enum: true
         items: [constant_height, constant_current, constant_spacing]
+    experiment_instrument(NXinstrument):
+      doc: |
+        The instrument information.
+      lockin_amplifier(NXlockin):
+        exists: optional
+        doc: |
+          The lock-in amplifier information.
+      current_sensor(NXsensor):
+        exists: optional
+        doc: |
+          Information for current sensor.
+        current(NX_NUMBER):
+          unit: NX_CURRENT
+          doc: |
+            The dc current between tip and sample.
+        current_offset(NX_NUMBER):
+          exists: optional
+          unit: NX_CURRENT
+          doc: |
+            The offset in the tunneling current between tip and sample.
+        current_calibration(NXcalibration):
+          exists: optional
+          doc: |
+            Calibration data of the current sensor.
+          coefficients(NX_NUMBER):
+            exists: optional
+            unit: NX_ANY
+            doc: |
+              The coefficients of the calibration.
+        (NXamplifier):
+          exists: optional
+          doc: |
+            An amplifier information for the input signal (e.g. from tip).
+          current_gain(NX_NUMBER):
+            unit: NX_UNITLESS
+            exists: optional
+            doc: |
+              The gain of the current sensor.
+      voltage_sensor(NXsensor):
+        exists: optional
+        doc: |
+          The sensor information for the voltage device.
+        voltage(NX_NUMBER):
+          unit: NX_VOLTAGE
+          doc: |
+            The dc voltage between tip and sample.
+        voltage_offset(NX_NUMBER):
+          exists: optional
+          unit: NX_VOLTAGE
+          doc: |
+            The offset in the tunneling voltage between tip and sample.
+        voltage_calibration(NXcalibration):
+          exists: optional
+          doc: |
+            Calibration data of the voltage sensor.
+          coefficients(NX_NUMBER):
+            exists: optional
+            unit: NX_ANY
+            doc: |
+              The coefficients of the calibration.
+        (NXamplifier):
+          exists: optional
+          doc: |
+            An amplifier information for the input signal (e.g. from tip).
+          voltage_gain(NX_NUMBER):
+            unit: NX_UNITLESS
+            exists: optional
+            doc: |
+              The gain of the voltage sensor.
+      piezo_sensor(NXsensor):
+        doc: |
+          The piezo sensor refers to the height (or Z) piezo sensor if nothing is
+          mentioned along the X and Y directions.
+        x(NX_NUMBER):
+          unit: NX_LENGTH
+          doc: |
+            The x position of the piezo. In STS experiment, the piezo stays fixed at
+            x,y and z and the the tunneling current is measured with respect to the
+            bias voltage (sweep voltage).
+        y(NX_NUMBER):
+          unit: NX_LENGTH
+          doc: |
+            The y position of the piezo.
+        z(NX_NUMBER):
+          unit: NX_LENGTH
+          doc: |
+            The z position of the piezo.
+        piezo_configuration(NXpiezo_config_spm):
+          exists: optional
+          doc: |
+            The piezo configuration information like piezoelectric calibration and material
+            properties.
+          calibration(NXcalibration):
+            exists: optional
+            doc: |
+              Calibration of the piezo device.
+        (NXpositioner_spm):
+          doc: |
+            The positioner information like the position of the tip, the position of the
+            sample, PID loop feedback etc.
+          z_controller(NXpid_controller):
+            doc: |
+              The PID controller information for the z-axis.
+            z(NX_NUMBER):
+              doc: |
+                To indicate the relative tip position z between tip and sample. The tip position
+                can also be varied when the z_controller is not running.
+            controller_status(NX_BOOLEAN):
+              doc: |
+                Status if controller is active.
+        piezo_material(NXpiezoelectric_material):
+          exists: optional
+          doc: |
+            The material description and properties of the piezoelectric scanner materials.
+      TEMPERATURE(NXsensor):
+        nameType: any
+        exists: optional
+        doc: |
+          A group handling the temperature such as cryo, shield and tip. For different
+          type of temperature sensors repeat this group.
+        temperature(NX_NUMBER):
+          exists: optional
+          unit: NX_TEMPERATURE
+          doc: |
+            The temperature of the sample.
+        CHANNEL_temp(NX_CHAR):
+          nameType: partial
+          exists: optional
+          doc: |
+            The name of the channel to measure the temperature.
+        temperature_calibration(NXcalibration):
+          exists: optional
+          doc: |
+            Calibration of the temperature measurement.
+          coefficients(NX_NUMBER):
+            unit: NX_ANY
+            doc: |
+              The coefficients of the calibration.
+        TEMPERATURE_DATA(NXdata):
+          nameType: any
+          exists: optional
+          doc: |
+            Data (e.g, record from SPM head temperature) from temperature sensor.
+      bias_spectroscopy_environment(NXenvironment):
+        doc: |
+          To explain bias (sweep measurement) voltage applied to the sample.
+        (NXbias_spectroscopy):
+          doc: |
+            Setup and scan data for continuous measurement of bias-voltage on the subject of experiment
+            vs tunneling current from probe.
+          (NXpositioner_spm):
+            exists: optional
+            doc: |
+              The positioner information like the position of the tip, PID loop feedback etc.
+            z_controller(NXpid_controller):
+              exists: optional
+              doc: |
+                The PID controller information for the z-axis.
+              z_average_time(NX_NUMBER):
+                exists: optional
+                unit: NX_TIME
+                doc: |
+                  The average time taken by the z-controller to stabilize the tip.
+              z_controller_time(NX_NUMBER):
+                exists: optional
+                unit: NX_TIME
+                doc: |
+                  The time taken by the z-controller to measure physical properties.
+              z_controller_hold(NX_BOOLEAN):
+                exists: optional
+                doc: |
+                  The status of the controller to be held on the previous position, before going to the
+                  next scan point or line to measure the physical properties.
+              record_final_z(NX_BOOLEAN):
+                exists: optional
+                doc: |
+                  The status of the controller to record the final z position after the scan.
+          bias_sweep(NXbias_sweep):
+            doc: |
+              The bais voltage sweep is a common technique used on the substance or sample or environment
+              to study the change in the behavior of the sample or substance or environment due to change
+              in applied  bias voltage.
+            scan_region(NXobject):
+              doc: |
+                The scan region (phase space or sub-phase space) is the region where the scan is
+                performed.
+              scan_offset_bias(NX_NUMBER):
+                exists: optional
+                unit: NX_VOLTAGE
+                doc: |
+                  The offset of the bias voltage for bias sweep.
+              scan_range_bias(NX_NUMBER):
+                exists: optional
+                unit: NX_VOLTAGE
+                doc: |
+                  The range of the scan is the length of the bias voltage over which the sweep
+                  scan will be performed.
+              scan_start_bias(NX_NUMBER):
+                unit: NX_VOLTAGE
+                doc: |
+                  The start of the bias scan voltage.
+              scan_end_bias(NX_NUMBER):
+                unit: NX_VOLTAGE
+                doc: |
+                  The end of the bias scan voltage.
+            linear_sweep(NXobject):
+              doc: |
+                The linear sweep is a type of scan where the bias voltage is swept
+                linearly from the starting voltage to the ending voltage.
+              scan_points_bias(NX_NUMBER):
+                doc: |
+                  The number of voltage points the sweep scan to be performed.
+              step_size_bias(NX_NUMBER):
+                unit: NX_VOLTAGE
+                doc: |
+                  The step size of the sweep.
+                  The step size is the difference between the two consecutive bias voltage during the sweep.
+              reset_bias(NX_BOOLEAN):
+                exists: optional
+                doc: |
+                  The reset_bias is used to reset the bias voltage to the starting value after a
+                  sweep is completed.
+      sample_bias_votage(NXsensor):
+        exists: optional
+        doc: |
+          The DC bias voltage that is applied to the sample.
+        bias_voltage(NX_NUMBER):
+          unit: NX_VOLTAGE
+          doc: |
+            The bias voltage (DC) applied to the sample.
+        bias_offset(NX_NUMBER):
+          exists: optional
+          unit: NX_VOLTAGE
+          doc: |
+            Offset value of the bias voltage.
+        bias_calibration(NXcalibration):
+          exists: optional
+          doc: |
+            Calibration of the bias voltage measurement (V/V).
+          coefficients(NX_NUMBER):
+            exists: optional
+            unit: NX_ANY
+            doc: |
+              The coefficients of the calibration.
     reproducibility_indicators(NXcollection):
       exists: optional
       doc: |
@@ -123,7 +367,7 @@ NXsts(NXspm):
           /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# f17a105b5f9c6b72f32e750f7c18e276275e072b32a18ddeb90bde5a66f3cd8a
+# c7bec6ff8476e325ca186a85621a6b08e0200f14cba6b0be21cf468ed6c19d8a
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -176,6 +420,302 @@ NXsts(NXspm):
 #                 <item value="constant_spacing"/>
 #             </enumeration>
 #         </field>
+#         <group name="experiment_instrument" type="NXinstrument">
+#             <doc>
+#                 The instrument information.
+#             </doc>
+#             <group name="lockin_amplifier" type="NXlockin" optional="true">
+#                 <doc>
+#                     The lock-in amplifier information.
+#                 </doc>
+#             </group>
+#             <group name="current_sensor" type="NXsensor" optional="true">
+#                 <doc>
+#                     Information for current sensor.
+#                 </doc>
+#                 <field name="current" type="NX_NUMBER" units="NX_CURRENT">
+#                     <doc>
+#                         The dc current between tip and sample.
+#                     </doc>
+#                 </field>
+#                 <field name="current_offset" type="NX_NUMBER" optional="true" units="NX_CURRENT">
+#                     <doc>
+#                         The offset in the tunneling current between tip and sample.
+#                     </doc>
+#                 </field>
+#                 <group name="current_calibration" type="NXcalibration" optional="true">
+#                     <doc>
+#                         Calibration data of the current sensor.
+#                     </doc>
+#                     <field name="coefficients" type="NX_NUMBER" optional="true" units="NX_ANY">
+#                         <doc>
+#                             The coefficients of the calibration.
+#                         </doc>
+#                     </field>
+#                 </group>
+#                 <group type="NXamplifier" optional="true">
+#                     <doc>
+#                         An amplifier information for the input signal (e.g. from tip).
+#                     </doc>
+#                     <field name="current_gain" type="NX_NUMBER" units="NX_UNITLESS" optional="true">
+#                         <doc>
+#                             The gain of the current sensor.
+#                         </doc>
+#                     </field>
+#                 </group>
+#             </group>
+#             <group name="voltage_sensor" type="NXsensor" optional="true">
+#                 <doc>
+#                     The sensor information for the voltage device.
+#                 </doc>
+#                 <field name="voltage" type="NX_NUMBER" units="NX_VOLTAGE">
+#                     <doc>
+#                         The dc voltage between tip and sample.
+#                     </doc>
+#                 </field>
+#                 <field name="voltage_offset" type="NX_NUMBER" optional="true" units="NX_VOLTAGE">
+#                     <doc>
+#                         The offset in the tunneling voltage between tip and sample.
+#                     </doc>
+#                 </field>
+#                 <group name="voltage_calibration" type="NXcalibration" optional="true">
+#                     <doc>
+#                         Calibration data of the voltage sensor.
+#                     </doc>
+#                     <field name="coefficients" type="NX_NUMBER" optional="true" units="NX_ANY">
+#                         <doc>
+#                             The coefficients of the calibration.
+#                         </doc>
+#                     </field>
+#                 </group>
+#                 <group type="NXamplifier" optional="true">
+#                     <doc>
+#                         An amplifier information for the input signal (e.g. from tip).
+#                     </doc>
+#                     <field name="voltage_gain" type="NX_NUMBER" units="NX_UNITLESS" optional="true">
+#                         <doc>
+#                             The gain of the voltage sensor.
+#                         </doc>
+#                     </field>
+#                 </group>
+#             </group>
+#             <group name="piezo_sensor" type="NXsensor">
+#                 <doc>
+#                     The piezo sensor refers to the height (or Z) piezo sensor if nothing is
+#                     mentioned along the X and Y directions.
+#                 </doc>
+#                 <field name="x" type="NX_NUMBER" units="NX_LENGTH">
+#                     <doc>
+#                         The x position of the piezo. In STS experiment, the piezo stays fixed at
+#                         x,y and z and the the tunneling current is measured with respect to the
+#                         bias voltage (sweep voltage).
+#                     </doc>
+#                 </field>
+#                 <field name="y" type="NX_NUMBER" units="NX_LENGTH">
+#                     <doc>
+#                         The y position of the piezo.
+#                     </doc>
+#                 </field>
+#                 <field name="z" type="NX_NUMBER" units="NX_LENGTH">
+#                     <doc>
+#                         The z position of the piezo.
+#                     </doc>
+#                 </field>
+#                 <group name="piezo_configuration" type="NXpiezo_config_spm" optional="true">
+#                     <doc>
+#                         The piezo configuration information like piezoelectric calibration and material
+#                         properties.
+#                     </doc>
+#                     <group name="calibration" type="NXcalibration" optional="true">
+#                         <doc>
+#                             Calibration of the piezo device.
+#                         </doc>
+#                     </group>
+#                 </group>
+#                 <group type="NXpositioner_spm">
+#                     <doc>
+#                         The positioner information like the position of the tip, the position of the
+#                         sample, PID loop feedback etc.
+#                     </doc>
+#                     <group name="z_controller" type="NXpid_controller">
+#                         <doc>
+#                             The PID controller information for the z-axis.
+#                         </doc>
+#                         <field name="z" type="NX_NUMBER">
+#                             <doc>
+#                                 To indicate the relative tip position z between tip and sample. The tip position
+#                                 can also be varied when the z_controller is not running.
+#                             </doc>
+#                         </field>
+#                         <field name="controller_status" type="NX_BOOLEAN">
+#                             <doc>
+#                                 Status if controller is active.
+#                             </doc>
+#                         </field>
+#                     </group>
+#                 </group>
+#                 <group name="piezo_material" type="NXpiezoelectric_material" optional="true">
+#                     <doc>
+#                         The material description and properties of the piezoelectric scanner materials.
+#                     </doc>
+#                 </group>
+#             </group>
+#             <group name="TEMPERATURE" type="NXsensor" nameType="any" optional="true">
+#                 <doc>
+#                     A group handling the temperature such as cryo, shield and tip. For different
+#                     type of temperature sensors repeat this group.
+#                 </doc>
+#                 <field name="temperature" type="NX_NUMBER" optional="true" units="NX_TEMPERATURE">
+#                     <doc>
+#                         The temperature of the sample.
+#                     </doc>
+#                 </field>
+#                 <field name="CHANNEL_temp" type="NX_CHAR" nameType="partial" optional="true">
+#                     <doc>
+#                         The name of the channel to measure the temperature.
+#                     </doc>
+#                 </field>
+#                 <group name="temperature_calibration" type="NXcalibration" optional="true">
+#                     <doc>
+#                         Calibration of the temperature measurement.
+#                     </doc>
+#                     <field name="coefficients" type="NX_NUMBER" units="NX_ANY">
+#                         <doc>
+#                             The coefficients of the calibration.
+#                         </doc>
+#                     </field>
+#                 </group>
+#                 <group name="TEMPERATURE_DATA" type="NXdata" nameType="any" optional="true">
+#                     <doc>
+#                         Data (e.g, record from SPM head temperature) from temperature sensor.
+#                     </doc>
+#                 </group>
+#             </group>
+#             <group name="bias_spectroscopy_environment" type="NXenvironment">
+#                 <doc>
+#                     To explain bias (sweep measurement) voltage applied to the sample.
+#                 </doc>
+#                 <group type="NXbias_spectroscopy">
+#                     <doc>
+#                         Setup and scan data for continuous measurement of bias-voltage on the subject of experiment
+#                         vs tunneling current from probe.
+#                     </doc>
+#                     <group type="NXpositioner_spm" optional="true">
+#                         <doc>
+#                             The positioner information like the position of the tip, PID loop feedback etc.
+#                         </doc>
+#                         <group name="z_controller" type="NXpid_controller" optional="true">
+#                             <doc>
+#                                 The PID controller information for the z-axis.
+#                             </doc>
+#                             <field name="z_average_time" type="NX_NUMBER" optional="true" units="NX_TIME">
+#                                 <doc>
+#                                     The average time taken by the z-controller to stabilize the tip.
+#                                 </doc>
+#                             </field>
+#                             <field name="z_controller_time" type="NX_NUMBER" optional="true" units="NX_TIME">
+#                                 <doc>
+#                                     The time taken by the z-controller to measure physical properties.
+#                                 </doc>
+#                             </field>
+#                             <field name="z_controller_hold" type="NX_BOOLEAN" optional="true">
+#                                 <doc>
+#                                     The status of the controller to be held on the previous position, before going to the
+#                                     next scan point or line to measure the physical properties.
+#                                 </doc>
+#                             </field>
+#                             <field name="record_final_z" type="NX_BOOLEAN" optional="true">
+#                                 <doc>
+#                                     The status of the controller to record the final z position after the scan.
+#                                 </doc>
+#                             </field>
+#                         </group>
+#                     </group>
+#                     <group name="bias_sweep" type="NXbias_sweep">
+#                         <doc>
+#                             The bais voltage sweep is a common technique used on the substance or sample or environment
+#                             to study the change in the behavior of the sample or substance or environment due to change
+#                             in applied  bias voltage.
+#                         </doc>
+#                         <group name="scan_region" type="NXobject">
+#                             <doc>
+#                                 The scan region (phase space or sub-phase space) is the region where the scan is
+#                                 performed.
+#                             </doc>
+#                             <field name="scan_offset_bias" type="NX_NUMBER" optional="true" units="NX_VOLTAGE">
+#                                 <doc>
+#                                     The offset of the bias voltage for bias sweep.
+#                                 </doc>
+#                             </field>
+#                             <field name="scan_range_bias" type="NX_NUMBER" optional="true" units="NX_VOLTAGE">
+#                                 <doc>
+#                                     The range of the scan is the length of the bias voltage over which the sweep
+#                                     scan will be performed.
+#                                 </doc>
+#                             </field>
+#                             <field name="scan_start_bias" type="NX_NUMBER" units="NX_VOLTAGE">
+#                                 <doc>
+#                                     The start of the bias scan voltage.
+#                                 </doc>
+#                             </field>
+#                             <field name="scan_end_bias" type="NX_NUMBER" units="NX_VOLTAGE">
+#                                 <doc>
+#                                     The end of the bias scan voltage.
+#                                 </doc>
+#                             </field>
+#                         </group>
+#                         <group name="linear_sweep" type="NXobject">
+#                             <doc>
+#                                 The linear sweep is a type of scan where the bias voltage is swept
+#                                 linearly from the starting voltage to the ending voltage.
+#                             </doc>
+#                             <field name="scan_points_bias" type="NX_NUMBER">
+#                                 <doc>
+#                                     The number of voltage points the sweep scan to be performed.
+#                                 </doc>
+#                             </field>
+#                             <field name="step_size_bias" type="NX_NUMBER" units="NX_VOLTAGE">
+#                                 <doc>
+#                                     The step size of the sweep.
+#                                     The step size is the difference between the two consecutive bias voltage during the sweep.
+#                                 </doc>
+#                             </field>
+#                             <field name="reset_bias" type="NX_BOOLEAN" optional="true">
+#                                 <doc>
+#                                     The reset_bias is used to reset the bias voltage to the starting value after a
+#                                     sweep is completed.
+#                                 </doc>
+#                             </field>
+#                         </group>
+#                     </group>
+#                 </group>
+#             </group>
+#             <group name="sample_bias_votage" type="NXsensor" optional="true">
+#                 <doc>
+#                     The DC bias voltage that is applied to the sample.
+#                 </doc>
+#                 <field name="bias_voltage" type="NX_NUMBER" units="NX_VOLTAGE">
+#                     <doc>
+#                         The bias voltage (DC) applied to the sample.
+#                     </doc>
+#                 </field>
+#                 <field name="bias_offset" type="NX_NUMBER" optional="true" units="NX_VOLTAGE">
+#                     <doc>
+#                         Offset value of the bias voltage.
+#                     </doc>
+#                 </field>
+#                 <group name="bias_calibration" type="NXcalibration" optional="true">
+#                     <doc>
+#                         Calibration of the bias voltage measurement (V/V).
+#                     </doc>
+#                     <field name="coefficients" type="NX_NUMBER" optional="true" units="NX_ANY">
+#                         <doc>
+#                             The coefficients of the calibration.
+#                         </doc>
+#                     </field>
+#                 </group>
+#             </group>
+#         </group>
 #         <group name="reproducibility_indicators" type="NXcollection" optional="true">
 #             <doc>
 #                 The group's concepts hold the link to the related concepts that define the

--- a/contributed_definitions/nyaml/NXsts.yaml
+++ b/contributed_definitions/nyaml/NXsts.yaml
@@ -20,7 +20,7 @@ NXsts(NXspm):
       enumeration:
         open_enum: true
         items: [constant_height, constant_current, constant_spacing]
-    reproducibility_indicators(NXobject):
+    reproducibility_indicators(NXcollection):
       exists: optional
       doc: |
         The group's concepts hold the link to the related concepts that define the
@@ -29,35 +29,52 @@ NXsts(NXspm):
         exists: optional
         doc: |
           The tunneling current between tip and sample after application of bias voltage.
-          link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
+          link to the target:
+          /ENTRY[entry]/experiment_instrument/current_sensor/current
+          
+          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
       current_offset(NX_NUMBER):
         exists: optional
         doc: |
           The offset in tunneling current between tip and sample after application of bias voltage.
-          link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
+          link to the target:
+          /ENTRY[entry]/experiment_instrument/current_sensor/current
+          
+          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
       current_gain(NX_NUMBER):
         exists: optional
         doc: |
           Proportional relationship between the probe output voltage and the actual
           tunneling current when measuring the tunneling current.
-          link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/amplifier/current_gain
+          link to the target:
+          /ENTRY[entry]/experiment_instrument/current_sensor/amplifier/current_gain
+          
+          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
       bias_sweep(NXobject):
         exists: optional
         doc: |
           Bias sweep measurement in bias spectroscopy.
           Link to target:
           /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
+          
+          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
       modulation_signal_type:
         exists: optional
         doc: |
           This is the signal on which the modulation voltage or current will be added.
-          link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
+          link to the target:
+          /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
+          
+          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
       modulation_frequency(NX_NUMBER):
         exists: optional
         doc: |
           The frequency of the sine modulation that is used to modulate the signal in lock-in.
-          link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
-    resolution_indicators(NXobject):
+          link to the target:
+          /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
+          
+          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
+    resolution_indicators(NXcollection):
       exists: optional
       doc: |
         The group's concepts hold the link to the related concepts that define the
@@ -65,36 +82,48 @@ NXsts(NXspm):
       tip_temp(NX_NUMBER):
         exists: optional
         doc: |
-          Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+          Link to target:
+          /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+          
+          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
       cryo_bottom_temp(NX_NUMBER):
         exists: optional
         doc: |
           Link to target:
           /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
+          
+          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
       cryo_shield_temp(NX_NUMBER):
         exists: optional
         doc: |
           Link to target:
           /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
+          
+          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
       bias_sweep(NXobject):
         exists: optional
         doc: |
           Link to target:
           /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
+          
+          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
       modulation_signal_type:
         exists: optional
         doc: |
           This is the signal on which the modulation voltage or current will be added.
-          link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
-          modulation_signal_type
+          link to the target:
+          /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
+          
+          Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
       modulation_frequency(NX_NUMBER):
         exists: optional
         doc: |
-          The frequency of the sine modulation that is used to modulate the signal in
-          lock-in.
+          The frequency of the sine modulation that is used to modulate the signal in lock-in.
+          link to the target:
+          /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 717e59f8af666f4e4217609f3c11f1ec7872dd4cf18fc17272cc6b116a241652
+# f17a105b5f9c6b72f32e750f7c18e276275e072b32a18ddeb90bde5a66f3cd8a
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -147,7 +176,7 @@ NXsts(NXspm):
 #                 <item value="constant_spacing"/>
 #             </enumeration>
 #         </field>
-#         <group name="reproducibility_indicators" type="NXobject" optional="true">
+#         <group name="reproducibility_indicators" type="NXcollection" optional="true">
 #             <doc>
 #                 The group's concepts hold the link to the related concepts that define the
 #                 reproducibility of the STM experiment.
@@ -155,20 +184,29 @@ NXsts(NXspm):
 #             <field name="current" type="NX_NUMBER" optional="true">
 #                 <doc>
 #                     The tunneling current between tip and sample after application of bias voltage.
-#                     link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
+#                     link to the target:
+#                     /ENTRY[entry]/experiment_instrument/current_sensor/current
+#                     
+#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                 </doc>
 #             </field>
 #             <field name="current_offset" type="NX_NUMBER" optional="true">
 #                 <doc>
 #                     The offset in tunneling current between tip and sample after application of bias voltage.
-#                     link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/current
+#                     link to the target:
+#                     /ENTRY[entry]/experiment_instrument/current_sensor/current
+#                     
+#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                 </doc>
 #             </field>
 #             <field name="current_gain" type="NX_NUMBER" optional="true">
 #                 <doc>
 #                     Proportional relationship between the probe output voltage and the actual
 #                     tunneling current when measuring the tunneling current.
-#                     link to the target: /ENTRY[entry]/experiment_instrument/current_sensor/amplifier/current_gain
+#                     link to the target:
+#                     /ENTRY[entry]/experiment_instrument/current_sensor/amplifier/current_gain
+#                     
+#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                 </doc>
 #             </field>
 #             <group name="bias_sweep" type="NXobject" optional="true">
@@ -176,60 +214,80 @@ NXsts(NXspm):
 #                     Bias sweep measurement in bias spectroscopy.
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
+#                     
+#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                 </doc>
 #             </group>
 #             <field name="modulation_signal_type" optional="true">
 #                 <doc>
 #                     This is the signal on which the modulation voltage or current will be added.
-#                     link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
+#                     link to the target:
+#                     /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
+#                     
+#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                 </doc>
 #             </field>
 #             <field name="modulation_frequency" type="NX_NUMBER" optional="true">
 #                 <doc>
 #                     The frequency of the sine modulation that is used to modulate the signal in lock-in.
-#                     link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
+#                     link to the target:
+#                     /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
+#                     
+#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                 </doc>
 #             </field>
 #         </group>
-#         <group name="resolution_indicators" type="NXobject" optional="true">
+#         <group name="resolution_indicators" type="NXcollection" optional="true">
 #             <doc>
 #                 The group's concepts hold the link to the related concepts that define the
 #                 resolution of the STM experiment.
 #             </doc>
 #             <field name="tip_temp" type="NX_NUMBER" optional="true">
 #                 <doc>
-#                     Link to target: /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+#                     Link to target:
+#                     /ENTRY[entry]/experiment_instrument/scan_environment/tip_temp
+#                     
+#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                 </doc>
 #             </field>
 #             <field name="cryo_bottom_temp" type="NX_NUMBER" optional="true">
 #                 <doc>
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_bottom_temp
+#                     
+#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                 </doc>
 #             </field>
 #             <field name="cryo_shield_temp" type="NX_NUMBER" optional="true">
 #                 <doc>
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/scan_environment/cryo_shield_temp
+#                     
+#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                 </doc>
 #             </field>
 #             <group name="bias_sweep" type="NXobject" optional="true">
 #                 <doc>
 #                     Link to target:
 #                     /ENTRY[entry]/experiment_instrument/bias_spectroscopy_environment/BIAS_SPECTROSCOPY[bias_spectroscopy]/BIAS_SWEEP[bias_sweep]
+#                     
+#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                 </doc>
 #             </group>
 #             <field name="modulation_signal_type" optional="true">
 #                 <doc>
 #                     This is the signal on which the modulation voltage or current will be added.
-#                     link to the target: /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
-#                     modulation_signal_type
+#                     link to the target:
+#                     /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_signal_type
+#                     
+#                     Note: group name (e.g. entry in ENTRY[entry]) inside the square bracket would be the exact instancename of the base class (e.g. NXentry).
 #                 </doc>
 #             </field>
 #             <field name="modulation_frequency" type="NX_NUMBER" optional="true">
 #                 <doc>
-#                     The frequency of the sine modulation that is used to modulate the signal in
-#                     lock-in.
+#                     The frequency of the sine modulation that is used to modulate the signal in lock-in.
+#                     link to the target:
+#                     /ENTRY[entry]/experiment_instrument/lockin_amplifier/modulation_frequency
 #                 </doc>
 #             </field>
 #         </group>

--- a/contributed_definitions/nyaml/NXxrd_pan.yaml
+++ b/contributed_definitions/nyaml/NXxrd_pan.yaml
@@ -20,7 +20,9 @@ NXxrd_pan(NXxrd):
       doc: |
         Method used to collect the data
         default='X-Ray Diffraction (XRD)'
-      enumeration: [X-Ray Diffraction (XRD)]
+      enumeration:
+        open_enum: true
+        items: [X-Ray Diffraction (XRD)]
     (NXinstrument):
       
       # Need a group that explain
@@ -28,7 +30,9 @@ NXxrd_pan(NXxrd):
         xray_tube_material:
           doc: |
             Type of the X-ray tube.
-          enumeration: [Cu, Cr, Mo, Fe, Ag, In, Ga]
+          enumeration:
+            open_enum: true
+            items: [Cu, Cr, Mo, Fe, Ag, In, Ga]
         xray_tube_current(NX_FLOAT):
           unit: NX_CURRENT
           doc: |
@@ -44,13 +48,17 @@ NXxrd_pan(NXxrd):
           doc: |
             Wavelength of the K\u03b1 1 line.
           \@units:
-            enumeration: [angstrom]
+            enumeration:
+              open_enum: true
+              items: [angstrom]
         k_alpha_two(NX_FLOAT):
           unit: NX_WAVELENGTH
           doc: |
             Wavelength of the K\u03b1 2 line.
           \@units:
-            enumeration: [angstrom]
+            enumeration:
+              open_enum: true
+              items: [angstrom]
         ratio_k_alphatwo_k_alphaone(NX_FLOAT):
           unit: NX_DIMENSIONLESS
           doc: |
@@ -61,7 +69,9 @@ NXxrd_pan(NXxrd):
           doc: |
             Wavelength of the K\u00df line.
           \@units:
-            enumeration: [angstrom]
+            enumeration:
+              open_enum: true
+              items: [angstrom]
         source_peak_wavelength(NX_FLOAT):
           exists: optional
           unit: NX_WAVELENGTH
@@ -243,7 +253,7 @@ NXxrd_pan(NXxrd):
           assumed name or given name.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# ea24fb9f19ac04432bece15f366c44f2c370632bdcbea76b916920013d4e6c11
+# cc61a2bbeb4f86542d584923ceb5702990bf3f147e4ebe2e1643e064cac41af2
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -269,23 +279,23 @@ NXxrd_pan(NXxrd):
 # -->
 # <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXxrd_pan" extends="NXxrd" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
 #     <doc>
-#          NXxrd_pan is a specialisation of NXxrd with extra properties
-#          for the PANalytical XRD data format.
+#         NXxrd_pan is a specialisation of NXxrd with extra properties
+#         for the PANalytical XRD data format.
 #     </doc>
 #     <group type="NXentry">
 #         <field name="data_file" optional="true">
 #             <doc>
-#                  Name of the data file.
+#                 Name of the data file.
 #             </doc>
 #         </field>
 #         <field name="measurement_type">
 #             <doc>
-#                  Type of measurement.
+#                 Type of measurement.
 #             </doc>
 #         </field>
 #         <field name="definition">
 #             <doc>
-#                  Official NeXus NXDL schema to which this file conforms.
+#                 Official NeXus NXDL schema to which this file conforms.
 #             </doc>
 #             <enumeration>
 #                 <item value="NXxrd_pan"/>
@@ -293,10 +303,10 @@ NXxrd_pan(NXxrd):
 #         </field>
 #         <field name="method">
 #             <doc>
-#                  Method used to collect the data
-#                  default='X-Ray Diffraction (XRD)'
+#                 Method used to collect the data
+#                 default='X-Ray Diffraction (XRD)'
 #             </doc>
-#             <enumeration>
+#             <enumeration open="true">
 #                 <item value="X-Ray Diffraction (XRD)"/>
 #             </enumeration>
 #         </field>
@@ -305,9 +315,9 @@ NXxrd_pan(NXxrd):
 #             <group type="NXsource">
 #                 <field name="xray_tube_material">
 #                     <doc>
-#                          Type of the X-ray tube.
+#                         Type of the X-ray tube.
 #                     </doc>
-#                     <enumeration>
+#                     <enumeration open="true">
 #                         <item value="Cu"/>
 #                         <item value="Cr"/>
 #                         <item value="Mo"/>
@@ -319,70 +329,70 @@ NXxrd_pan(NXxrd):
 #                 </field>
 #                 <field name="xray_tube_current" type="NX_FLOAT" units="NX_CURRENT">
 #                     <doc>
-#                          Current of the X-ray tube.
+#                         Current of the X-ray tube.
 #                     </doc>
 #                 </field>
 #                 <field name="xray_tube_voltage" type="NX_FLOAT" units="NX_VOLTAGE">
 #                     <doc>
-#                          Voltage of the X-ray tube.
+#                         Voltage of the X-ray tube.
 #                     </doc>
 #                 </field>
 #                 <!--Unicode for alpha : \u03b1-->
 #                 <field name="k_alpha_one" type="NX_FLOAT" units="NX_WAVELENGTH">
 #                     <doc>
-#                          Wavelength of the K\u03b1 1 line.
+#                         Wavelength of the K\u03b1 1 line.
 #                     </doc>
 #                     <attribute name="units">
-#                         <enumeration>
+#                         <enumeration open="true">
 #                             <item value="angstrom"/>
 #                         </enumeration>
 #                     </attribute>
 #                 </field>
 #                 <field name="k_alpha_two" type="NX_FLOAT" units="NX_WAVELENGTH">
 #                     <doc>
-#                          Wavelength of the K\u03b1 2 line.
+#                         Wavelength of the K\u03b1 2 line.
 #                     </doc>
 #                     <attribute name="units">
-#                         <enumeration>
+#                         <enumeration open="true">
 #                             <item value="angstrom"/>
 #                         </enumeration>
 #                     </attribute>
 #                 </field>
 #                 <field name="ratio_k_alphatwo_k_alphaone" type="NX_FLOAT" units="NX_DIMENSIONLESS">
 #                     <doc>
-#                          K\u03b1 2/K\u03b1 1 intensity ratio.
+#                         K\u03b1 2/K\u03b1 1 intensity ratio.
 #                     </doc>
 #                 </field>
 #                 <field name="kbeta" type="NX_FLOAT" optional="true" units="NX_WAVELENGTH">
 #                     <doc>
-#                          Wavelength of the K\u00df line.
+#                         Wavelength of the K\u00df line.
 #                     </doc>
 #                     <attribute name="units">
-#                         <enumeration>
+#                         <enumeration open="true">
 #                             <item value="angstrom"/>
 #                         </enumeration>
 #                     </attribute>
 #                 </field>
 #                 <field name="source_peak_wavelength" type="NX_FLOAT" optional="true" units="NX_WAVELENGTH">
 #                     <doc>
-#                          Wavelength of the X-ray source. Used to convert from 2-theta to Q.
+#                         Wavelength of the X-ray source. Used to convert from 2-theta to Q.
 #                     </doc>
 #                 </field>
 #             </group>
 #             <group type="NXdetector">
 #                 <field name="scan_axis">
 #                     <doc>
-#                          Axis scanned.
+#                         Axis scanned.
 #                     </doc>
 #                 </field>
 #                 <field name="scan_mode">
 #                     <doc>
-#                          Mode of scan.
+#                         Mode of scan.
 #                     </doc>
 #                 </field>
 #                 <field name="integration_time" type="NX_FLOAT" optional="true" units="NX_TIME">
 #                     <doc>
-#                          Integration time per channel.
+#                         Integration time per channel.
 #                     </doc>
 #                 </field>
 #             </group>
@@ -393,76 +403,76 @@ NXxrd_pan(NXxrd):
 # defracted_beam(NXbeam):-->
 #         <group name="experiment_config" type="NXobject" optional="true">
 #             <doc>
-#                  Collect user inputs e.g. name or path of the input file.
+#                 Collect user inputs e.g. name or path of the input file.
 #             </doc>
 #             <group name="two_theta" type="NXobject">
 #                 <field name="start" type="NX_FLOAT" units="NX_ANGLE">
 #                     <doc>
-#                          Starting value of the diffraction angle.
+#                         Starting value of the diffraction angle.
 #                     </doc>
 #                 </field>
 #                 <field name="end" type="NX_FLOAT" units="NX_ANGLE">
 #                     <doc>
-#                          Ending value of the diffraction angle.
+#                         Ending value of the diffraction angle.
 #                     </doc>
 #                 </field>
 #                 <field name="step" type="NX_FLOAT" units="NX_ANGLE">
 #                     <doc>
-#                          Minimum step size in-between two diffraction angles.
+#                         Minimum step size in-between two diffraction angles.
 #                     </doc>
 #                 </field>
 #             </group>
 #             <group name="omega" type="NXobject">
 #                 <field name="start" type="NX_FLOAT" units="NX_ANGLE">
 #                     <doc>
-#                          Starting value of the incident angle.
+#                         Starting value of the incident angle.
 #                     </doc>
 #                 </field>
 #                 <field name="end" type="NX_FLOAT" units="NX_ANGLE">
 #                     <doc>
-#                          Ending value of the incident angle.
+#                         Ending value of the incident angle.
 #                     </doc>
 #                 </field>
 #                 <field name="step" type="NX_FLOAT" units="NX_ANGLE">
 #                     <doc>
-#                          Minimum step size in the between two incident angles.
+#                         Minimum step size in the between two incident angles.
 #                     </doc>
 #                 </field>
 #             </group>
 #             <field name="beam_attenuation_factors">
 #                 <doc>
-#                      Beam attenuation factors over the path.
+#                     Beam attenuation factors over the path.
 #                 </doc>
 #             </field>
 #             <field name="goniometer_x" type="NX_FLOAT" optional="true" units="NX_LENGTH">
 #                 <doc>
-#                      Goniometer position X.
+#                     Goniometer position X.
 #                 </doc>
 #             </field>
 #             <field name="goniometer_y" type="NX_FLOAT" optional="true" units="NX_LENGTH">
 #                 <doc>
-#                      Goniometer position Y.
+#                     Goniometer position Y.
 #                 </doc>
 #             </field>
 #             <field name="goniometer_z" type="NX_FLOAT" optional="true" units="NX_LENGTH">
 #                 <doc>
-#                      Goniometer position Z
+#                     Goniometer position Z
 #                 </doc>
 #             </field>
 #             <field name="count_time" type="NX_FLOAT" units="NX_TIME">
 #                 <doc>
-#                      Total time of count.
+#                     Total time of count.
 #                 </doc>
 #             </field>
 #         </group>
 #         <group name="experiment_result" type="NXdata">
 #             <doc>
-#                  All experiment results data such as scattering angle (2theta),
-#                  intensity, incident angle, scattering vector, etc will be stored here.
+#                 All experiment results data such as scattering angle (2theta),
+#                 intensity, incident angle, scattering vector, etc will be stored here.
 #             </doc>
 #             <field name="intensity" type="NX_FLOAT">
 #                 <doc>
-#                      Number of scattered electrons per unit time.
+#                     Number of scattered electrons per unit time.
 #                 </doc>
 #                 <dimensions rank="1">
 #                     <dim index="1" value="nDet"/>
@@ -470,7 +480,7 @@ NXxrd_pan(NXxrd):
 #             </field>
 #             <field name="two_theta" type="NX_FLOAT" units="NX_ANGLE">
 #                 <doc>
-#                      Two-theta (scattering angle) of the diffractogram.
+#                     Two-theta (scattering angle) of the diffractogram.
 #                 </doc>
 #                 <dimensions rank="1">
 #                     <dim index="1" value="nDet"/>
@@ -478,7 +488,7 @@ NXxrd_pan(NXxrd):
 #             </field>
 #             <field name="omega" type="NX_FLOAT" optional="true" units="NX_ANGLE">
 #                 <doc>
-#                      Incident angle of the diffractogram.
+#                     Incident angle of the diffractogram.
 #                 </doc>
 #                 <dimensions rank="1">
 #                     <dim index="1" value="nDet"/>
@@ -486,7 +496,7 @@ NXxrd_pan(NXxrd):
 #             </field>
 #             <field name="phi" type="NX_FLOAT" optional="true" units="NX_ANGLE">
 #                 <doc>
-#                      The phi range of the diffractogram.
+#                     The phi range of the diffractogram.
 #                 </doc>
 #                 <dimensions rank="1">
 #                     <dim index="1" value="nDet"/>
@@ -494,7 +504,7 @@ NXxrd_pan(NXxrd):
 #             </field>
 #             <field name="chi" type="NX_FLOAT" optional="true" units="NX_ANGLE">
 #                 <doc>
-#                      The chi range of the diffractogram
+#                     The chi range of the diffractogram
 #                 </doc>
 #                 <dimensions rank="1">
 #                     <dim index="1" value="nDet"/>
@@ -502,78 +512,78 @@ NXxrd_pan(NXxrd):
 #             </field>
 #             <field name="q_parallel" type="NX_FLOAT" optional="true" units="NX_ANY">
 #                 <doc>
-#                      The scattering vector component, which is parallel to the sample surface.
+#                     The scattering vector component, which is parallel to the sample surface.
 #                 </doc>
 #             </field>
 #             <field name="q_perpendicular" type="NX_FLOAT" optional="true" units="NX_ANY">
 #                 <doc>
-#                      The scattering vector component, which is perpendicular to the sample surface.
+#                     The scattering vector component, which is perpendicular to the sample surface.
 #                 </doc>
 #             </field>
 #             <field name="q_norm" type="NX_FLOAT" optional="true" units="NX_ANY">
 #                 <doc>
-#                      The norm value of the scattering vector, q. The scattering vector is defined as a
-#                      difference between the incident and scattered wave vectors.
-#                      For details: https://en.wikipedia.org/wiki/Powder_diffraction
-#                      and https://theory.labster.com/scattering-vector/
+#                     The norm value of the scattering vector, q. The scattering vector is defined as a
+#                     difference between the incident and scattered wave vectors.
+#                     For details: https://en.wikipedia.org/wiki/Powder_diffraction
+#                     and https://theory.labster.com/scattering-vector/
 #                 </doc>
 #             </field>
 #         </group>
 #         <group name="q_data" type="NXdata" optional="true">
 #             <doc>
-#                  The desired view for scattering vectors.
+#                 The desired view for scattering vectors.
 #             </doc>
 #             <field name="q" type="NX_FLOAT" optional="true">
 #                 <doc>
-#                      This concept corresponds to the norm value of the scattering vector(q).
-#                      The concept is the same as 'q_norm' of 'experiment_result'
-#                      and should be linked to /entry[ENTRY]/experiment_result/q_norm.
+#                     This concept corresponds to the norm value of the scattering vector(q).
+#                     The concept is the same as 'q_norm' of 'experiment_result'
+#                     and should be linked to /entry[ENTRY]/experiment_result/q_norm.
 #                 </doc>
 #             </field>
 #             <field name="intensity" type="NX_FLOAT" optional="true">
 #                 <doc>
-#                      Number of scattered electrons per unit time at each scattering vector (q) value.
-#                      The concept is the same as the 'intensity' of experiment_result
-#                      and should be linked to /entry[ENTRY]/experiment_result/intensity.
+#                     Number of scattered electrons per unit time at each scattering vector (q) value.
+#                     The concept is the same as the 'intensity' of experiment_result
+#                     and should be linked to /entry[ENTRY]/experiment_result/intensity.
 #                 </doc>
 #             </field>
 #             <field name="q_parallel" type="NX_FLOAT" optional="true">
 #                 <doc>
-#                      The scattering vector (q) component, which is parallel to the sample surface.
-#                      This component is used in the Reciprocal Space Mapping (RSM) technique of
-#                      X-ray diffraction method.
-#                      
-#                      The concept is the same as 'q_parallel' of experiment_result,
-#                      and should be linked to /entry[ENTRY]/experiment_result/q_parallel.
+#                     The scattering vector (q) component, which is parallel to the sample surface.
+#                     This component is used in the Reciprocal Space Mapping (RSM) technique of
+#                     X-ray diffraction method.
+#                     
+#                     The concept is the same as 'q_parallel' of experiment_result,
+#                     and should be linked to /entry[ENTRY]/experiment_result/q_parallel.
 #                 </doc>
 #             </field>
 #             <field name="q_perpendicular" type="NX_FLOAT" optional="true">
 #                 <doc>
-#                      The scattering vector component, which is perpendicular to the sample surface.
-#                      
-#                      The concept is the same as  'q_perpendicular' of experiment_result,
-#                      and should be linked to /entry[ENTRY]/experiment_result/q_perpendicular.
+#                     The scattering vector component, which is perpendicular to the sample surface.
+#                     
+#                     The concept is the same as  'q_perpendicular' of experiment_result,
+#                     and should be linked to /entry[ENTRY]/experiment_result/q_perpendicular.
 #                 </doc>
 #             </field>
 #         </group>
 #         <group type="NXsample" optional="true">
 #             <doc>
-#                  Description on sample.
+#                 Description on sample.
 #             </doc>
 #             <field name="sample_mode">
 #                 <doc>
-#                      Mode of sample.
+#                     Mode of sample.
 #                 </doc>
 #             </field>
 #             <field name="sample_id">
 #                 <doc>
-#                      Id of sample.
+#                     Id of sample.
 #                 </doc>
 #             </field>
 #             <field name="sample_name">
 #                 <doc>
-#                      Usually in xrd sample are being analysed, but sample might be identified by
-#                      assumed name or given name.
+#                     Usually in xrd sample are being analysed, but sample might be identified by
+#                     assumed name or given name.
 #                 </doc>
 #             </field>
 #         </group>


### PR DESCRIPTION
Fix issue for `nameType` `Open enumeration`, `NXcomponent instead of the NXobject where needed` and `remove NXidentifier instead use a field inplace` 

- [x] SPM domain app defs and base classes
- [x] `xrd_pan` 
- [x] specialize `NXsts`
- [x] Some inheriting of the base class:
    - NXlock-in --> NXnxcomponent &#x2611;
    - ~~scan_region --> NXcomponent  &#x2611;~~
    - ~~**_SCAN --> NXcomponent &#x2611;~~
    - ~~linear_sweep --> NXcomponent &#x2611;~~
    - ~~cantilever_oscillator --> NXcomponent &#x2611;~~
    - ~~cantilever_config --> NXcomponent &#x2611;~~
    - NXamplifier --> NXcomponent &#x2611;
    - NXpiezoelectric_material --> NXcomponent &#x2611