### PR TITLE
rename `target` field in `NXspindispersion`

### DIFF
--- a/contributed_definitions/NXspindispersion.nxdl.xml
+++ b/contributed_definitions/NXspindispersion.nxdl.xml
@@ -50,7 +50,7 @@
             Angle of the spin-selective scattering
         </doc>
     </field>
-    <field name="target" type="NX_CHAR">
+    <field name="target_name" type="NX_CHAR">
         <doc>
             Name of the target
         </doc>

--- a/contributed_definitions/NXspindispersion.nxdl.xml
+++ b/contributed_definitions/NXspindispersion.nxdl.xml
@@ -67,7 +67,6 @@
                 Preparation procedure of the spin target
             </doc>
         </group>
-
     </group>
     <group type="NXdeflector">
         <doc>

--- a/contributed_definitions/NXspindispersion.nxdl.xml
+++ b/contributed_definitions/NXspindispersion.nxdl.xml
@@ -50,21 +50,25 @@
             Angle of the spin-selective scattering
         </doc>
     </field>
-    <field name="target_name" type="NX_CHAR">
+    <field name="scattering_target" type="NX_CHAR">
         <doc>
             Name of the target
         </doc>
     </field>
-    <field name="target_preparation" type="NX_CHAR">
+    <group name="scattering_target_history" type="NXhistory">
         <doc>
-            Preparation procedure of the spin target
+            A set of activities that occurred to the ``scattering_target`` prior to/during the.
+            experiment. For exmaple, this group can be used to describe the preparation of the
+            scattering_target
+            experiment, e.g. the cleaning procedure for a spin filter crystal.
         </doc>
-    </field>
-    <field name="target_preparation_date" type="NX_DATE_TIME">
-        <doc>
-            Date of last preparation of the spin target
-        </doc>
-    </field>
+        <group name="preparation" type="NXactivity">
+            <doc>
+                Preparation procedure of the spin target
+            </doc>
+        </group>
+
+    </group>
     <group type="NXdeflector">
         <doc>
             Deflectors in the spin dispersive section

--- a/contributed_definitions/NXspindispersion.nxdl.xml
+++ b/contributed_definitions/NXspindispersion.nxdl.xml
@@ -58,9 +58,8 @@
     <group name="scattering_target_history" type="NXhistory">
         <doc>
             A set of activities that occurred to the ``scattering_target`` prior to/during the.
-            experiment. For exmaple, this group can be used to describe the preparation of the
-            scattering_target
-            experiment, e.g. the cleaning procedure for a spin filter crystal.
+            experiment. For example, this group can be used to describe the preparation of the
+            ``scattering_target``.
         </doc>
         <group name="preparation" type="NXactivity">
             <doc>

--- a/contributed_definitions/nyaml/NXspindispersion.yaml
+++ b/contributed_definitions/nyaml/NXspindispersion.yaml
@@ -22,7 +22,7 @@ NXspindispersion(NXcomponent):
     unit: NX_ANGLE
     doc: |
       Angle of the spin-selective scattering
-  target(NX_CHAR):
+  target_name(NX_CHAR):
     doc: |
       Name of the target
   target_preparation(NX_CHAR):
@@ -39,7 +39,7 @@ NXspindispersion(NXcomponent):
       Individual lenses in the spin dispersive section
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# d52d393ebd50f966bcfc14dd617dbb594cb71eefb5393c95a1e48cd033c5f499
+# 4e732d9cbc2f88b0adf440d0bd13cbca0d33a91933f45452dd313b5e6137f043
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -92,7 +92,7 @@ NXspindispersion(NXcomponent):
 #             Angle of the spin-selective scattering
 #         </doc>
 #     </field>
-#     <field name="target" type="NX_CHAR">
+#     <field name="target_name" type="NX_CHAR">
 #         <doc>
 #             Name of the target
 #         </doc>

--- a/contributed_definitions/nyaml/NXspindispersion.yaml
+++ b/contributed_definitions/nyaml/NXspindispersion.yaml
@@ -112,7 +112,6 @@ NXspindispersion(NXcomponent):
 #                 Preparation procedure of the spin target
 #             </doc>
 #         </group>
-# 
 #     </group>
 #     <group type="NXdeflector">
 #         <doc>

--- a/contributed_definitions/nyaml/NXspindispersion.yaml
+++ b/contributed_definitions/nyaml/NXspindispersion.yaml
@@ -22,15 +22,18 @@ NXspindispersion(NXcomponent):
     unit: NX_ANGLE
     doc: |
       Angle of the spin-selective scattering
-  target_name(NX_CHAR):
+  scattering_target(NX_CHAR):
     doc: |
       Name of the target
-  target_preparation(NX_CHAR):
+  scattering_target_history(NXhistory):
     doc: |
-      Preparation procedure of the spin target
-  target_preparation_date(NX_DATE_TIME):
-    doc: |
-      Date of last preparation of the spin target
+      A set of activities that occurred to the ``scattering_target`` prior to/during the.
+      experiment. For exmaple, this group can be used to describe the preparation of the
+      scattering_target
+      experiment, e.g. the cleaning procedure for a spin filter crystal.
+    preparation(NXactivity):
+      doc: |
+        Preparation procedure of the spin target
   (NXdeflector):
     doc: |
       Deflectors in the spin dispersive section
@@ -39,7 +42,7 @@ NXspindispersion(NXcomponent):
       Individual lenses in the spin dispersive section
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 4e732d9cbc2f88b0adf440d0bd13cbca0d33a91933f45452dd313b5e6137f043
+# 07fd051208ca9885e643c9dba6fcbbda656e1fb2dde5f069d9e6f682dedecd01
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -92,21 +95,25 @@ NXspindispersion(NXcomponent):
 #             Angle of the spin-selective scattering
 #         </doc>
 #     </field>
-#     <field name="target_name" type="NX_CHAR">
+#     <field name="scattering_target" type="NX_CHAR">
 #         <doc>
 #             Name of the target
 #         </doc>
 #     </field>
-#     <field name="target_preparation" type="NX_CHAR">
+#     <group name="scattering_target_history" type="NXhistory">
 #         <doc>
-#             Preparation procedure of the spin target
+#             A set of activities that occurred to the ``scattering_target`` prior to/during the.
+#             experiment. For exmaple, this group can be used to describe the preparation of the
+#             scattering_target
+#             experiment, e.g. the cleaning procedure for a spin filter crystal.
 #         </doc>
-#     </field>
-#     <field name="target_preparation_date" type="NX_DATE_TIME">
-#         <doc>
-#             Date of last preparation of the spin target
-#         </doc>
-#     </field>
+#         <group name="preparation" type="NXactivity">
+#             <doc>
+#                 Preparation procedure of the spin target
+#             </doc>
+#         </group>
+# 
+#     </group>
 #     <group type="NXdeflector">
 #         <doc>
 #             Deflectors in the spin dispersive section

--- a/contributed_definitions/nyaml/NXspindispersion.yaml
+++ b/contributed_definitions/nyaml/NXspindispersion.yaml
@@ -28,9 +28,8 @@ NXspindispersion(NXcomponent):
   scattering_target_history(NXhistory):
     doc: |
       A set of activities that occurred to the ``scattering_target`` prior to/during the.
-      experiment. For exmaple, this group can be used to describe the preparation of the
-      scattering_target
-      experiment, e.g. the cleaning procedure for a spin filter crystal.
+      experiment. For example, this group can be used to describe the preparation of the
+      ``scattering_target``.
     preparation(NXactivity):
       doc: |
         Preparation procedure of the spin target
@@ -42,7 +41,7 @@ NXspindispersion(NXcomponent):
       Individual lenses in the spin dispersive section
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 07fd051208ca9885e643c9dba6fcbbda656e1fb2dde5f069d9e6f682dedecd01
+# 30aac623f8f9603313b7688145c7d9063847baf5df564687ec4f064fb6871395
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -103,9 +102,8 @@ NXspindispersion(NXcomponent):
 #     <group name="scattering_target_history" type="NXhistory">
 #         <doc>
 #             A set of activities that occurred to the ``scattering_target`` prior to/during the.
-#             experiment. For exmaple, this group can be used to describe the preparation of the
-#             scattering_target
-#             experiment, e.g. the cleaning procedure for a spin filter crystal.
+#             experiment. For example, this group can be used to describe the preparation of the
+#             ``scattering_target``.
 #         </doc>
 #         <group name="preparation" type="NXactivity">
 #             <doc>


### PR DESCRIPTION
@rettigl considering that the `@target` attribute can be added everywhere, it probably makes sense to rename this field to avoid name clashes.

## Summary by Sourcery

Enhancements:
- Renamed the field to provide a more explicit and unique name to prevent potential naming conflicts