### PR TITLE
Fix types and units for inherited fields in MPES

### DIFF
--- a/contributed_definitions/NXmpes.nxdl.xml
+++ b/contributed_definitions/NXmpes.nxdl.xml
@@ -778,7 +778,7 @@
                     <field name="type" optional="true"/>
                     <field name="output_heater_power" type="NX_FLOAT" recommended="true"/>
                     <group type="NXpid_controller" recommended="true">
-                        <field name="setpoint" type="NX_FLOAT" recommended="true"/>
+                        <field name="setpoint" type="NX_FLOAT" units="NX_TEMPERATURE" recommended="true"/>
                     </group>
                 </group>
                 <group name="cryostat" type="NXactuator" optional="true">
@@ -790,7 +790,7 @@
                     </field>
                     <field name="type" optional="true"/>
                     <group type="NXpid_controller">
-                        <field name="setpoint" type="NX_FLOAT" recommended="true"/>
+                        <field name="setpoint" type="NX_FLOAT" units="NX_TEMPERATURE" recommended="true"/>
                     </group>
                 </group>
                 <group name="drain_current_ammeter" type="NXsensor" optional="true">
@@ -822,7 +822,7 @@
                     </field>
                     <field name="type" optional="true"/>
                     <group type="NXpid_controller" recommended="true">
-                        <field name="setpoint" type="NX_FLOAT" recommended="true"/>
+                        <field name="setpoint" type="NX_FLOAT" units="NX_VOLTAGE" recommended="true"/>
                     </group>
                 </group>
                 <group name="device_information" type="NXfabrication" recommended="true">

--- a/contributed_definitions/NXmpes.nxdl.xml
+++ b/contributed_definitions/NXmpes.nxdl.xml
@@ -339,7 +339,7 @@
                     This is the beam that is used to facilitate the photoemission during MPES
                     experiments.
                 </doc>
-                <field name="distance" type="NX_NUMBER" units="NX_LENGTH" recommended="true">
+                <field name="distance" type="NX_FLOAT" units="NX_LENGTH" recommended="true">
                     <doc>
                         Distance between the point where the current NXbeam instance is evaluating
                         the beam properties and the point where the beam interacts with the sample.
@@ -371,7 +371,7 @@
                     initiating a change in its state. It sets the timing for the experiment
                     by defining time zero in a pump-probe setup.
                 </doc>
-                <field name="distance" type="NX_NUMBER" units="NX_LENGTH" recommended="true">
+                <field name="distance" type="NX_FLOAT" units="NX_LENGTH" recommended="true">
                     <doc>
                         Distance between the point where the current NXbeam instance is evaluating
                         the beam properties and the point where the beam interacts with the sample.
@@ -406,7 +406,7 @@
                     Should be named with the same appendix as ``source_TYPE``, e.g.,
                     for ``source_laser`` it should refer to ``beam_laser``.
                 </doc>
-                <field name="distance" type="NX_NUMBER" units="NX_LENGTH" recommended="true">
+                <field name="distance" type="NX_FLOAT" units="NX_LENGTH" recommended="true">
                     <doc>
                         Distance between the point where the current NXbeam instance is evaluating
                         the beam properties and the point where the beam interacts with the sample.

--- a/contributed_definitions/NXxps.nxdl.xml
+++ b/contributed_definitions/NXxps.nxdl.xml
@@ -468,12 +468,12 @@
                     </field>
                     <field name="formula_description" recommended="true"/>
                     <group name="fit_parameters" type="NXparameters" recommended="true">
-                        <field name="area" units="NX_ANY" optional="true">
+                        <field name="area" type="NX_NUMBER" units="NX_ANY" optional="true">
                             <doc>
                                 Area of the peak.
                             </doc>
                         </field>
-                        <field name="width" units="NX_ENERGY" optional="true">
+                        <field name="width" type="NX_NUMBER" units="NX_ENERGY" optional="true">
                             <doc>
                                 Width of a peak at a defined fraction of the peak height.
                                 
@@ -486,14 +486,14 @@
                                 .. _3.28: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:3.28
                             </doc>
                         </field>
-                        <field name="position" units="NX_ENERGY" optional="true">
+                        <field name="position" type="NX_NUMBER" units="NX_ENERGY" optional="true">
                             <doc>
                                 Position of the peak on the energy axis.
                             </doc>
                         </field>
                     </group>
                 </group>
-                <field name="total_area" recommended="true">
+                <field name="total_area" type="NX_NUMBER" recommended="true">
                     <doc>
                         Total area under the peak after background removal.
                         

--- a/contributed_definitions/NXxps.nxdl.xml
+++ b/contributed_definitions/NXxps.nxdl.xml
@@ -493,7 +493,7 @@
                         </field>
                     </group>
                 </group>
-                <field name="total_area" type="NX_NUMBER" recommended="true">
+                <field name="total_area" type="NX_NUMBER" recommended="true" units="NX_ANY">
                     <doc>
                         Total area under the peak after background removal.
                         

--- a/contributed_definitions/nyaml/NXmpes.yaml
+++ b/contributed_definitions/nyaml/NXmpes.yaml
@@ -725,6 +725,7 @@ NXmpes(NXobject):
           (NXpid_controller):
             exists: recommended
             setpoint(NX_FLOAT):
+              unit: NX_TEMPERATURE
               exists: recommended
         cryostat(NXactuator):
           exists: optional
@@ -736,6 +737,7 @@ NXmpes(NXobject):
             exists: optional
           (NXpid_controller):
             setpoint(NX_FLOAT):
+              unit: NX_TEMPERATURE
               exists: recommended
         drain_current_ammeter(NXsensor):
           exists: optional
@@ -766,6 +768,7 @@ NXmpes(NXobject):
           (NXpid_controller):
             exists: recommended
             setpoint(NX_FLOAT):
+              unit: NX_VOLTAGE
               exists: recommended
         device_information(NXfabrication):
           exists: recommended
@@ -1348,7 +1351,7 @@ NXmpes(NXobject):
           /entry/sample/temperature_env/temperature_sensor/value.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# bd7fa22fcfb5693a5ba2e94dd5775ca6da5c32500bc56e83602d78071a375c14
+# 7c34196f8e8a73fe65cfb354066eb77fa57d03b76ac2788ae4d5ce55a1286e38
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -2129,7 +2132,7 @@ NXmpes(NXobject):
 #                     <field name="type" optional="true"/>
 #                     <field name="output_heater_power" type="NX_FLOAT" recommended="true"/>
 #                     <group type="NXpid_controller" recommended="true">
-#                         <field name="setpoint" type="NX_FLOAT" recommended="true"/>
+#                         <field name="setpoint" type="NX_FLOAT" units="NX_TEMPERATURE" recommended="true"/>
 #                     </group>
 #                 </group>
 #                 <group name="cryostat" type="NXactuator" optional="true">
@@ -2141,7 +2144,7 @@ NXmpes(NXobject):
 #                     </field>
 #                     <field name="type" optional="true"/>
 #                     <group type="NXpid_controller">
-#                         <field name="setpoint" type="NX_FLOAT" recommended="true"/>
+#                         <field name="setpoint" type="NX_FLOAT" units="NX_TEMPERATURE" recommended="true"/>
 #                     </group>
 #                 </group>
 #                 <group name="drain_current_ammeter" type="NXsensor" optional="true">
@@ -2173,7 +2176,7 @@ NXmpes(NXobject):
 #                     </field>
 #                     <field name="type" optional="true"/>
 #                     <group type="NXpid_controller" recommended="true">
-#                         <field name="setpoint" type="NX_FLOAT" recommended="true"/>
+#                         <field name="setpoint" type="NX_FLOAT" units="NX_VOLTAGE" recommended="true"/>
 #                     </group>
 #                 </group>
 #                 <group name="device_information" type="NXfabrication" recommended="true">

--- a/contributed_definitions/nyaml/NXmpes.yaml
+++ b/contributed_definitions/nyaml/NXmpes.yaml
@@ -295,7 +295,7 @@ NXmpes(NXobject):
           
           This is the beam that is used to facilitate the photoemission during MPES
           experiments.
-        distance(NX_NUMBER):
+        distance(NX_FLOAT):
           unit: NX_LENGTH
           exists: recommended
           doc: |
@@ -331,7 +331,7 @@ NXmpes(NXobject):
           In pump-probe experiments, this is the beam that excites the system,
           initiating a change in its state. It sets the timing for the experiment
           by defining time zero in a pump-probe setup.
-        distance(NX_NUMBER):
+        distance(NX_FLOAT):
           unit: NX_LENGTH
           exists: recommended
           doc: |
@@ -371,7 +371,7 @@ NXmpes(NXobject):
           
           Should be named with the same appendix as ``source_TYPE``, e.g.,
           for ``source_laser`` it should refer to ``beam_laser``.
-        distance(NX_NUMBER):
+        distance(NX_FLOAT):
           unit: NX_LENGTH
           exists: recommended
           doc: |
@@ -1348,7 +1348,7 @@ NXmpes(NXobject):
           /entry/sample/temperature_env/temperature_sensor/value.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 88d317acf7147547240cd21103c9d3daf77064f06099e055232cdbb4ff234d66
+# bd7fa22fcfb5693a5ba2e94dd5775ca6da5c32500bc56e83602d78071a375c14
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -1690,7 +1690,7 @@ NXmpes(NXobject):
 #                     This is the beam that is used to facilitate the photoemission during MPES
 #                     experiments.
 #                 </doc>
-#                 <field name="distance" type="NX_NUMBER" units="NX_LENGTH" recommended="true">
+#                 <field name="distance" type="NX_FLOAT" units="NX_LENGTH" recommended="true">
 #                     <doc>
 #                         Distance between the point where the current NXbeam instance is evaluating
 #                         the beam properties and the point where the beam interacts with the sample.
@@ -1722,7 +1722,7 @@ NXmpes(NXobject):
 #                     initiating a change in its state. It sets the timing for the experiment
 #                     by defining time zero in a pump-probe setup.
 #                 </doc>
-#                 <field name="distance" type="NX_NUMBER" units="NX_LENGTH" recommended="true">
+#                 <field name="distance" type="NX_FLOAT" units="NX_LENGTH" recommended="true">
 #                     <doc>
 #                         Distance between the point where the current NXbeam instance is evaluating
 #                         the beam properties and the point where the beam interacts with the sample.
@@ -1757,7 +1757,7 @@ NXmpes(NXobject):
 #                     Should be named with the same appendix as ``source_TYPE``, e.g.,
 #                     for ``source_laser`` it should refer to ``beam_laser``.
 #                 </doc>
-#                 <field name="distance" type="NX_NUMBER" units="NX_LENGTH" recommended="true">
+#                 <field name="distance" type="NX_FLOAT" units="NX_LENGTH" recommended="true">
 #                     <doc>
 #                         Distance between the point where the current NXbeam instance is evaluating
 #                         the beam properties and the point where the beam interacts with the sample.

--- a/contributed_definitions/nyaml/NXxps.yaml
+++ b/contributed_definitions/nyaml/NXxps.yaml
@@ -369,12 +369,12 @@ NXxps(NXmpes):
             exists: recommended
           fit_parameters(NXparameters):
             exists: recommended
-            area:
+            area(NX_NUMBER):
               unit: NX_ANY
               exists: optional
               doc: |
                 Area of the peak.
-            width:
+            width(NX_NUMBER):
               unit: NX_ENERGY
               exists: optional
               doc:
@@ -389,12 +389,12 @@ NXxps(NXmpes):
                   spec: ISO 18115-1:2023
                   term: 3.28
                   url: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:3.28
-            position:
+            position(NX_NUMBER):
               unit: NX_ENERGY
               exists: optional
               doc: |
                 Position of the peak on the energy axis.
-        total_area:
+        total_area(NX_NUMBER):
           exists: recommended
           doc:
           - |
@@ -595,7 +595,7 @@ NXxps(NXmpes):
       \@energy_indices(NX_INT):
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# fa4095b9097645b7f1cf98d3cb14dc0e4ec2f77332c137b1860db8bfa809d2fa
+# ab500ee8ab11d5698d9abd94d07337929b5888eaae549ada8c01dbf64029de8c
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -1066,12 +1066,12 @@ NXxps(NXmpes):
 #                     </field>
 #                     <field name="formula_description" recommended="true"/>
 #                     <group name="fit_parameters" type="NXparameters" recommended="true">
-#                         <field name="area" units="NX_ANY" optional="true">
+#                         <field name="area" type="NX_NUMBER" units="NX_ANY" optional="true">
 #                             <doc>
 #                                 Area of the peak.
 #                             </doc>
 #                         </field>
-#                         <field name="width" units="NX_ENERGY" optional="true">
+#                         <field name="width" type="NX_NUMBER" units="NX_ENERGY" optional="true">
 #                             <doc>
 #                                 Width of a peak at a defined fraction of the peak height.
 #                                 
@@ -1084,14 +1084,14 @@ NXxps(NXmpes):
 #                                 .. _3.28: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:3.28
 #                             </doc>
 #                         </field>
-#                         <field name="position" units="NX_ENERGY" optional="true">
+#                         <field name="position" type="NX_NUMBER" units="NX_ENERGY" optional="true">
 #                             <doc>
 #                                 Position of the peak on the energy axis.
 #                             </doc>
 #                         </field>
 #                     </group>
 #                 </group>
-#                 <field name="total_area" recommended="true">
+#                 <field name="total_area" type="NX_NUMBER" recommended="true">
 #                     <doc>
 #                         Total area under the peak after background removal.
 #                         

--- a/contributed_definitions/nyaml/NXxps.yaml
+++ b/contributed_definitions/nyaml/NXxps.yaml
@@ -396,6 +396,7 @@ NXxps(NXmpes):
                 Position of the peak on the energy axis.
         total_area(NX_NUMBER):
           exists: recommended
+          unit: NX_ANY
           doc:
           - |
             Total area under the peak after background removal.
@@ -595,7 +596,7 @@ NXxps(NXmpes):
       \@energy_indices(NX_INT):
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# ab500ee8ab11d5698d9abd94d07337929b5888eaae549ada8c01dbf64029de8c
+# ec0a086f689254d9eef6fd2f4c8568dde398b28d7907c6566aae7bbfedca38e9
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -1091,7 +1092,7 @@ NXxps(NXmpes):
 #                         </field>
 #                     </group>
 #                 </group>
-#                 <field name="total_area" type="NX_NUMBER" recommended="true">
+#                 <field name="total_area" type="NX_NUMBER" recommended="true" units="NX_ANY">
 #                     <doc>
 #                         Total area under the peak after background removal.
 #                         


### PR DESCRIPTION
When starting to build sibling inheritance in the NexusTree of pynxtools, I found these small inconsistencies where fields in MPES-related appdefs had mismatches to the same fields defined in base classes or in the MPES application definition.

## Summary by Sourcery

Fix field type and unit inconsistencies in MPES and XPS NeXus definitions

Bug Fixes:
- Correct field types from NX_NUMBER to NX_FLOAT for distance fields
- Add missing type specifications for numeric fields in XPS fit parameters

Enhancements:
- Standardize field types for various measurements in MPES and XPS definitions
- Add missing units to setpoint and other fields in MPES and XPS definitions