### PR TITLE
Calibration time -> recommended.

### DIFF
--- a/.github/workflows/fairmat-build-pages.yaml
+++ b/.github/workflows/fairmat-build-pages.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   pages:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v2

--- a/contributed_definitions/NXsensor_scan.nxdl.xml
+++ b/contributed_definitions/NXsensor_scan.nxdl.xml
@@ -196,7 +196,7 @@
                             </doc>
                         </attribute>
                     </field>
-                    <field name="calibration_time" type="NX_DATE_TIME">
+                    <field name="calibration_time" type="NX_DATE_TIME" recommended="true">
                         <doc>
                             ISO8601 datum when calibration was last performed
                             before this measurement. UTC offset should be specified.

--- a/contributed_definitions/nyaml/NXsensor_scan.yaml
+++ b/contributed_definitions/nyaml/NXsensor_scan.yaml
@@ -146,6 +146,7 @@ NXsensor_scan(NXobject):
                 sweep using the built-in functionality of the controller device,
                 or a set/wait/read/repeat mechanism.
           calibration_time(NX_DATE_TIME):
+            exists: recommended
             doc: |
               ISO8601 datum when calibration was last performed
               before this measurement. UTC offset should be specified.
@@ -170,7 +171,7 @@ NXsensor_scan(NXobject):
         Plot of every measured signal as a function of the timestamp of when they have been acquired is also possible.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# b45cfc509c33838a3bf54cdcff33f1cdf4b0816fa2be7f20270e8b8465263142
+# bd6ca9b7323b38206d9706fb50a8333b64eb1d9c2a3007744ca3b241198663bb
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -369,7 +370,7 @@ NXsensor_scan(NXobject):
 #                             </doc>
 #                         </attribute>
 #                     </field>
-#                     <field name="calibration_time" type="NX_DATE_TIME">
+#                     <field name="calibration_time" type="NX_DATE_TIME" recommended="true">
 #                         <doc>
 #                             ISO8601 datum when calibration was last performed
 #                             before this measurement. UTC offset should be specified.


### PR DESCRIPTION
@GinzburgLev, here is the change, please have a look.

## Summary by Sourcery

Enhancements:
- Change the calibration_time field to be recommended instead of required in the NeXus sensor scan definition files