### PR TITLE
MPES: further changes from NIAC

### DIFF
--- a/contributed_definitions/NXmanipulator.nxdl.xml
+++ b/contributed_definitions/NXmanipulator.nxdl.xml
@@ -44,7 +44,7 @@
         <doc>
             Cryostat for cooling the sample.
         </doc>
-        <field name="physical_quantity">
+        <field name="actuation_target">
             <enumeration>
                 <item value="temperature"/>
             </enumeration>
@@ -95,18 +95,18 @@
         <doc>
             Device to heat the sample.
         </doc>
-        <field name="physical_quantity">
+        <field name="actuation_target">
             <enumeration>
                 <item value="temperature"/>
             </enumeration>
         </field>
-        <field name="heater_power" type="NX_FLOAT" units="NX_POWER">
+        <field name="output_heater_power" type="NX_FLOAT" units="NX_POWER">
             <doc>
                 In case of a fixed or averaged heating power, this is the scalar heater power.
                 It can also be a 1D array of heater powers (without time stamps).
             </doc>
         </field>
-        <group name="heater_power_log" type="NXlog">
+        <group name="output_heater_power_log" type="NXlog">
             <field name="value" type="NX_FLOAT" units="NX_POWER">
                 <doc>
                     In the case of an experiment in which the heater power is changed and recorded with time stamps,
@@ -159,7 +159,7 @@
         <doc>
             Actuator applying a voltage to sample and sample holder.
         </doc>
-        <field name="physical_quantity">
+        <field name="actuation_target">
             <enumeration>
                 <item value="voltage"/>
             </enumeration>

--- a/contributed_definitions/NXmpes.nxdl.xml
+++ b/contributed_definitions/NXmpes.nxdl.xml
@@ -764,20 +764,20 @@
                 </group>
                 <group name="sample_heater" type="NXactuator" optional="true">
                     <field name="name" recommended="true"/>
-                    <field name="physical_quantity">
+                    <field name="actuation_target">
                         <enumeration>
                             <item value="temperature"/>
                         </enumeration>
                     </field>
                     <field name="type" optional="true"/>
-                    <field name="heater_power" type="NX_FLOAT"/>
+                    <field name="output_heater_power" type="NX_FLOAT"/>
                     <group type="NXpid_controller" recommended="true">
                         <field name="setpoint" type="NX_FLOAT" recommended="true"/>
                     </group>
                 </group>
                 <group name="cryostat" type="NXactuator" optional="true">
                     <field name="name" recommended="true"/>
-                    <field name="physical_quantity">
+                    <field name="actuation_target">
                         <enumeration>
                             <item value="temperature"/>
                         </enumeration>
@@ -809,7 +809,7 @@
                 </group>
                 <group name="sample_bias_potentiostat" type="NXactuator" recommended="true">
                     <field name="name" recommended="true"/>
-                    <field name="physical_quantity">
+                    <field name="actuation_target">
                         <enumeration>
                             <item value="voltage"/>
                         </enumeration>
@@ -856,7 +856,7 @@
                     Device to bring low-energy electrons to the sample for charge neutralization
                 </doc>
                 <field name="name" recommended="true"/>
-                <field name="physical_quantity">
+                <field name="actuation_target">
                     <enumeration>
                         <item value="current"/>
                     </enumeration>

--- a/contributed_definitions/NXmpes.nxdl.xml
+++ b/contributed_definitions/NXmpes.nxdl.xml
@@ -1220,16 +1220,16 @@
                         In most cases this can be a link to /entry/instrument/flood_gun
                         if a flood_gun is present in the instrument.
                     </doc>
-                    <field name="value" type="NX_FLOAT" optional="true" units="NX_CURRENT">
-                        <doc>
-                            This is to be used if there is no actuator/sensor that controls/measures
-                            the drain_current.
-                            
-                            Note that this method for recording the flood gun current is not advised, but using
-                            NXsensor and NXactuator is strongly recommended instead.
-                        </doc>
-                    </field>
                 </group>
+                <field name="value" type="NX_FLOAT" optional="true" units="NX_CURRENT">
+                    <doc>
+                        This is to be used if there is no actuator/sensor that controls/measures
+                        the flood_gun_current.
+                        
+                        Note that this method for recording the flood gun current is not advised, but using
+                        NXsensor and NXactuator is strongly recommended instead.
+                    </doc>
+                </field>
             </group>
         </group>
         <group name="data" type="NXdata">

--- a/contributed_definitions/NXmpes.nxdl.xml
+++ b/contributed_definitions/NXmpes.nxdl.xml
@@ -1256,7 +1256,8 @@
                     Represents a measure of one- or more-dimensional photoemission counts, where the
                     varied axis may be for example energy, momentum, spatial coordinate, pump-probe
                     delay, spin index, temperature, etc. The axes traces should be linked to the
-                    actual encoder position in NXinstrument or calibrated axes in NXprocess.
+                    actual encoder position in NXinstrument or calibrated axes in NXprocess (or classes
+                    inheriting from NXprocess).
                 </doc>
             </field>
             <field name="energy" type="NX_NUMBER" recommended="true" units="NX_ENERGY">

--- a/contributed_definitions/NXmpes.nxdl.xml
+++ b/contributed_definitions/NXmpes.nxdl.xml
@@ -877,6 +877,28 @@
                     </field>
                 </group>
             </group>
+            <group name="monochromator_TYPE" type="NXmonochromator" optional="true">
+                <doc>
+                    If any of the beams is monochromatized, an ``NXmonochromator`` can be used to describe
+                    the properties of the monochromator.
+                </doc>
+                <field name="energy" type="NX_FLOAT" recommended="true" units="NX_ENERGY"/>
+                <field name="associated_beam">
+                    <doc>
+                        A reference to a beam emitted by this source.
+                        Should be named with the same appendix, e.g.,
+                        for ``monochromator_probe`` it should refer to ``beam_probe``.
+                        
+                        Example:
+                          * /entry/instrument/monochromator_probe/associated_beam = /entry/instrument/beam_probe
+                    </doc>
+                </field>
+            </group>
+            <group type="NXinsertion_device" optional="true">
+                <doc>
+                    Insertion device if synchrotron radiation is used for the MPES experiment.
+                </doc>
+            </group>
             <group name="history" type="NXhistory" optional="true">
                 <doc>
                     A set of activities that occurred to the instrument prior to/during the photoemission

--- a/contributed_definitions/NXxps.nxdl.xml
+++ b/contributed_definitions/NXxps.nxdl.xml
@@ -271,6 +271,7 @@
                     Should be named with the same appendix as ``beam_TYPE``, e.g.,
                     for `` monochromator_probe`` it should refer to ``beam_probe``.
                 </doc>
+                <field name="energy" type="NX_FLOAT" recommended="true" units="NX_ENERGY"/>
                 <field name="associated_beam">
                     <doc>
                         A reference to a beam emitted by this source.

--- a/contributed_definitions/NXxps.nxdl.xml
+++ b/contributed_definitions/NXxps.nxdl.xml
@@ -269,7 +269,7 @@
                     the properties of the monochromator.
                     
                     Should be named with the same appendix as ``beam_TYPE``, e.g.,
-                    for `` monochromator_laser`` it should refer to ``beam_laser``.
+                    for `` monochromator_probe`` it should refer to ``beam_probe``.
                 </doc>
                 <field name="associated_beam">
                     <doc>

--- a/contributed_definitions/NXxps.nxdl.xml
+++ b/contributed_definitions/NXxps.nxdl.xml
@@ -263,6 +263,30 @@
                     </field>
                 </group>
             </group>
+            <group name="monochromator_TYPE" type="NXmonochromator" optional="true">
+                <doc>
+                    If any of the beams is monochromatized, an ``NXmonochromator`` can be used to describe
+                    the properties of the monochromator.
+                    
+                    Should be named with the same appendix as ``beam_TYPE``, e.g.,
+                    for `` monochromator_laser`` it should refer to ``beam_laser``.
+                </doc>
+                <field name="associated_beam">
+                    <doc>
+                        A reference to a beam emitted by this source.
+                        Should be named with the same appendix, e.g.,
+                        for `` monochromator_probe`` it should refer to ``beam_probe``.
+                        
+                        Example:
+                          * /entry/instrument/monochromator_probe/associated_beam = /entry/instrument/beam_probe
+                    </doc>
+                </field>
+            </group>
+            <group type="NXinsertion_device" optional="true">
+                <doc>
+                    Insertion device if snychrotron radiation is used for the XPS experiment.
+                </doc>
+            </group>
         </group>
         <group name="energy_referencing" type="NXcalibration" recommended="true"/>
         <group name="transmission_correction" type="NXcalibration" recommended="true"/>

--- a/contributed_definitions/NXxps.nxdl.xml
+++ b/contributed_definitions/NXxps.nxdl.xml
@@ -658,12 +658,14 @@
                 </group>
             </group>
             <group name="global_fit_function" type="NXfit_function" recommended="true">
+                <field name="function_type" recommended="true"/>
                 <field name="description" recommended="true"/>
-                <field name="formula" recommended="true"/>
+                <field name="formula_description" recommended="true"/>
             </group>
             <group name="error_function" type="NXfit_function" recommended="true">
+                <field name="function_type" recommended="true"/>
                 <field name="description" recommended="true"/>
-                <field name="formula" recommended="true"/>
+                <field name="formula_description" recommended="true"/>
             </group>
             <field name="figure_of_meritMETRIC" type="NX_NUMBER" nameType="partial" recommended="true">
                 <attribute name="metric"/>

--- a/contributed_definitions/NXxps.nxdl.xml
+++ b/contributed_definitions/NXxps.nxdl.xml
@@ -263,28 +263,6 @@
                     </field>
                 </group>
             </group>
-            <group name="monochromator_TYPE" type="NXmonochromator" optional="true">
-                <doc>
-                    If any of the beams is monochromatized, an ``NXmonochromator`` can be used to describe
-                    the properties of the monochromator.
-                </doc>
-                <field name="energy" type="NX_FLOAT" recommended="true" units="NX_ENERGY"/>
-                <field name="associated_beam">
-                    <doc>
-                        A reference to a beam emitted by this source.
-                        Should be named with the same appendix, e.g.,
-                        for ``monochromator_probe`` it should refer to ``beam_probe``.
-                        
-                        Example:
-                          * /entry/instrument/monochromator_probe/associated_beam = /entry/instrument/beam_probe
-                    </doc>
-                </field>
-            </group>
-            <group type="NXinsertion_device" optional="true">
-                <doc>
-                    Insertion device if snychrotron radiation is used for the XPS experiment.
-                </doc>
-            </group>
         </group>
         <group name="energy_referencing" type="NXcalibration" recommended="true"/>
         <group name="transmission_correction" type="NXcalibration" recommended="true"/>

--- a/contributed_definitions/NXxps.nxdl.xml
+++ b/contributed_definitions/NXxps.nxdl.xml
@@ -267,9 +267,6 @@
                 <doc>
                     If any of the beams is monochromatized, an ``NXmonochromator`` can be used to describe
                     the properties of the monochromator.
-                    
-                    Should be named with the same appendix as ``beam_TYPE``, e.g.,
-                    for `` monochromator_probe`` it should refer to ``beam_probe``.
                 </doc>
                 <field name="energy" type="NX_FLOAT" recommended="true" units="NX_ENERGY"/>
                 <field name="associated_beam">

--- a/contributed_definitions/NXxps.nxdl.xml
+++ b/contributed_definitions/NXxps.nxdl.xml
@@ -273,7 +273,7 @@
                     <doc>
                         A reference to a beam emitted by this source.
                         Should be named with the same appendix, e.g.,
-                        for `` monochromator_probe`` it should refer to ``beam_probe``.
+                        for ``monochromator_probe`` it should refer to ``beam_probe``.
                         
                         Example:
                           * /entry/instrument/monochromator_probe/associated_beam = /entry/instrument/beam_probe

--- a/contributed_definitions/nyaml/NXmanipulator.yaml
+++ b/contributed_definitions/nyaml/NXmanipulator.yaml
@@ -15,7 +15,7 @@ NXmanipulator(NXcomponent):
   cryostat(NXactuator):
     doc: |
       Cryostat for cooling the sample.
-    physical_quantity:
+    actuation_target:
       enumeration: [temperature]
     (NXpid_controller):
       setpoint(NX_FLOAT):
@@ -49,14 +49,14 @@ NXmanipulator(NXcomponent):
   sample_heater(NXactuator):
     doc: |
       Device to heat the sample.
-    physical_quantity:
+    actuation_target:
       enumeration: [temperature]
-    heater_power(NX_FLOAT):
+    output_heater_power(NX_FLOAT):
       unit: NX_POWER
       doc: |
         In case of a fixed or averaged heating power, this is the scalar heater power.
         It can also be a 1D array of heater powers (without time stamps).
-    heater_power_log(NXlog):
+    output_heater_power_log(NXlog):
       value(NX_FLOAT):
         unit: NX_POWER
         doc: |
@@ -93,7 +93,7 @@ NXmanipulator(NXcomponent):
   sample_bias_potentiostat(NXactuator):
     doc: |
       Actuator applying a voltage to sample and sample holder.
-    physical_quantity:
+    actuation_target:
       enumeration: [voltage]
     (NXpid_controller):
       setpoint(NX_FLOAT):
@@ -135,7 +135,7 @@ NXmanipulator(NXcomponent):
       Class to describe the motors that are used in the manipulator.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 1f8a367d050e4aa799de284ecee50595c6262849e7d27ede60cc521a86bdac5a
+# 218e50684a24fe4e6d89fd14055c1f4f55dead040a6d781aec02009e6359a20e
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -182,7 +182,7 @@ NXmanipulator(NXcomponent):
 #         <doc>
 #             Cryostat for cooling the sample.
 #         </doc>
-#         <field name="physical_quantity">
+#         <field name="actuation_target">
 #             <enumeration>
 #                 <item value="temperature"/>
 #             </enumeration>
@@ -233,18 +233,18 @@ NXmanipulator(NXcomponent):
 #         <doc>
 #             Device to heat the sample.
 #         </doc>
-#         <field name="physical_quantity">
+#         <field name="actuation_target">
 #             <enumeration>
 #                 <item value="temperature"/>
 #             </enumeration>
 #         </field>
-#         <field name="heater_power" type="NX_FLOAT" units="NX_POWER">
+#         <field name="output_heater_power" type="NX_FLOAT" units="NX_POWER">
 #             <doc>
 #                 In case of a fixed or averaged heating power, this is the scalar heater power.
 #                 It can also be a 1D array of heater powers (without time stamps).
 #             </doc>
 #         </field>
-#         <group name="heater_power_log" type="NXlog">
+#         <group name="output_heater_power_log" type="NXlog">
 #             <field name="value" type="NX_FLOAT" units="NX_POWER">
 #                 <doc>
 #                     In the case of an experiment in which the heater power is changed and recorded with time stamps,
@@ -297,7 +297,7 @@ NXmanipulator(NXcomponent):
 #         <doc>
 #             Actuator applying a voltage to sample and sample holder.
 #         </doc>
-#         <field name="physical_quantity">
+#         <field name="actuation_target">
 #             <enumeration>
 #                 <item value="voltage"/>
 #             </enumeration>

--- a/contributed_definitions/nyaml/NXmpes.yaml
+++ b/contributed_definitions/nyaml/NXmpes.yaml
@@ -1151,7 +1151,8 @@ NXmpes(NXobject):
           Represents a measure of one- or more-dimensional photoemission counts, where the
           varied axis may be for example energy, momentum, spatial coordinate, pump-probe
           delay, spin index, temperature, etc. The axes traces should be linked to the
-          actual encoder position in NXinstrument or calibrated axes in NXprocess.
+          actual encoder position in NXinstrument or calibrated axes in NXprocess (or classes
+          inheriting from NXprocess).
       energy(NX_NUMBER):
         exists: recommended
         unit: NX_ENERGY
@@ -1320,7 +1321,7 @@ NXmpes(NXobject):
           /entry/sample/temperature_env/temperature_sensor/value.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 7e319de2fb03f039624ef32ddaea42f60d19ea85362e59c08d465a9af87eab47
+# d998b913417eef1c27f1f59da1ee4e40cdf08af224285128b6bf8b63b417bfc5
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -2579,7 +2580,8 @@ NXmpes(NXobject):
 #                     Represents a measure of one- or more-dimensional photoemission counts, where the
 #                     varied axis may be for example energy, momentum, spatial coordinate, pump-probe
 #                     delay, spin index, temperature, etc. The axes traces should be linked to the
-#                     actual encoder position in NXinstrument or calibrated axes in NXprocess.
+#                     actual encoder position in NXinstrument or calibrated axes in NXprocess (or classes
+#                     inheriting from NXprocess).
 #                 </doc>
 #             </field>
 #             <field name="energy" type="NX_NUMBER" recommended="true" units="NX_ENERGY">

--- a/contributed_definitions/nyaml/NXmpes.yaml
+++ b/contributed_definitions/nyaml/NXmpes.yaml
@@ -711,11 +711,11 @@ NXmpes(NXobject):
           exists: optional
           name:
             exists: recommended
-          physical_quantity:
+          actuation_target:
             enumeration: [temperature]
           type:
             exists: optional
-          heater_power(NX_FLOAT):
+          output_heater_power(NX_FLOAT):
           (NXpid_controller):
             exists: recommended
             setpoint(NX_FLOAT):
@@ -724,7 +724,7 @@ NXmpes(NXobject):
           exists: optional
           name:
             exists: recommended
-          physical_quantity:
+          actuation_target:
             enumeration: [temperature]
           type:
             exists: optional
@@ -753,7 +753,7 @@ NXmpes(NXobject):
           exists: recommended
           name:
             exists: recommended
-          physical_quantity:
+          actuation_target:
             enumeration: [voltage]
           type:
             exists: optional
@@ -797,7 +797,7 @@ NXmpes(NXobject):
           Device to bring low-energy electrons to the sample for charge neutralization
         name:
           exists: recommended
-        physical_quantity:
+        actuation_target:
           enumeration: [current]
         type:
           exists: optional
@@ -1320,7 +1320,7 @@ NXmpes(NXobject):
           /entry/sample/temperature_env/temperature_sensor/value.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 1cc6ddaeb7f3ea03fc870982c0e4f5f369ea2e2767f08e1d278fb4834e444244
+# 7e319de2fb03f039624ef32ddaea42f60d19ea85362e59c08d465a9af87eab47
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -2087,20 +2087,20 @@ NXmpes(NXobject):
 #                 </group>
 #                 <group name="sample_heater" type="NXactuator" optional="true">
 #                     <field name="name" recommended="true"/>
-#                     <field name="physical_quantity">
+#                     <field name="actuation_target">
 #                         <enumeration>
 #                             <item value="temperature"/>
 #                         </enumeration>
 #                     </field>
 #                     <field name="type" optional="true"/>
-#                     <field name="heater_power" type="NX_FLOAT"/>
+#                     <field name="output_heater_power" type="NX_FLOAT"/>
 #                     <group type="NXpid_controller" recommended="true">
 #                         <field name="setpoint" type="NX_FLOAT" recommended="true"/>
 #                     </group>
 #                 </group>
 #                 <group name="cryostat" type="NXactuator" optional="true">
 #                     <field name="name" recommended="true"/>
-#                     <field name="physical_quantity">
+#                     <field name="actuation_target">
 #                         <enumeration>
 #                             <item value="temperature"/>
 #                         </enumeration>
@@ -2132,7 +2132,7 @@ NXmpes(NXobject):
 #                 </group>
 #                 <group name="sample_bias_potentiostat" type="NXactuator" recommended="true">
 #                     <field name="name" recommended="true"/>
-#                     <field name="physical_quantity">
+#                     <field name="actuation_target">
 #                         <enumeration>
 #                             <item value="voltage"/>
 #                         </enumeration>
@@ -2179,7 +2179,7 @@ NXmpes(NXobject):
 #                     Device to bring low-energy electrons to the sample for charge neutralization
 #                 </doc>
 #                 <field name="name" recommended="true"/>
-#                 <field name="physical_quantity">
+#                 <field name="actuation_target">
 #                     <enumeration>
 #                         <item value="current"/>
 #                     </enumeration>

--- a/contributed_definitions/nyaml/NXmpes.yaml
+++ b/contributed_definitions/nyaml/NXmpes.yaml
@@ -814,6 +814,26 @@ NXmpes(NXobject):
             doc: |
               In the case of an experiment in which the electron current is changed and
               recorded with time stamps, this is an array of length m of current setpoints.
+      monochromator_TYPE(NXmonochromator):
+        exists: optional
+        doc: |
+          If any of the beams is monochromatized, an ``NXmonochromator`` can be used to describe
+          the properties of the monochromator.
+        energy(NX_FLOAT):
+          exists: recommended
+          unit: NX_ENERGY
+        associated_beam:
+          doc: |
+            A reference to a beam emitted by this source.
+            Should be named with the same appendix, e.g.,
+            for ``monochromator_probe`` it should refer to ``beam_probe``.
+            
+            Example:
+              * /entry/instrument/monochromator_probe/associated_beam = /entry/instrument/beam_probe
+      (NXinsertion_device):
+        exists: optional
+        doc: |
+          Insertion device if synchrotron radiation is used for the MPES experiment.
       history(NXhistory):
         exists: optional
         doc: |
@@ -1321,7 +1341,7 @@ NXmpes(NXobject):
           /entry/sample/temperature_env/temperature_sensor/value.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 9e70350f64f214f35affba5ffc565954927059a5ce3c369e4ac504490d8238ee
+# 18ec70702f255a682894d2ab68bdbd79d0d5134344f38e8411bcf00567228de0
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -2200,6 +2220,28 @@ NXmpes(NXobject):
 #                         </doc>
 #                     </field>
 #                 </group>
+#             </group>
+#             <group name="monochromator_TYPE" type="NXmonochromator" optional="true">
+#                 <doc>
+#                     If any of the beams is monochromatized, an ``NXmonochromator`` can be used to describe
+#                     the properties of the monochromator.
+#                 </doc>
+#                 <field name="energy" type="NX_FLOAT" recommended="true" units="NX_ENERGY"/>
+#                 <field name="associated_beam">
+#                     <doc>
+#                         A reference to a beam emitted by this source.
+#                         Should be named with the same appendix, e.g.,
+#                         for ``monochromator_probe`` it should refer to ``beam_probe``.
+#                         
+#                         Example:
+#                           * /entry/instrument/monochromator_probe/associated_beam = /entry/instrument/beam_probe
+#                     </doc>
+#                 </field>
+#             </group>
+#             <group type="NXinsertion_device" optional="true">
+#                 <doc>
+#                     Insertion device if synchrotron radiation is used for the MPES experiment.
+#                 </doc>
 #             </group>
 #             <group name="history" type="NXhistory" optional="true">
 #                 <doc>

--- a/contributed_definitions/nyaml/NXmpes.yaml
+++ b/contributed_definitions/nyaml/NXmpes.yaml
@@ -1121,15 +1121,15 @@ NXmpes(NXobject):
             
             In most cases this can be a link to /entry/instrument/flood_gun
             if a flood_gun is present in the instrument.
-          value(NX_FLOAT):
-            exists: optional
-            unit: NX_CURRENT
-            doc: |
-              This is to be used if there is no actuator/sensor that controls/measures
-              the drain_current.
-              
-              Note that this method for recording the flood gun current is not advised, but using
-              NXsensor and NXactuator is strongly recommended instead.
+        value(NX_FLOAT):
+          exists: optional
+          unit: NX_CURRENT
+          doc: |
+            This is to be used if there is no actuator/sensor that controls/measures
+            the flood_gun_current.
+            
+            Note that this method for recording the flood gun current is not advised, but using
+            NXsensor and NXactuator is strongly recommended instead.
     data(NXdata):
       doc: |
         The default NXdata group containing a view on the measured data.
@@ -1321,7 +1321,7 @@ NXmpes(NXobject):
           /entry/sample/temperature_env/temperature_sensor/value.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# d998b913417eef1c27f1f59da1ee4e40cdf08af224285128b6bf8b63b417bfc5
+# 9e70350f64f214f35affba5ffc565954927059a5ce3c369e4ac504490d8238ee
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -2544,16 +2544,16 @@ NXmpes(NXobject):
 #                         In most cases this can be a link to /entry/instrument/flood_gun
 #                         if a flood_gun is present in the instrument.
 #                     </doc>
-#                     <field name="value" type="NX_FLOAT" optional="true" units="NX_CURRENT">
-#                         <doc>
-#                             This is to be used if there is no actuator/sensor that controls/measures
-#                             the drain_current.
-#                             
-#                             Note that this method for recording the flood gun current is not advised, but using
-#                             NXsensor and NXactuator is strongly recommended instead.
-#                         </doc>
-#                     </field>
 #                 </group>
+#                 <field name="value" type="NX_FLOAT" optional="true" units="NX_CURRENT">
+#                     <doc>
+#                         This is to be used if there is no actuator/sensor that controls/measures
+#                         the flood_gun_current.
+#                         
+#                         Note that this method for recording the flood gun current is not advised, but using
+#                         NXsensor and NXactuator is strongly recommended instead.
+#                     </doc>
+#                 </field>
 #             </group>
 #         </group>
 #         <group name="data" type="NXdata">

--- a/contributed_definitions/nyaml/NXxps.yaml
+++ b/contributed_definitions/nyaml/NXxps.yaml
@@ -191,7 +191,7 @@ NXxps(NXmpes):
           doc: |
             A reference to a beam emitted by this source.
             Should be named with the same appendix, e.g.,
-            for `` monochromator_probe`` it should refer to ``beam_probe``.
+            for ``monochromator_probe`` it should refer to ``beam_probe``.
             
             Example:
               * /entry/instrument/monochromator_probe/associated_beam = /entry/instrument/beam_probe
@@ -611,7 +611,7 @@ NXxps(NXmpes):
       \@energy_indices(NX_INT):
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 2b0569f6fdb299f3fc74783ef5d8324f600000f4825a419051ca5bfaa3b38427
+# b34a89dd11fd942b11ba52e7b6290817fb4db589e23a4eb682032e687b26f813
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -887,7 +887,7 @@ NXxps(NXmpes):
 #                     <doc>
 #                         A reference to a beam emitted by this source.
 #                         Should be named with the same appendix, e.g.,
-#                         for `` monochromator_probe`` it should refer to ``beam_probe``.
+#                         for ``monochromator_probe`` it should refer to ``beam_probe``.
 #                         
 #                         Example:
 #                           * /entry/instrument/monochromator_probe/associated_beam = /entry/instrument/beam_probe

--- a/contributed_definitions/nyaml/NXxps.yaml
+++ b/contributed_definitions/nyaml/NXxps.yaml
@@ -548,15 +548,19 @@ NXxps(NXmpes):
             exists: recommended
       global_fit_function(NXfit_function):
         exists: recommended
+        function_type:
+          exists: recommended
         description:
           exists: recommended
-        formula:
+        formula_description:
           exists: recommended
       error_function(NXfit_function):
         exists: recommended
+        function_type:
+          exists: recommended
         description:
           exists: recommended
-        formula:
+        formula_description:
           exists: recommended
       figure_of_meritMETRIC(NX_NUMBER):
         nameType: partial
@@ -611,7 +615,7 @@ NXxps(NXmpes):
       \@energy_indices(NX_INT):
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# b34a89dd11fd942b11ba52e7b6290817fb4db589e23a4eb682032e687b26f813
+# d8283a74cef207300ccf937f8d15e3e3725d15f7bfcea89014614776992179c0
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -1272,12 +1276,14 @@ NXxps(NXmpes):
 #                 </group>
 #             </group>
 #             <group name="global_fit_function" type="NXfit_function" recommended="true">
+#                 <field name="function_type" recommended="true"/>
 #                 <field name="description" recommended="true"/>
-#                 <field name="formula" recommended="true"/>
+#                 <field name="formula_description" recommended="true"/>
 #             </group>
 #             <group name="error_function" type="NXfit_function" recommended="true">
+#                 <field name="function_type" recommended="true"/>
 #                 <field name="description" recommended="true"/>
-#                 <field name="formula" recommended="true"/>
+#                 <field name="formula_description" recommended="true"/>
 #             </group>
 #             <field name="figure_of_meritMETRIC" type="NX_NUMBER" nameType="partial" recommended="true">
 #                 <attribute name="metric"/>

--- a/contributed_definitions/nyaml/NXxps.yaml
+++ b/contributed_definitions/nyaml/NXxps.yaml
@@ -179,26 +179,6 @@ NXxps(NXmpes):
               doc: |
                 This should point to the last element of the coordinate system transformations defined in
                 /entry/geometries/xps_coordinate_system/coordinate_system_transformations.
-      monochromator_TYPE(NXmonochromator):
-        exists: optional
-        doc: |
-          If any of the beams is monochromatized, an ``NXmonochromator`` can be used to describe
-          the properties of the monochromator.
-        energy(NX_FLOAT):
-          exists: recommended
-          unit: NX_ENERGY
-        associated_beam:
-          doc: |
-            A reference to a beam emitted by this source.
-            Should be named with the same appendix, e.g.,
-            for ``monochromator_probe`` it should refer to ``beam_probe``.
-            
-            Example:
-              * /entry/instrument/monochromator_probe/associated_beam = /entry/instrument/beam_probe
-      (NXinsertion_device):
-        exists: optional
-        doc: |
-          Insertion device if snychrotron radiation is used for the XPS experiment.
     energy_referencing(NXcalibration):
       exists: recommended
     transmission_correction(NXcalibration):
@@ -615,7 +595,7 @@ NXxps(NXmpes):
       \@energy_indices(NX_INT):
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# d8283a74cef207300ccf937f8d15e3e3725d15f7bfcea89014614776992179c0
+# fa4095b9097645b7f1cf98d3cb14dc0e4ec2f77332c137b1860db8bfa809d2fa
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -880,28 +860,6 @@ NXxps(NXmpes):
 #                         </attribute>
 #                     </field>
 #                 </group>
-#             </group>
-#             <group name="monochromator_TYPE" type="NXmonochromator" optional="true">
-#                 <doc>
-#                     If any of the beams is monochromatized, an ``NXmonochromator`` can be used to describe
-#                     the properties of the monochromator.
-#                 </doc>
-#                 <field name="energy" type="NX_FLOAT" recommended="true" units="NX_ENERGY"/>
-#                 <field name="associated_beam">
-#                     <doc>
-#                         A reference to a beam emitted by this source.
-#                         Should be named with the same appendix, e.g.,
-#                         for ``monochromator_probe`` it should refer to ``beam_probe``.
-#                         
-#                         Example:
-#                           * /entry/instrument/monochromator_probe/associated_beam = /entry/instrument/beam_probe
-#                     </doc>
-#                 </field>
-#             </group>
-#             <group type="NXinsertion_device" optional="true">
-#                 <doc>
-#                     Insertion device if snychrotron radiation is used for the XPS experiment.
-#                 </doc>
 #             </group>
 #         </group>
 #         <group name="energy_referencing" type="NXcalibration" recommended="true"/>

--- a/contributed_definitions/nyaml/NXxps.yaml
+++ b/contributed_definitions/nyaml/NXxps.yaml
@@ -186,7 +186,7 @@ NXxps(NXmpes):
           the properties of the monochromator.
           
           Should be named with the same appendix as ``beam_TYPE``, e.g.,
-          for `` monochromator_laser`` it should refer to ``beam_laser``.
+          for `` monochromator_probe`` it should refer to ``beam_probe``.
         associated_beam:
           doc: |
             A reference to a beam emitted by this source.
@@ -611,7 +611,7 @@ NXxps(NXmpes):
       \@energy_indices(NX_INT):
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 7f1bb99db0661f1e3074e916eb539f25417650d74bdc173862181b057f88db3e
+# 70228c3f82e4370f29cfe5590b474363f938abc70f4f0b68391da35315ae3961
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -883,7 +883,7 @@ NXxps(NXmpes):
 #                     the properties of the monochromator.
 #                     
 #                     Should be named with the same appendix as ``beam_TYPE``, e.g.,
-#                     for `` monochromator_laser`` it should refer to ``beam_laser``.
+#                     for `` monochromator_probe`` it should refer to ``beam_probe``.
 #                 </doc>
 #                 <field name="associated_beam">
 #                     <doc>

--- a/contributed_definitions/nyaml/NXxps.yaml
+++ b/contributed_definitions/nyaml/NXxps.yaml
@@ -179,6 +179,26 @@ NXxps(NXmpes):
               doc: |
                 This should point to the last element of the coordinate system transformations defined in
                 /entry/geometries/xps_coordinate_system/coordinate_system_transformations.
+      monochromator_TYPE(NXmonochromator):
+        exists: optional
+        doc: |
+          If any of the beams is monochromatized, an ``NXmonochromator`` can be used to describe
+          the properties of the monochromator.
+          
+          Should be named with the same appendix as ``beam_TYPE``, e.g.,
+          for `` monochromator_laser`` it should refer to ``beam_laser``.
+        associated_beam:
+          doc: |
+            A reference to a beam emitted by this source.
+            Should be named with the same appendix, e.g.,
+            for `` monochromator_probe`` it should refer to ``beam_probe``.
+            
+            Example:
+              * /entry/instrument/monochromator_probe/associated_beam = /entry/instrument/beam_probe
+      (NXinsertion_device):
+        exists: optional
+        doc: |
+          Insertion device if snychrotron radiation is used for the XPS experiment.
     energy_referencing(NXcalibration):
       exists: recommended
     transmission_correction(NXcalibration):
@@ -591,7 +611,7 @@ NXxps(NXmpes):
       \@energy_indices(NX_INT):
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# a24a34cb7b585c185e1ffb99994094f7039aa0f1b91821718840fa4e63aacad7
+# 7f1bb99db0661f1e3074e916eb539f25417650d74bdc173862181b057f88db3e
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -856,6 +876,30 @@ NXxps(NXmpes):
 #                         </attribute>
 #                     </field>
 #                 </group>
+#             </group>
+#             <group name="monochromator_TYPE" type="NXmonochromator" optional="true">
+#                 <doc>
+#                     If any of the beams is monochromatized, an ``NXmonochromator`` can be used to describe
+#                     the properties of the monochromator.
+#                     
+#                     Should be named with the same appendix as ``beam_TYPE``, e.g.,
+#                     for `` monochromator_laser`` it should refer to ``beam_laser``.
+#                 </doc>
+#                 <field name="associated_beam">
+#                     <doc>
+#                         A reference to a beam emitted by this source.
+#                         Should be named with the same appendix, e.g.,
+#                         for `` monochromator_probe`` it should refer to ``beam_probe``.
+#                         
+#                         Example:
+#                           * /entry/instrument/monochromator_probe/associated_beam = /entry/instrument/beam_probe
+#                     </doc>
+#                 </field>
+#             </group>
+#             <group type="NXinsertion_device" optional="true">
+#                 <doc>
+#                     Insertion device if snychrotron radiation is used for the XPS experiment.
+#                 </doc>
 #             </group>
 #         </group>
 #         <group name="energy_referencing" type="NXcalibration" recommended="true"/>

--- a/contributed_definitions/nyaml/NXxps.yaml
+++ b/contributed_definitions/nyaml/NXxps.yaml
@@ -184,9 +184,6 @@ NXxps(NXmpes):
         doc: |
           If any of the beams is monochromatized, an ``NXmonochromator`` can be used to describe
           the properties of the monochromator.
-          
-          Should be named with the same appendix as ``beam_TYPE``, e.g.,
-          for `` monochromator_probe`` it should refer to ``beam_probe``.
         energy(NX_FLOAT):
           exists: recommended
           unit: NX_ENERGY
@@ -614,7 +611,7 @@ NXxps(NXmpes):
       \@energy_indices(NX_INT):
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# abcd66d1bd669283d5c54b17aec90993d56a2749aca743c07326c8616e92fe5a
+# 2b0569f6fdb299f3fc74783ef5d8324f600000f4825a419051ca5bfaa3b38427
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -884,9 +881,6 @@ NXxps(NXmpes):
 #                 <doc>
 #                     If any of the beams is monochromatized, an ``NXmonochromator`` can be used to describe
 #                     the properties of the monochromator.
-#                     
-#                     Should be named with the same appendix as ``beam_TYPE``, e.g.,
-#                     for `` monochromator_probe`` it should refer to ``beam_probe``.
 #                 </doc>
 #                 <field name="energy" type="NX_FLOAT" recommended="true" units="NX_ENERGY"/>
 #                 <field name="associated_beam">

--- a/contributed_definitions/nyaml/NXxps.yaml
+++ b/contributed_definitions/nyaml/NXxps.yaml
@@ -187,6 +187,9 @@ NXxps(NXmpes):
           
           Should be named with the same appendix as ``beam_TYPE``, e.g.,
           for `` monochromator_probe`` it should refer to ``beam_probe``.
+        energy(NX_FLOAT):
+          exists: recommended
+          unit: NX_ENERGY
         associated_beam:
           doc: |
             A reference to a beam emitted by this source.
@@ -611,7 +614,7 @@ NXxps(NXmpes):
       \@energy_indices(NX_INT):
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 70228c3f82e4370f29cfe5590b474363f938abc70f4f0b68391da35315ae3961
+# abcd66d1bd669283d5c54b17aec90993d56a2749aca743c07326c8616e92fe5a
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -885,6 +888,7 @@ NXxps(NXmpes):
 #                     Should be named with the same appendix as ``beam_TYPE``, e.g.,
 #                     for `` monochromator_probe`` it should refer to ``beam_probe``.
 #                 </doc>
+#                 <field name="energy" type="NX_FLOAT" recommended="true" units="NX_ENERGY"/>
 #                 <field name="associated_beam">
 #                     <doc>
 #                         A reference to a beam emitted by this source.


### PR DESCRIPTION
These changes are necessary because during standardization, NIAC sugggested changes to the base classes that we were bringing in, but this was not yet reflected in the application definitions.

I also added an optional monochromator to `NXxps`, following suggestions in https://github.com/FAIRmat-NFDI/nexus_definitions/pull/147.

For checking that everything is correct now, these are the base classes that were changed so far:
- NXaperture
- NXbeam
- NXdetector
- NXenvironment
- NXinstrument
- NXmonochromator
- NXnote
- NXprocess
- NXsample
- NXsample_component
- NXsensor
- NXsource

And these are the ones that we added and are now standardized:
- NXactuator
- NXactivity
- NXcalibration
- NXcomponent
- NXdistortion
- NXelectron_detector
- NXfabrication
- NXhistory
- NXregistration
- NXresolution