### PR TITLE
Consider multiple scans on the same confined phase space.

### DIFF
--- a/contributed_definitions/NXscan_control.nxdl.xml
+++ b/contributed_definitions/NXscan_control.nxdl.xml
@@ -89,54 +89,14 @@
             <item value="oscillating"/>
         </enumeration>
     </field>
-    <group name="scan_region" type="NXobject">
+    <group name="scan_region" type="NXscan_region">
         <doc>
             The scan region is the area of phase space or sub-phase space where the scan is
             performed. The region could be N-dimensional and is defined by the minimum and
             maximum values of the scan axes.
         </doc>
-        <field name="scan_offset_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
-            <doc>
-                The offset of center of the scan region from the origin along the specific scan axis.
-                
-                'N' denotes the name of the specific scan axis. (Offset, start and end positions are related)
-            </doc>
-        </field>
-        <field name="scan_range_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
-            <doc>
-                The range of the scan is the difference start and end values of the scan region
-                along the dimension 'N'.
-            </doc>
-        </field>
-        <field name="scan_angle_N" type="NX_NUMBER" nameType="partial" units="NX_ANGLE">
-            <doc>
-                The orientation of the scan region or subspace. Usually, the scan_offset and scan_range are enough
-                to define the scan region. This field defines how the spatial space is oriented with respect to
-                the frame of reference.
-                
-                Rename the field describing the angle with an axis of the spatial space (e.g. scan_angle_x).
-            </doc>
-        </field>
-        <field name="scan_start_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
-            <doc>
-                The start of the scan is the starting point of the scan region (phase space or sub-phase space)
-                for each independent scan axis.
-                
-                For N-dimensional, it is a list of N numbers.
-            </doc>
-        </field>
-        <field name="scan_end_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
-            <doc>
-                The end of the scan is the ending point of the scan region (phase space or sub-phase space)
-                for each independent scan axis.
-                
-                Note: The scan_offset and scan_range are equivalent to the scan_start and scan_end.
-                
-                For N-dimensional, it is a list of N numbers.
-            </doc>
-        </field>
     </group>
-    <group name="mesh_SCAN" type="NXobject" nameType="partial">
+    <group name="mesh_SCAN" type="NXscan_pattern" nameType="partial">
         <doc>
             For each dimension a range and a direction are chosen. When a scan along a dimension is done,
             a single step in the next dimension is taken, and then the scan in the previous dimension is
@@ -164,73 +124,8 @@
                 Rename the field, according to the name of the dimension.
             </doc>
         </field>
-        <field name="channel_NAME" nameType="partial">
-            <doc>
-                Name of the channel that records the scan data for the given dimension. The ending annotation 'N' is
-                to represent the name of the dimensions.
-                
-                Rename the field, according to the name of the channel and dimension (e.g. piezo_scanner_x).
-            </doc>
-        </field>
-        <field name="scan_points_N" type="NX_NUMBER" nameType="partial">
-            <doc>
-                Define the total number of points in the given axis scan to be performed.
-                
-                Rename the field, according to the name of the dimension (e.g. scan_points_x, scan_points_voltage).
-            </doc>
-        </field>
-        <field name="stepping_N" type="NX_NUMBER" nameType="partial">
-            <doc>
-                The number of steps the probe jumps over the scan steps or points. This describes when not
-                every point from the scan_points is measured along an axis.
-                
-                Rename the field, according to the name of the dimension (e.g. stepping_x, stepping_voltage).
-            </doc>
-            <attribute name="frog_leap_scan" type="NX_BOOLEAN">
-                <doc>
-                    If the scan probe jumps over a number of scan steps or points (more than one)
-                    to perform each scan. By default, it is False.
-                </doc>
-            </attribute>
-        </field>
-        <field name="step_size_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
-            <doc>
-                The length of each step in the scan on each dimension.
-                
-                Rename the field, according to the name of the dimension (e.g. step_size_x, step_size_voltage).
-            </doc>
-        </field>
-        <field name="continuous_N" type="NX_BOOLEAN" nameType="partial">
-            <doc>
-                If the scan probe moves continuously over the scan points or steps, use True. The default value is True.
-                Usually, continuous scanning is possible in one dimension. On other dimensions, the scan probe moves
-                in steps.
-                
-                Rename the field, according to the name of the dimension (e.g. continuous_voltage).
-            </doc>
-        </field>
-        <field name="oscillating_N" type="NX_BOOLEAN" nameType="partial">
-            <doc>
-                If the scan probe oscillates over the scan point, use True.
-                The default value is False.
-            </doc>
-        </field>
-        <field name="oscillation_frequency" type="NX_NUMBER">
-            <doc>
-                The number of oscillations on each scanning point per second.
-            </doc>
-        </field>
-        <group name="SCAN_data" type="NXdata" nameType="partial">
-            <field name="DATA" type="NX_NUMBER" units="NX_ANY">
-                <doc>
-                    The scan data is the data collected during the scan.
-                    If the scan has several channels or derivatives from the channel data, please
-                    duplicate this NXdata group for each.
-                </doc>
-            </field>
-        </group>
     </group>
-    <group name="spiral_SCAN" type="NXobject" nameType="partial">
+    <group name="spiral_SCAN" type="NXscan_pattern" nameType="partial">
         <doc>
             To define the spiral or circular scan, use this group.
         </doc>
@@ -277,72 +172,8 @@
                 Rename the field, according to the circle order, the nearest circle to the center is 0.
             </doc>
         </field>
-        <field name="scan_points_N" type="NX_NUMBER" nameType="partial">
-            <doc>
-                Define the total number of points in a given circle scan to be performed.
-                
-                Rename the field, according to the circle order, the nearest circle to the center
-                is 0 (e.g. scan_points_2).
-            </doc>
-        </field>
-        <field name="stepping_N" type="NX_NUMBER" nameType="partial">
-            <doc>
-                If the scan probe steps over a number of scan points.
-                
-                Rename the field, according to the circle index. The circle near the center starts with 0.
-                In case, the stepping is the same for all the circles, replace 'N' by 'all'.
-            </doc>
-            <attribute name="frog_leap_scan" type="NX_BOOLEAN">
-                <doc>
-                    If the scan probe jumps over a number of scan steps or points (more than one), use True.
-                    The default value is False.
-                </doc>
-            </attribute>
-        </field>
-        <field name="step_size_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
-            <doc>
-                Define the number of points that the scan probe steps over.
-                
-                Rename the field, according to the circle index. The circle near the center or lowest value of a
-                parameter starts with 0.
-                In case, the step size is the same for all the circles, replace 'N' by 'all'.
-            </doc>
-        </field>
-        <field name="continuous_N" type="NX_BOOLEAN" nameType="partial">
-            <doc>
-                If the scan probe moves continuously over the scan points, use True. The default value is True.
-                A scan process can run continuously in the spatial dimension but can be discretized in time or
-                other physical dimensions (e.g. voltage).
-                
-                Rename this field according to the dimensions, considering continuous scan in a two-dimensional space
-                rename the field as continuous_x_y.
-            </doc>
-        </field>
-        <field name="oscillating_N" type="NX_BOOLEAN" nameType="partial">
-            <doc>
-                If the scan probe oscillates over the scan point, use True. The default value is
-                False.
-            </doc>
-        </field>
-        <field name="oscillation_frequency" type="NX_NUMBER" units="NX_FREQUENCY">
-            <doc>
-                Number of oscillation on each scanning point per second.
-            </doc>
-        </field>
-        <group name="SCAN_data" type="NXdata" nameType="partial">
-            <doc>
-                The scan data is the data collected during the scan.
-                If the scan has several channels or derivatives from the channel data, please
-                duplicate this NXdata group for each.
-            </doc>
-            <field name="DATA" type="NX_NUMBER" units="NX_ANY">
-                <doc>
-                    The scan data is the data collected during the scan.
-                </doc>
-            </field>
-        </group>
     </group>
-    <group name="snake_SCAN" type="NXobject" nameType="partial">
+    <group name="snake_SCAN" type="NXscan_pattern" nameType="partial">
         <doc>
             To define the snake scan, use this group.
         </doc>
@@ -368,77 +199,8 @@
                 Rename the field, according to the name of the fast axis.
             </doc>
         </field>
-        <field name="scan_points_N" type="NX_NUMBER" nameType="partial">
-            <doc>
-                Define the total number of points in the given axis scan to be performed.
-                
-                Rename the field, according to the name of the dimension (e.g. scan_points_x, scan_points_voltage).
-            </doc>
-        </field>
-        <field name="stepping_N" type="NX_NUMBER" nameType="partial">
-            <doc>
-                The number of steps the probe jumps over the scan steps or points.
-                
-                Rename the field, according to the name of the dimension (e.g. stepping_x, stepping_voltage).
-            </doc>
-            <attribute name="frog_leap_scan" type="NX_BOOLEAN">
-                <doc>
-                    If the scan probe jumps over a number of scan steps or points (more than one)
-                    to perform each scan. By default, it is False.
-                    
-                    Rename the field, according to the name of the dimension.
-                </doc>
-            </attribute>
-        </field>
-        <field name="step_size_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
-            <doc>
-                The length of each step in the scan on each dimension.
-                
-                Rename the field, according to the name of the dimension (e.g. step_size_x, step_size_voltage).
-            </doc>
-        </field>
-        <field name="channel_NAME" nameType="partial">
-            <doc>
-                Name of the channel that records the scan data for the given dimension. The ending annotation 'N' is
-                to represent the name of the dimensions.
-                
-                Rename the field, according to the name of the channel and dimension (e.g. piezo_scanner_x).
-            </doc>
-        </field>
-        <field name="continuous_N" type="NX_BOOLEAN" nameType="partial">
-            <doc>
-                If the scan probe moves continuously over the scan points or steps, use True. The default value is True.
-                Usually, continuous scanning is possible in one dimension. On other dimensions, the scan probe moves
-                in a stepping manner.
-                
-                Rename the field, according to the name of the dimension (e.g. continuous_voltage).
-            </doc>
-        </field>
-        <field name="oscillating_N" type="NX_BOOLEAN" nameType="partial">
-            <doc>
-                If the scan probe oscillates over the scan point, use True.
-                The default value is False.
-            </doc>
-        </field>
-        <field name="oscillation_frequency" type="NX_NUMBER" units="NX_FREQUENCY">
-            <doc>
-                The number of oscillations on each scanning point per second.
-            </doc>
-        </field>
-        <group name="SCAN_data" type="NXdata" nameType="partial">
-            <doc>
-                The scan data is the data collected during the scan.
-                If the scan has several channels or derivatives from the channel data, please
-                duplicate this NXdata group for each.
-            </doc>
-            <field name="DATA" type="NX_NUMBER" units="NX_ANY">
-                <doc>
-                    The scan data is the data collected during the scan.
-                </doc>
-            </field>
-        </group>
     </group>
-    <group name="traj_SCAN" type="NXobject" nameType="partial">
+    <group name="traj_SCAN" type="NXscan_pattern" nameType="partial">
         <doc>
             To define the trajectory scan, use this group.
         </doc>
@@ -459,14 +221,6 @@
                 through the trajectory points.
             </doc>
         </field>
-        <field name="channel_NAME" nameType="partial">
-            <doc>
-                Name of the channel that records the scan data for the given dimension. The ending annotation 'N' is
-                to represent the name of the dimensions.
-                
-                Rename the field, according to the name of the channel and dimension (e.g. piezo_scanner_x).
-            </doc>
-        </field>
         <field name="number_of_trajectory_points" type="NX_NUMBER">
             <doc>
                 The number of trajectory points in the entire scan.
@@ -484,64 +238,8 @@
                 <dim index="2" value="nD"/>
             </dimensions>
         </field>
-        <field name="scan_points_N" type="NX_NUMBER" nameType="partial">
-            <doc>
-                Define the total number of scan points between two trajectory points.
-                
-                Rename the field, according to the index of the second trajectory points.
-                For example, scan_points_1 is the number of points between the starting(zero) and first trajectory points.
-            </doc>
-        </field>
-        <field name="stepping_N" type="NX_NUMBER" nameType="partial">
-            <doc>
-                The number of steps the probe jumps over the scan steps or points along the trajectory line from between two trajectory points.
-                
-                Rename the field, according to the index of the second trajectory points.
-                For example, scan_points_1 is the number of points between the starting(zero) and first trajectory points.
-            </doc>
-            <attribute name="frog_leap_scan" type="NX_BOOLEAN">
-                <doc>
-                    If the scan probe jumps over a number of scan steps or points (more than one)
-                    to perform each scan. By default, it is False.
-                </doc>
-            </attribute>
-        </field>
-        <field name="step_size" type="NX_NUMBER" units="NX_ANY">
-            <doc>
-                The length of each step along the entire trajectory line.
-            </doc>
-        </field>
-        <field name="continuous" type="NX_BOOLEAN">
-            <doc>
-                If the scan probe moves continuously over the scan points or steps between two
-                trajectory points, use True. The default value is True.
-            </doc>
-        </field>
-        <field name="oscillating_N" type="NX_BOOLEAN" nameType="partial">
-            <doc>
-                If the scan probe oscillates over the scan point, use True.
-                The default value is False.
-            </doc>
-        </field>
-        <field name="oscillation_frequency" type="NX_NUMBER" units="NX_FREQUENCY">
-            <doc>
-                The number of oscillations on each scanning point per second.
-            </doc>
-        </field>
-        <group name="SCAN_data" type="NXdata" nameType="partial">
-            <doc>
-                The scan data is the data collected during the scan.
-                If the scan has several channels or derivatives from the channel data, please
-                duplicate this NXdata group for each.
-            </doc>
-            <field name="DATA" type="NX_NUMBER" units="NX_ANY">
-                <doc>
-                    The scan data is the data collected during the scan.
-                </doc>
-            </field>
-        </group>
     </group>
-    <group name="linear_SCAN" type="NXobject" nameType="partial">
+    <group name="linear_SCAN" type="NXscan_pattern" nameType="partial">
         <doc>
             Define the scan mode that is performed for a single independent data axis.
         </doc>
@@ -561,69 +259,5 @@
                 Define the scan speed in the backward directions.
             </doc>
         </field>
-        <field name="channel_NAME" type="NX_CHAR" nameType="partial">
-            <doc>
-                Name of the channel that records the scan data for the given dimension.
-            </doc>
-        </field>
-        <field name="scan_points_N" type="NX_NUMBER" nameType="partial">
-            <doc>
-                Define the total number of points in the given axis scan to be performed.
-                
-                Rename the field, according to the name of the dimension (e.g. scan_points_x, scan_points_voltage).
-            </doc>
-        </field>
-        <field name="stepping_N" type="NX_NUMBER" nameType="partial">
-            <doc>
-                The number of steps the probe jumps over the scan steps or points.
-                
-                Rename the field, according to the name of the dimension (e.g. stepping_x, stepping_voltage).
-            </doc>
-            <attribute name="frog_leap_scan" type="NX_BOOLEAN">
-                <doc>
-                    If the scan probe jumps over a number of scan steps or points (more than one)
-                    to perform each scan. By default, it is False.
-                </doc>
-            </attribute>
-        </field>
-        <field name="step_size_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
-            <doc>
-                The length of each step in the scan on each dimension.
-                
-                Rename the field, according to the name of the dimension (e.g. step_size_x, step_size_voltage).
-            </doc>
-        </field>
-        <field name="continuous_N" type="NX_BOOLEAN" nameType="partial">
-            <doc>
-                If the scan probe moves continuously over the scan points or steps, use True. The default value is True.
-                Usually, continuous scanning is possible in one dimension. On other dimensions, the scan probe moves
-                in a stepping manner.
-                
-                Rename the field, according to the name of the dimension (e.g. continuous_voltage).
-            </doc>
-        </field>
-        <field name="oscillating_N" type="NX_BOOLEAN" nameType="partial">
-            <doc>
-                If the scan probe oscillates over the scan point, use True.
-                The default value is False.
-            </doc>
-        </field>
-        <field name="oscillation_frequency" type="NX_NUMBER" units="NX_FREQUENCY">
-            <doc>
-                The number of oscillations on each scanning point per second.
-            </doc>
-        </field>
-        <group name="SCAN_data" type="NXdata" nameType="partial">
-            <doc>
-                The scan data is the data collected during the scan.
-                If the scan has several channels or derivatives from the channel data, please
-                duplicate this NXdata group for each.
-            </doc>
-            <field name="DATA" type="NX_NUMBER" units="NX_ANY">
-                <doc>
-                    The scan data is the data collected during the scan.
-                </doc>
-            </field>
-        </group>
     </group>
 </definition>

--- a/contributed_definitions/NXscan_pattern.nxdl.xml
+++ b/contributed_definitions/NXscan_pattern.nxdl.xml
@@ -30,13 +30,18 @@
         <doc>
             Define the scan speed in the different directions (e.g. forward or backward) along the axis.
             
-            Rename the field, according to the name of the dimension or direction (e.g. forward_speed_x, 
+            Rename the field, according to the name of the dimension or direction (e.g. forward_speed_x,
             forward_speed_y).
         </doc>
     </field>
     <field name="repeats" type="NX_BOOLEAN">
         <doc>
             If scan repeats over the same scan region, use True, else False by default.
+        </doc>
+    </field>
+    <field name="total_repetitions" type="NX_NUMBER">
+        <doc>
+            The total number of repetitions of the scan over the same scan region.
         </doc>
     </field>
     <field name="scan_order" type="NX_CHAR_OR_NUMBER">

--- a/contributed_definitions/NXscan_pattern.nxdl.xml
+++ b/contributed_definitions/NXscan_pattern.nxdl.xml
@@ -1,0 +1,127 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+<!--
+# NeXus - Neutron and X-ray Common Data Format
+#
+# Copyright (C) 2025-2025 NeXus International Advisory Committee (NIAC)
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# For further information, see http://www.nexusformat.org
+-->
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXscan_pattern" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+    <doc>
+        This base class handles the scan pattern describing the movement of the probe
+        in the confined phase space.
+    </doc>
+    <field name="SPEED" type="NX_NUMBER" nameType="partial" units="NX_ANY">
+        <doc>
+            Define the scan speed in the different directions (e.g. forward or backward) along the axis.
+            
+            Rename the field, according to the name of the dimension or direction (e.g. forward_speed_x, 
+            forward_speed_y).
+        </doc>
+    </field>
+    <field name="repeats" type="NX_BOOLEAN">
+        <doc>
+            If scan repeats over the same scan region, use True, else False by default.
+        </doc>
+    </field>
+    <field name="scan_order" type="NX_CHAR_OR_NUMBER">
+        <doc>
+            On the same scan region a scan can be repeated over several times and the mesh scan group
+            needs to be initialized multiple times with an specific scan order (e.g. A, B, ...,
+            First, Second ...) which will be considered as a tag to each scan.
+        </doc>
+    </field>
+    <group name="NOTE" type="NXnote" nameType="any">
+        <doc>
+            Takes note for individual scan or scan_order.
+        </doc>
+        <field name="description" type="NX_CHAR">
+            <doc>
+                The note, comment or description of the corresponding scan or scan_oder.
+            </doc>
+        </field>
+    </group>
+    <field name="channel_NAME" nameType="partial">
+        <doc>
+            Name of the channel that records the scan data for the given dimension. The ending annotation 'N' is
+            to represent the name of the dimensions.
+            
+            Rename the field, according to the name of the channel and dimension (e.g. piezo_scanner_x).
+        </doc>
+    </field>
+    <field name="scan_points_N" type="NX_NUMBER" nameType="partial">
+        <doc>
+            Define the total number of points in the given axis scan to be performed.
+            
+            Rename the field, according to the name of the dimension (e.g. scan_points_x, scan_points_voltage).
+        </doc>
+    </field>
+    <field name="stepping_N" type="NX_NUMBER" nameType="partial">
+        <doc>
+            The number of steps the probe jumps over the scan steps or points. This describes when not
+            every point from the scan_points is measured along an axis.
+            
+            Rename the field, according to the name of the dimension (e.g. stepping_x, stepping_voltage).
+        </doc>
+        <attribute name="frog_leap_scan" type="NX_BOOLEAN">
+            <doc>
+                If the scan probe jumps over a number of scan steps or points (more than one)
+                to perform each scan. By default, it is False.
+            </doc>
+        </attribute>
+    </field>
+    <field name="step_size_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
+        <doc>
+            The length of each step in the scan on each dimension.
+            
+            Rename the field, according to the name of the dimension (e.g. step_size_x, step_size_voltage).
+        </doc>
+    </field>
+    <field name="continuous_N" type="NX_BOOLEAN" nameType="partial">
+        <doc>
+            If the scan probe moves continuously over the scan points or steps, use True. The default value is False.
+            Usually, continuous scanning is possible in one dimension. On other dimensions, the scan probe moves
+            in steps.
+            
+            Rename the field, according to the name of the dimension (e.g. continuous_voltage).
+        </doc>
+    </field>
+    <field name="oscillating_N" type="NX_BOOLEAN" nameType="partial">
+        <doc>
+            If the scan probe oscillates over the scan point, use True.
+            The default value is False.
+        </doc>
+    </field>
+    <field name="oscillation_frequency" type="NX_NUMBER">
+        <doc>
+            The number of oscillations on each scanning point per second.
+        </doc>
+    </field>
+    <group name="SCAN_data" type="NXdata" nameType="partial">
+        <doc>
+            The scan data is the data collected during the scan.
+            If the scan has several channels or derivatives from the channel data, please
+            duplicate this NXdata group for each.
+        </doc>
+        <field name="DATA" type="NX_NUMBER" units="NX_ANY">
+            <doc>
+                The scan data is the data collected during the scan.
+            </doc>
+        </field>
+    </group>
+</definition>

--- a/contributed_definitions/NXscan_pattern.nxdl.xml
+++ b/contributed_definitions/NXscan_pattern.nxdl.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format
@@ -42,6 +42,7 @@
     <field name="total_repetitions" type="NX_NUMBER">
         <doc>
             The total number of repetitions of the scan over the same scan region.
+            In that case, this base class will be duplicated for each repetition.
         </doc>
     </field>
     <field name="scan_order" type="NX_CHAR_OR_NUMBER">

--- a/contributed_definitions/NXscan_region.nxdl.xml
+++ b/contributed_definitions/NXscan_region.nxdl.xml
@@ -1,0 +1,70 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+<!--
+# NeXus - Neutron and X-ray Common Data Format
+#
+# Copyright (C) 2025-2025 NeXus International Advisory Committee (NIAC)
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# For further information, see http://www.nexusformat.org
+-->
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXscan_region" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+    <doc>
+        The scan region is the area of phase space or sub-phase space where the scan is
+        performed. The region could be N-dimensional and is defined by the minimum and
+        maximum values of the scan axes.
+    </doc>
+    <field name="scan_offset_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
+        <doc>
+            The offset of center of the scan region from the origin along the specific scan axis.
+            
+            'N' denotes the name of the specific scan axis. (Offset, start and end positions are related)
+        </doc>
+    </field>
+    <field name="scan_range_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
+        <doc>
+            The range of the scan is the difference start and end values of the scan region
+            along the dimension 'N'.
+        </doc>
+    </field>
+    <field name="scan_angle_N" type="NX_NUMBER" nameType="partial" units="NX_ANGLE">
+        <doc>
+            The orientation of the scan region or subspace. Usually, the scan_offset and scan_range are enough
+            to define the scan region. This field defines how the spatial space is oriented with respect to
+            the frame of reference.
+            
+            Rename the field describing the angle with an axis of the spatial space (e.g. scan_angle_x).
+        </doc>
+    </field>
+    <field name="scan_start_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
+        <doc>
+            The start of the scan is the starting point of the scan region (phase space or sub-phase space)
+            for each independent scan axis.
+            
+            For N-dimensional, it is a list of N numbers.
+        </doc>
+    </field>
+    <field name="scan_end_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
+        <doc>
+            The end of the scan is the ending point of the scan region (phase space or sub-phase space)
+            for each independent scan axis.
+            
+            Note: The scan_offset and scan_range are equivalent to the scan_start and scan_end.
+            
+            For N-dimensional, it is a list of N numbers.
+        </doc>
+    </field>
+</definition>

--- a/contributed_definitions/nyaml/NXscan_control.yaml
+++ b/contributed_definitions/nyaml/NXscan_control.yaml
@@ -50,52 +50,12 @@ NXscan_control(NXobject):
     doc: |
       This string describes how the scan was performed.
     enumeration: [stepping, continuous, oscillating]
-  scan_region(NXobject):
+  scan_region(NXscan_region):
     doc: |
       The scan region is the area of phase space or sub-phase space where the scan is
       performed. The region could be N-dimensional and is defined by the minimum and
       maximum values of the scan axes.
-    scan_offset_N(NX_NUMBER):
-      nameType: partial
-      unit: NX_ANY
-      doc: |
-        The offset of center of the scan region from the origin along the specific scan axis.
-        
-        'N' denotes the name of the specific scan axis. (Offset, start and end positions are related)
-    scan_range_N(NX_NUMBER):
-      nameType: partial
-      unit: NX_ANY
-      doc: |
-        The range of the scan is the difference start and end values of the scan region
-        along the dimension 'N'.
-    scan_angle_N(NX_NUMBER):
-      nameType: partial
-      unit: NX_ANGLE
-      doc: |
-        The orientation of the scan region or subspace. Usually, the scan_offset and scan_range are enough
-        to define the scan region. This field defines how the spatial space is oriented with respect to
-        the frame of reference.
-        
-        Rename the field describing the angle with an axis of the spatial space (e.g. scan_angle_x).
-    scan_start_N(NX_NUMBER):
-      nameType: partial
-      unit: NX_ANY
-      doc: |
-        The start of the scan is the starting point of the scan region (phase space or sub-phase space)
-        for each independent scan axis.
-        
-        For N-dimensional, it is a list of N numbers.
-    scan_end_N(NX_NUMBER):
-      nameType: partial
-      unit: NX_ANY
-      doc: |
-        The end of the scan is the ending point of the scan region (phase space or sub-phase space)
-        for each independent scan axis.
-        
-        Note: The scan_offset and scan_range are equivalent to the scan_start and scan_end.
-        
-        For N-dimensional, it is a list of N numbers.
-  mesh_SCAN(NXobject):
+  mesh_SCAN(NXscan_pattern):
     nameType: partial
     doc: |
       For each dimension a range and a direction are chosen. When a scan along a dimension is done,
@@ -123,62 +83,7 @@ NXscan_control(NXobject):
       doc: |
         Define the scan speed in the backward directions.
         Rename the field, according to the name of the dimension.
-    channel_NAME:
-      nameType: partial
-      doc: |
-        Name of the channel that records the scan data for the given dimension. The ending annotation 'N' is
-        to represent the name of the dimensions.
-        
-        Rename the field, according to the name of the channel and dimension (e.g. piezo_scanner_x).
-    scan_points_N(NX_NUMBER):
-      nameType: partial
-      doc: |
-        Define the total number of points in the given axis scan to be performed.
-        
-        Rename the field, according to the name of the dimension (e.g. scan_points_x, scan_points_voltage).
-    stepping_N(NX_NUMBER):
-      nameType: partial
-      doc: |
-        The number of steps the probe jumps over the scan steps or points. This describes when not
-        every point from the scan_points is measured along an axis.
-        
-        Rename the field, according to the name of the dimension (e.g. stepping_x, stepping_voltage).
-      \@frog_leap_scan(NX_BOOLEAN):
-        doc: |
-          If the scan probe jumps over a number of scan steps or points (more than one)
-          to perform each scan. By default, it is False.
-    step_size_N(NX_NUMBER):
-      nameType: partial
-      unit: NX_ANY
-      doc: |
-        The length of each step in the scan on each dimension.
-        
-        Rename the field, according to the name of the dimension (e.g. step_size_x, step_size_voltage).
-    continuous_N(NX_BOOLEAN):
-      nameType: partial
-      doc: |
-        If the scan probe moves continuously over the scan points or steps, use True. The default value is True.
-        Usually, continuous scanning is possible in one dimension. On other dimensions, the scan probe moves
-        in steps.
-        
-        Rename the field, according to the name of the dimension (e.g. continuous_voltage).
-    oscillating_N(NX_BOOLEAN):
-      nameType: partial
-      doc: |
-        If the scan probe oscillates over the scan point, use True.
-        The default value is False.
-    oscillation_frequency(NX_NUMBER):
-      doc: |
-        The number of oscillations on each scanning point per second.
-    SCAN_data(NXdata):
-      nameType: partial
-      DATA(NX_NUMBER):
-        unit: NX_ANY
-        doc: |
-          The scan data is the data collected during the scan.
-          If the scan has several channels or derivatives from the channel data, please
-          duplicate this NXdata group for each.
-  spiral_SCAN(NXobject):
+  spiral_SCAN(NXscan_pattern):
     nameType: partial
     doc: |
       To define the spiral or circular scan, use this group.
@@ -220,62 +125,7 @@ NXscan_control(NXobject):
         Define the radius of the spiral circle of scanning.
         
         Rename the field, according to the circle order, the nearest circle to the center is 0.
-    scan_points_N(NX_NUMBER):
-      nameType: partial
-      doc: |
-        Define the total number of points in a given circle scan to be performed.
-        
-        Rename the field, according to the circle order, the nearest circle to the center
-        is 0 (e.g. scan_points_2).
-    stepping_N(NX_NUMBER):
-      nameType: partial
-      doc: |
-        If the scan probe steps over a number of scan points.
-        
-        Rename the field, according to the circle index. The circle near the center starts with 0.
-        In case, the stepping is the same for all the circles, replace 'N' by 'all'.
-      \@frog_leap_scan(NX_BOOLEAN):
-        doc: |
-          If the scan probe jumps over a number of scan steps or points (more than one), use True.
-          The default value is False.
-    step_size_N(NX_NUMBER):
-      nameType: partial
-      unit: NX_ANY
-      doc: |
-        Define the number of points that the scan probe steps over.
-        
-        Rename the field, according to the circle index. The circle near the center or lowest value of a
-        parameter starts with 0.
-        In case, the step size is the same for all the circles, replace 'N' by 'all'.
-    continuous_N(NX_BOOLEAN):
-      nameType: partial
-      doc: |
-        If the scan probe moves continuously over the scan points, use True. The default value is True.
-        A scan process can run continuously in the spatial dimension but can be discretized in time or
-        other physical dimensions (e.g. voltage).
-        
-        Rename this field according to the dimensions, considering continuous scan in a two-dimensional space
-        rename the field as continuous_x_y.
-    oscillating_N(NX_BOOLEAN):
-      nameType: partial
-      doc: |
-        If the scan probe oscillates over the scan point, use True. The default value is
-        False.
-    oscillation_frequency(NX_NUMBER):
-      unit: NX_FREQUENCY
-      doc: |
-        Number of oscillation on each scanning point per second.
-    SCAN_data(NXdata):
-      nameType: partial
-      doc: |
-        The scan data is the data collected during the scan.
-        If the scan has several channels or derivatives from the channel data, please
-        duplicate this NXdata group for each.
-      DATA(NX_NUMBER):
-        unit: NX_ANY
-        doc: |
-          The scan data is the data collected during the scan.
-  snake_SCAN(NXobject):
+  snake_SCAN(NXscan_pattern):
     nameType: partial
     doc: |
       To define the snake scan, use this group.
@@ -299,66 +149,7 @@ NXscan_control(NXobject):
         The field defines the scan speed in the negative direction on the fast axis.
         
         Rename the field, according to the name of the fast axis.
-    scan_points_N(NX_NUMBER):
-      nameType: partial
-      doc: |
-        Define the total number of points in the given axis scan to be performed.
-        
-        Rename the field, according to the name of the dimension (e.g. scan_points_x, scan_points_voltage).
-    stepping_N(NX_NUMBER):
-      nameType: partial
-      doc: |
-        The number of steps the probe jumps over the scan steps or points.
-        
-        Rename the field, according to the name of the dimension (e.g. stepping_x, stepping_voltage).
-      \@frog_leap_scan(NX_BOOLEAN):
-        doc: |
-          If the scan probe jumps over a number of scan steps or points (more than one)
-          to perform each scan. By default, it is False.
-          
-          Rename the field, according to the name of the dimension.
-    step_size_N(NX_NUMBER):
-      nameType: partial
-      unit: NX_ANY
-      doc: |
-        The length of each step in the scan on each dimension.
-        
-        Rename the field, according to the name of the dimension (e.g. step_size_x, step_size_voltage).
-    channel_NAME:
-      nameType: partial
-      doc: |
-        Name of the channel that records the scan data for the given dimension. The ending annotation 'N' is
-        to represent the name of the dimensions.
-        
-        Rename the field, according to the name of the channel and dimension (e.g. piezo_scanner_x).
-    continuous_N(NX_BOOLEAN):
-      nameType: partial
-      doc: |
-        If the scan probe moves continuously over the scan points or steps, use True. The default value is True.
-        Usually, continuous scanning is possible in one dimension. On other dimensions, the scan probe moves
-        in a stepping manner.
-        
-        Rename the field, according to the name of the dimension (e.g. continuous_voltage).
-    oscillating_N(NX_BOOLEAN):
-      nameType: partial
-      doc: |
-        If the scan probe oscillates over the scan point, use True.
-        The default value is False.
-    oscillation_frequency(NX_NUMBER):
-      unit: NX_FREQUENCY
-      doc: |
-        The number of oscillations on each scanning point per second.
-    SCAN_data(NXdata):
-      nameType: partial
-      doc: |
-        The scan data is the data collected during the scan.
-        If the scan has several channels or derivatives from the channel data, please
-        duplicate this NXdata group for each.
-      DATA(NX_NUMBER):
-        unit: NX_ANY
-        doc: |
-          The scan data is the data collected during the scan.
-  traj_SCAN(NXobject):
+  traj_SCAN(NXscan_pattern):
     nameType: partial
     doc: |
       To define the trajectory scan, use this group.
@@ -376,13 +167,6 @@ NXscan_control(NXobject):
       doc: |
         The field defines the scan speed in the backward directions (backtracking)
         through the trajectory points.
-    channel_NAME:
-      nameType: partial
-      doc: |
-        Name of the channel that records the scan data for the given dimension. The ending annotation 'N' is
-        to represent the name of the dimensions.
-        
-        Rename the field, according to the name of the channel and dimension (e.g. piezo_scanner_x).
     number_of_trajectory_points(NX_NUMBER):
       doc: |
         The number of trajectory points in the entire scan.
@@ -395,52 +179,7 @@ NXscan_control(NXobject):
       dimensions:
         rank: 2
         dim: (nTraj, nD)
-    scan_points_N(NX_NUMBER):
-      nameType: partial
-      doc: |
-        Define the total number of scan points between two trajectory points.
-        
-        Rename the field, according to the index of the second trajectory points.
-        For example, scan_points_1 is the number of points between the starting(zero) and first trajectory points.
-    stepping_N(NX_NUMBER):
-      nameType: partial
-      doc: |
-        The number of steps the probe jumps over the scan steps or points along the trajectory line from between two trajectory points.
-        
-        Rename the field, according to the index of the second trajectory points.
-        For example, scan_points_1 is the number of points between the starting(zero) and first trajectory points.
-      \@frog_leap_scan(NX_BOOLEAN):
-        doc: |
-          If the scan probe jumps over a number of scan steps or points (more than one)
-          to perform each scan. By default, it is False.
-    step_size(NX_NUMBER):
-      unit: NX_ANY
-      doc: |
-        The length of each step along the entire trajectory line.
-    continuous(NX_BOOLEAN):
-      doc: |
-        If the scan probe moves continuously over the scan points or steps between two
-        trajectory points, use True. The default value is True.
-    oscillating_N(NX_BOOLEAN):
-      nameType: partial
-      doc: |
-        If the scan probe oscillates over the scan point, use True.
-        The default value is False.
-    oscillation_frequency(NX_NUMBER):
-      unit: NX_FREQUENCY
-      doc: |
-        The number of oscillations on each scanning point per second.
-    SCAN_data(NXdata):
-      nameType: partial
-      doc: |
-        The scan data is the data collected during the scan.
-        If the scan has several channels or derivatives from the channel data, please
-        duplicate this NXdata group for each.
-      DATA(NX_NUMBER):
-        unit: NX_ANY
-        doc: |
-          The scan data is the data collected during the scan.
-  linear_SCAN(NXobject):
+  linear_SCAN(NXscan_pattern):
     nameType: partial
     doc: |
       Define the scan mode that is performed for a single independent data axis.
@@ -457,63 +196,9 @@ NXscan_control(NXobject):
       unit: NX_ANY
       doc: |
         Define the scan speed in the backward directions.
-    channel_NAME(NX_CHAR):
-      nameType: partial
-      doc: |
-        Name of the channel that records the scan data for the given dimension.
-    scan_points_N(NX_NUMBER):
-      nameType: partial
-      doc: |
-        Define the total number of points in the given axis scan to be performed.
-        
-        Rename the field, according to the name of the dimension (e.g. scan_points_x, scan_points_voltage).
-    stepping_N(NX_NUMBER):
-      nameType: partial
-      doc: |
-        The number of steps the probe jumps over the scan steps or points.
-        
-        Rename the field, according to the name of the dimension (e.g. stepping_x, stepping_voltage).
-      \@frog_leap_scan(NX_BOOLEAN):
-        doc: |
-          If the scan probe jumps over a number of scan steps or points (more than one)
-          to perform each scan. By default, it is False.
-    step_size_N(NX_NUMBER):
-      nameType: partial
-      unit: NX_ANY
-      doc: |
-        The length of each step in the scan on each dimension.
-        
-        Rename the field, according to the name of the dimension (e.g. step_size_x, step_size_voltage).
-    continuous_N(NX_BOOLEAN):
-      nameType: partial
-      doc: |
-        If the scan probe moves continuously over the scan points or steps, use True. The default value is True.
-        Usually, continuous scanning is possible in one dimension. On other dimensions, the scan probe moves
-        in a stepping manner.
-        
-        Rename the field, according to the name of the dimension (e.g. continuous_voltage).
-    oscillating_N(NX_BOOLEAN):
-      nameType: partial
-      doc: |
-        If the scan probe oscillates over the scan point, use True.
-        The default value is False.
-    oscillation_frequency(NX_NUMBER):
-      unit: NX_FREQUENCY
-      doc: |
-        The number of oscillations on each scanning point per second.
-    SCAN_data(NXdata):
-      nameType: partial
-      doc: |
-        The scan data is the data collected during the scan.
-        If the scan has several channels or derivatives from the channel data, please
-        duplicate this NXdata group for each.
-      DATA(NX_NUMBER):
-        unit: NX_ANY
-        doc: |
-          The scan data is the data collected during the scan.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 5e415856e99e3a0c659457686cc1f98d94349f4043b28517e474ba23d19ffbe4
+# 0cfe43f93f049702bbba6f7cc31cab5b645ae1079f0c3eaa3f33b0235a42f652
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -605,54 +290,14 @@ NXscan_control(NXobject):
 #             <item value="oscillating"/>
 #         </enumeration>
 #     </field>
-#     <group name="scan_region" type="NXobject">
+#     <group name="scan_region" type="NXscan_region">
 #         <doc>
 #             The scan region is the area of phase space or sub-phase space where the scan is
 #             performed. The region could be N-dimensional and is defined by the minimum and
 #             maximum values of the scan axes.
 #         </doc>
-#         <field name="scan_offset_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
-#             <doc>
-#                 The offset of center of the scan region from the origin along the specific scan axis.
-#                 
-#                 'N' denotes the name of the specific scan axis. (Offset, start and end positions are related)
-#             </doc>
-#         </field>
-#         <field name="scan_range_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
-#             <doc>
-#                 The range of the scan is the difference start and end values of the scan region
-#                 along the dimension 'N'.
-#             </doc>
-#         </field>
-#         <field name="scan_angle_N" type="NX_NUMBER" nameType="partial" units="NX_ANGLE">
-#             <doc>
-#                 The orientation of the scan region or subspace. Usually, the scan_offset and scan_range are enough
-#                 to define the scan region. This field defines how the spatial space is oriented with respect to
-#                 the frame of reference.
-#                 
-#                 Rename the field describing the angle with an axis of the spatial space (e.g. scan_angle_x).
-#             </doc>
-#         </field>
-#         <field name="scan_start_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
-#             <doc>
-#                 The start of the scan is the starting point of the scan region (phase space or sub-phase space)
-#                 for each independent scan axis.
-#                 
-#                 For N-dimensional, it is a list of N numbers.
-#             </doc>
-#         </field>
-#         <field name="scan_end_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
-#             <doc>
-#                 The end of the scan is the ending point of the scan region (phase space or sub-phase space)
-#                 for each independent scan axis.
-#                 
-#                 Note: The scan_offset and scan_range are equivalent to the scan_start and scan_end.
-#                 
-#                 For N-dimensional, it is a list of N numbers.
-#             </doc>
-#         </field>
 #     </group>
-#     <group name="mesh_SCAN" type="NXobject" nameType="partial">
+#     <group name="mesh_SCAN" type="NXscan_pattern" nameType="partial">
 #         <doc>
 #             For each dimension a range and a direction are chosen. When a scan along a dimension is done,
 #             a single step in the next dimension is taken, and then the scan in the previous dimension is
@@ -680,73 +325,8 @@ NXscan_control(NXobject):
 #                 Rename the field, according to the name of the dimension.
 #             </doc>
 #         </field>
-#         <field name="channel_NAME" nameType="partial">
-#             <doc>
-#                 Name of the channel that records the scan data for the given dimension. The ending annotation 'N' is
-#                 to represent the name of the dimensions.
-#                 
-#                 Rename the field, according to the name of the channel and dimension (e.g. piezo_scanner_x).
-#             </doc>
-#         </field>
-#         <field name="scan_points_N" type="NX_NUMBER" nameType="partial">
-#             <doc>
-#                 Define the total number of points in the given axis scan to be performed.
-#                 
-#                 Rename the field, according to the name of the dimension (e.g. scan_points_x, scan_points_voltage).
-#             </doc>
-#         </field>
-#         <field name="stepping_N" type="NX_NUMBER" nameType="partial">
-#             <doc>
-#                 The number of steps the probe jumps over the scan steps or points. This describes when not
-#                 every point from the scan_points is measured along an axis.
-#                 
-#                 Rename the field, according to the name of the dimension (e.g. stepping_x, stepping_voltage).
-#             </doc>
-#             <attribute name="frog_leap_scan" type="NX_BOOLEAN">
-#                 <doc>
-#                     If the scan probe jumps over a number of scan steps or points (more than one)
-#                     to perform each scan. By default, it is False.
-#                 </doc>
-#             </attribute>
-#         </field>
-#         <field name="step_size_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
-#             <doc>
-#                 The length of each step in the scan on each dimension.
-#                 
-#                 Rename the field, according to the name of the dimension (e.g. step_size_x, step_size_voltage).
-#             </doc>
-#         </field>
-#         <field name="continuous_N" type="NX_BOOLEAN" nameType="partial">
-#             <doc>
-#                 If the scan probe moves continuously over the scan points or steps, use True. The default value is True.
-#                 Usually, continuous scanning is possible in one dimension. On other dimensions, the scan probe moves
-#                 in steps.
-#                 
-#                 Rename the field, according to the name of the dimension (e.g. continuous_voltage).
-#             </doc>
-#         </field>
-#         <field name="oscillating_N" type="NX_BOOLEAN" nameType="partial">
-#             <doc>
-#                 If the scan probe oscillates over the scan point, use True.
-#                 The default value is False.
-#             </doc>
-#         </field>
-#         <field name="oscillation_frequency" type="NX_NUMBER">
-#             <doc>
-#                 The number of oscillations on each scanning point per second.
-#             </doc>
-#         </field>
-#         <group name="SCAN_data" type="NXdata" nameType="partial">
-#             <field name="DATA" type="NX_NUMBER" units="NX_ANY">
-#                 <doc>
-#                     The scan data is the data collected during the scan.
-#                     If the scan has several channels or derivatives from the channel data, please
-#                     duplicate this NXdata group for each.
-#                 </doc>
-#             </field>
-#         </group>
 #     </group>
-#     <group name="spiral_SCAN" type="NXobject" nameType="partial">
+#     <group name="spiral_SCAN" type="NXscan_pattern" nameType="partial">
 #         <doc>
 #             To define the spiral or circular scan, use this group.
 #         </doc>
@@ -793,72 +373,8 @@ NXscan_control(NXobject):
 #                 Rename the field, according to the circle order, the nearest circle to the center is 0.
 #             </doc>
 #         </field>
-#         <field name="scan_points_N" type="NX_NUMBER" nameType="partial">
-#             <doc>
-#                 Define the total number of points in a given circle scan to be performed.
-#                 
-#                 Rename the field, according to the circle order, the nearest circle to the center
-#                 is 0 (e.g. scan_points_2).
-#             </doc>
-#         </field>
-#         <field name="stepping_N" type="NX_NUMBER" nameType="partial">
-#             <doc>
-#                 If the scan probe steps over a number of scan points.
-#                 
-#                 Rename the field, according to the circle index. The circle near the center starts with 0.
-#                 In case, the stepping is the same for all the circles, replace 'N' by 'all'.
-#             </doc>
-#             <attribute name="frog_leap_scan" type="NX_BOOLEAN">
-#                 <doc>
-#                     If the scan probe jumps over a number of scan steps or points (more than one), use True.
-#                     The default value is False.
-#                 </doc>
-#             </attribute>
-#         </field>
-#         <field name="step_size_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
-#             <doc>
-#                 Define the number of points that the scan probe steps over.
-#                 
-#                 Rename the field, according to the circle index. The circle near the center or lowest value of a
-#                 parameter starts with 0.
-#                 In case, the step size is the same for all the circles, replace 'N' by 'all'.
-#             </doc>
-#         </field>
-#         <field name="continuous_N" type="NX_BOOLEAN" nameType="partial">
-#             <doc>
-#                 If the scan probe moves continuously over the scan points, use True. The default value is True.
-#                 A scan process can run continuously in the spatial dimension but can be discretized in time or
-#                 other physical dimensions (e.g. voltage).
-#                 
-#                 Rename this field according to the dimensions, considering continuous scan in a two-dimensional space
-#                 rename the field as continuous_x_y.
-#             </doc>
-#         </field>
-#         <field name="oscillating_N" type="NX_BOOLEAN" nameType="partial">
-#             <doc>
-#                 If the scan probe oscillates over the scan point, use True. The default value is
-#                 False.
-#             </doc>
-#         </field>
-#         <field name="oscillation_frequency" type="NX_NUMBER" units="NX_FREQUENCY">
-#             <doc>
-#                 Number of oscillation on each scanning point per second.
-#             </doc>
-#         </field>
-#         <group name="SCAN_data" type="NXdata" nameType="partial">
-#             <doc>
-#                 The scan data is the data collected during the scan.
-#                 If the scan has several channels or derivatives from the channel data, please
-#                 duplicate this NXdata group for each.
-#             </doc>
-#             <field name="DATA" type="NX_NUMBER" units="NX_ANY">
-#                 <doc>
-#                     The scan data is the data collected during the scan.
-#                 </doc>
-#             </field>
-#         </group>
 #     </group>
-#     <group name="snake_SCAN" type="NXobject" nameType="partial">
+#     <group name="snake_SCAN" type="NXscan_pattern" nameType="partial">
 #         <doc>
 #             To define the snake scan, use this group.
 #         </doc>
@@ -884,77 +400,8 @@ NXscan_control(NXobject):
 #                 Rename the field, according to the name of the fast axis.
 #             </doc>
 #         </field>
-#         <field name="scan_points_N" type="NX_NUMBER" nameType="partial">
-#             <doc>
-#                 Define the total number of points in the given axis scan to be performed.
-#                 
-#                 Rename the field, according to the name of the dimension (e.g. scan_points_x, scan_points_voltage).
-#             </doc>
-#         </field>
-#         <field name="stepping_N" type="NX_NUMBER" nameType="partial">
-#             <doc>
-#                 The number of steps the probe jumps over the scan steps or points.
-#                 
-#                 Rename the field, according to the name of the dimension (e.g. stepping_x, stepping_voltage).
-#             </doc>
-#             <attribute name="frog_leap_scan" type="NX_BOOLEAN">
-#                 <doc>
-#                     If the scan probe jumps over a number of scan steps or points (more than one)
-#                     to perform each scan. By default, it is False.
-#                     
-#                     Rename the field, according to the name of the dimension.
-#                 </doc>
-#             </attribute>
-#         </field>
-#         <field name="step_size_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
-#             <doc>
-#                 The length of each step in the scan on each dimension.
-#                 
-#                 Rename the field, according to the name of the dimension (e.g. step_size_x, step_size_voltage).
-#             </doc>
-#         </field>
-#         <field name="channel_NAME" nameType="partial">
-#             <doc>
-#                 Name of the channel that records the scan data for the given dimension. The ending annotation 'N' is
-#                 to represent the name of the dimensions.
-#                 
-#                 Rename the field, according to the name of the channel and dimension (e.g. piezo_scanner_x).
-#             </doc>
-#         </field>
-#         <field name="continuous_N" type="NX_BOOLEAN" nameType="partial">
-#             <doc>
-#                 If the scan probe moves continuously over the scan points or steps, use True. The default value is True.
-#                 Usually, continuous scanning is possible in one dimension. On other dimensions, the scan probe moves
-#                 in a stepping manner.
-#                 
-#                 Rename the field, according to the name of the dimension (e.g. continuous_voltage).
-#             </doc>
-#         </field>
-#         <field name="oscillating_N" type="NX_BOOLEAN" nameType="partial">
-#             <doc>
-#                 If the scan probe oscillates over the scan point, use True.
-#                 The default value is False.
-#             </doc>
-#         </field>
-#         <field name="oscillation_frequency" type="NX_NUMBER" units="NX_FREQUENCY">
-#             <doc>
-#                 The number of oscillations on each scanning point per second.
-#             </doc>
-#         </field>
-#         <group name="SCAN_data" type="NXdata" nameType="partial">
-#             <doc>
-#                 The scan data is the data collected during the scan.
-#                 If the scan has several channels or derivatives from the channel data, please
-#                 duplicate this NXdata group for each.
-#             </doc>
-#             <field name="DATA" type="NX_NUMBER" units="NX_ANY">
-#                 <doc>
-#                     The scan data is the data collected during the scan.
-#                 </doc>
-#             </field>
-#         </group>
 #     </group>
-#     <group name="traj_SCAN" type="NXobject" nameType="partial">
+#     <group name="traj_SCAN" type="NXscan_pattern" nameType="partial">
 #         <doc>
 #             To define the trajectory scan, use this group.
 #         </doc>
@@ -975,14 +422,6 @@ NXscan_control(NXobject):
 #                 through the trajectory points.
 #             </doc>
 #         </field>
-#         <field name="channel_NAME" nameType="partial">
-#             <doc>
-#                 Name of the channel that records the scan data for the given dimension. The ending annotation 'N' is
-#                 to represent the name of the dimensions.
-#                 
-#                 Rename the field, according to the name of the channel and dimension (e.g. piezo_scanner_x).
-#             </doc>
-#         </field>
 #         <field name="number_of_trajectory_points" type="NX_NUMBER">
 #             <doc>
 #                 The number of trajectory points in the entire scan.
@@ -1000,64 +439,8 @@ NXscan_control(NXobject):
 #                 <dim index="2" value="nD"/>
 #             </dimensions>
 #         </field>
-#         <field name="scan_points_N" type="NX_NUMBER" nameType="partial">
-#             <doc>
-#                 Define the total number of scan points between two trajectory points.
-#                 
-#                 Rename the field, according to the index of the second trajectory points.
-#                 For example, scan_points_1 is the number of points between the starting(zero) and first trajectory points.
-#             </doc>
-#         </field>
-#         <field name="stepping_N" type="NX_NUMBER" nameType="partial">
-#             <doc>
-#                 The number of steps the probe jumps over the scan steps or points along the trajectory line from between two trajectory points.
-#                 
-#                 Rename the field, according to the index of the second trajectory points.
-#                 For example, scan_points_1 is the number of points between the starting(zero) and first trajectory points.
-#             </doc>
-#             <attribute name="frog_leap_scan" type="NX_BOOLEAN">
-#                 <doc>
-#                     If the scan probe jumps over a number of scan steps or points (more than one)
-#                     to perform each scan. By default, it is False.
-#                 </doc>
-#             </attribute>
-#         </field>
-#         <field name="step_size" type="NX_NUMBER" units="NX_ANY">
-#             <doc>
-#                 The length of each step along the entire trajectory line.
-#             </doc>
-#         </field>
-#         <field name="continuous" type="NX_BOOLEAN">
-#             <doc>
-#                 If the scan probe moves continuously over the scan points or steps between two
-#                 trajectory points, use True. The default value is True.
-#             </doc>
-#         </field>
-#         <field name="oscillating_N" type="NX_BOOLEAN" nameType="partial">
-#             <doc>
-#                 If the scan probe oscillates over the scan point, use True.
-#                 The default value is False.
-#             </doc>
-#         </field>
-#         <field name="oscillation_frequency" type="NX_NUMBER" units="NX_FREQUENCY">
-#             <doc>
-#                 The number of oscillations on each scanning point per second.
-#             </doc>
-#         </field>
-#         <group name="SCAN_data" type="NXdata" nameType="partial">
-#             <doc>
-#                 The scan data is the data collected during the scan.
-#                 If the scan has several channels or derivatives from the channel data, please
-#                 duplicate this NXdata group for each.
-#             </doc>
-#             <field name="DATA" type="NX_NUMBER" units="NX_ANY">
-#                 <doc>
-#                     The scan data is the data collected during the scan.
-#                 </doc>
-#             </field>
-#         </group>
 #     </group>
-#     <group name="linear_SCAN" type="NXobject" nameType="partial">
+#     <group name="linear_SCAN" type="NXscan_pattern" nameType="partial">
 #         <doc>
 #             Define the scan mode that is performed for a single independent data axis.
 #         </doc>
@@ -1077,69 +460,5 @@ NXscan_control(NXobject):
 #                 Define the scan speed in the backward directions.
 #             </doc>
 #         </field>
-#         <field name="channel_NAME" type="NX_CHAR" nameType="partial">
-#             <doc>
-#                 Name of the channel that records the scan data for the given dimension.
-#             </doc>
-#         </field>
-#         <field name="scan_points_N" type="NX_NUMBER" nameType="partial">
-#             <doc>
-#                 Define the total number of points in the given axis scan to be performed.
-#                 
-#                 Rename the field, according to the name of the dimension (e.g. scan_points_x, scan_points_voltage).
-#             </doc>
-#         </field>
-#         <field name="stepping_N" type="NX_NUMBER" nameType="partial">
-#             <doc>
-#                 The number of steps the probe jumps over the scan steps or points.
-#                 
-#                 Rename the field, according to the name of the dimension (e.g. stepping_x, stepping_voltage).
-#             </doc>
-#             <attribute name="frog_leap_scan" type="NX_BOOLEAN">
-#                 <doc>
-#                     If the scan probe jumps over a number of scan steps or points (more than one)
-#                     to perform each scan. By default, it is False.
-#                 </doc>
-#             </attribute>
-#         </field>
-#         <field name="step_size_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
-#             <doc>
-#                 The length of each step in the scan on each dimension.
-#                 
-#                 Rename the field, according to the name of the dimension (e.g. step_size_x, step_size_voltage).
-#             </doc>
-#         </field>
-#         <field name="continuous_N" type="NX_BOOLEAN" nameType="partial">
-#             <doc>
-#                 If the scan probe moves continuously over the scan points or steps, use True. The default value is True.
-#                 Usually, continuous scanning is possible in one dimension. On other dimensions, the scan probe moves
-#                 in a stepping manner.
-#                 
-#                 Rename the field, according to the name of the dimension (e.g. continuous_voltage).
-#             </doc>
-#         </field>
-#         <field name="oscillating_N" type="NX_BOOLEAN" nameType="partial">
-#             <doc>
-#                 If the scan probe oscillates over the scan point, use True.
-#                 The default value is False.
-#             </doc>
-#         </field>
-#         <field name="oscillation_frequency" type="NX_NUMBER" units="NX_FREQUENCY">
-#             <doc>
-#                 The number of oscillations on each scanning point per second.
-#             </doc>
-#         </field>
-#         <group name="SCAN_data" type="NXdata" nameType="partial">
-#             <doc>
-#                 The scan data is the data collected during the scan.
-#                 If the scan has several channels or derivatives from the channel data, please
-#                 duplicate this NXdata group for each.
-#             </doc>
-#             <field name="DATA" type="NX_NUMBER" units="NX_ANY">
-#                 <doc>
-#                     The scan data is the data collected during the scan.
-#                 </doc>
-#             </field>
-#         </group>
 #     </group>
 # </definition>

--- a/contributed_definitions/nyaml/NXscan_pattern.yaml
+++ b/contributed_definitions/nyaml/NXscan_pattern.yaml
@@ -1,0 +1,216 @@
+category: base
+doc: |
+  This base class handles the scan pattern describing the movement of the probe
+  in the confined phase space.
+type: group
+NXscan_pattern(NXobject):
+  SPEED(NX_NUMBER):
+    nameType: partial
+    unit: NX_ANY
+    doc: |
+      Define the scan speed in the different directions (e.g. forward or backward) along the axis.
+      
+      Rename the field, according to the name of the dimension or direction (e.g. forward_speed_x,
+      forward_speed_y).
+  repeats(NX_BOOLEAN):
+    doc: |
+      If scan repeats over the same scan region, use True, else False by default.
+  scan_order(NX_CHAR_OR_NUMBER):
+    doc: |
+      On the same scan region a scan can be repeated over several times and the mesh scan group
+      needs to be initialized multiple times with an specific scan order (e.g. A, B, ...,
+      First, Second ...) which will be considered as a tag to each scan.
+  NOTE(NXnote):
+    nameType: any
+    doc: |
+      Takes note for individual scan or scan_order.
+    description(NX_CHAR):
+      doc: |
+        The note, comment or description of the corresponding scan or scan_oder.
+  channel_NAME:
+    nameType: partial
+    doc: |
+      Name of the channel that records the scan data for the given dimension. The ending annotation 'N' is
+      to represent the name of the dimensions.
+      
+      Rename the field, according to the name of the channel and dimension (e.g. piezo_scanner_x).
+  scan_points_N(NX_NUMBER):
+    nameType: partial
+    doc: |
+      Define the total number of points in the given axis scan to be performed.
+      
+      Rename the field, according to the name of the dimension (e.g. scan_points_x, scan_points_voltage).
+  stepping_N(NX_NUMBER):
+    nameType: partial
+    doc: |
+      The number of steps the probe jumps over the scan steps or points. This describes when not
+      every point from the scan_points is measured along an axis.
+      
+      Rename the field, according to the name of the dimension (e.g. stepping_x, stepping_voltage).
+    \@frog_leap_scan(NX_BOOLEAN):
+      doc: |
+        If the scan probe jumps over a number of scan steps or points (more than one)
+        to perform each scan. By default, it is False.
+  step_size_N(NX_NUMBER):
+    nameType: partial
+    unit: NX_ANY
+    doc: |
+      The length of each step in the scan on each dimension.
+      
+      Rename the field, according to the name of the dimension (e.g. step_size_x, step_size_voltage).
+  continuous_N(NX_BOOLEAN):
+    nameType: partial
+    doc: |
+      If the scan probe moves continuously over the scan points or steps, use True. The default value is False.
+      Usually, continuous scanning is possible in one dimension. On other dimensions, the scan probe moves
+      in steps.
+      
+      Rename the field, according to the name of the dimension (e.g. continuous_voltage).
+  oscillating_N(NX_BOOLEAN):
+    nameType: partial
+    doc: |
+      If the scan probe oscillates over the scan point, use True.
+      The default value is False.
+  oscillation_frequency(NX_NUMBER):
+    doc: |
+      The number of oscillations on each scanning point per second.
+  SCAN_data(NXdata):
+    nameType: partial
+    doc: |
+      The scan data is the data collected during the scan.
+      If the scan has several channels or derivatives from the channel data, please
+      duplicate this NXdata group for each.
+    DATA(NX_NUMBER):
+      unit: NX_ANY
+      doc: |
+        The scan data is the data collected during the scan.
+
+# ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
+# d3c69715fcef0d61f4f387a90d1145230b6286ac7181cf312298422e98a57ef8
+# <?xml version='1.0' encoding='UTF-8'?>
+# <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+# <!--
+# # NeXus - Neutron and X-ray Common Data Format
+# #
+# # Copyright (C) 2025-2025 NeXus International Advisory Committee (NIAC)
+# #
+# # This library is free software; you can redistribute it and/or
+# # modify it under the terms of the GNU Lesser General Public
+# # License as published by the Free Software Foundation; either
+# # version 3 of the License, or (at your option) any later version.
+# #
+# # This library is distributed in the hope that it will be useful,
+# # but WITHOUT ANY WARRANTY; without even the implied warranty of
+# # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# # Lesser General Public License for more details.
+# #
+# # You should have received a copy of the GNU Lesser General Public
+# # License along with this library; if not, write to the Free Software
+# # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# #
+# # For further information, see http://www.nexusformat.org
+# -->
+# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXscan_pattern" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+#     <doc>
+#         This base class handles the scan pattern describing the movement of the probe
+#         in the confined phase space.
+#     </doc>
+#     <field name="SPEED" type="NX_NUMBER" nameType="partial" units="NX_ANY">
+#         <doc>
+#             Define the scan speed in the different directions (e.g. forward or backward) along the axis.
+#             
+#             Rename the field, according to the name of the dimension or direction (e.g. forward_speed_x, 
+#             forward_speed_y).
+#         </doc>
+#     </field>
+#     <field name="repeats" type="NX_BOOLEAN">
+#         <doc>
+#             If scan repeats over the same scan region, use True, else False by default.
+#         </doc>
+#     </field>
+#     <field name="scan_order" type="NX_CHAR_OR_NUMBER">
+#         <doc>
+#             On the same scan region a scan can be repeated over several times and the mesh scan group
+#             needs to be initialized multiple times with an specific scan order (e.g. A, B, ...,
+#             First, Second ...) which will be considered as a tag to each scan.
+#         </doc>
+#     </field>
+#     <group name="NOTE" type="NXnote" nameType="any">
+#         <doc>
+#             Takes note for individual scan or scan_order.
+#         </doc>
+#         <field name="description" type="NX_CHAR">
+#             <doc>
+#                 The note, comment or description of the corresponding scan or scan_oder.
+#             </doc>
+#         </field>
+#     </group>
+#     <field name="channel_NAME" nameType="partial">
+#         <doc>
+#             Name of the channel that records the scan data for the given dimension. The ending annotation 'N' is
+#             to represent the name of the dimensions.
+#             
+#             Rename the field, according to the name of the channel and dimension (e.g. piezo_scanner_x).
+#         </doc>
+#     </field>
+#     <field name="scan_points_N" type="NX_NUMBER" nameType="partial">
+#         <doc>
+#             Define the total number of points in the given axis scan to be performed.
+#             
+#             Rename the field, according to the name of the dimension (e.g. scan_points_x, scan_points_voltage).
+#         </doc>
+#     </field>
+#     <field name="stepping_N" type="NX_NUMBER" nameType="partial">
+#         <doc>
+#             The number of steps the probe jumps over the scan steps or points. This describes when not
+#             every point from the scan_points is measured along an axis.
+#             
+#             Rename the field, according to the name of the dimension (e.g. stepping_x, stepping_voltage).
+#         </doc>
+#         <attribute name="frog_leap_scan" type="NX_BOOLEAN">
+#             <doc>
+#                 If the scan probe jumps over a number of scan steps or points (more than one)
+#                 to perform each scan. By default, it is False.
+#             </doc>
+#         </attribute>
+#     </field>
+#     <field name="step_size_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
+#         <doc>
+#             The length of each step in the scan on each dimension.
+#             
+#             Rename the field, according to the name of the dimension (e.g. step_size_x, step_size_voltage).
+#         </doc>
+#     </field>
+#     <field name="continuous_N" type="NX_BOOLEAN" nameType="partial">
+#         <doc>
+#             If the scan probe moves continuously over the scan points or steps, use True. The default value is False.
+#             Usually, continuous scanning is possible in one dimension. On other dimensions, the scan probe moves
+#             in steps.
+#             
+#             Rename the field, according to the name of the dimension (e.g. continuous_voltage).
+#         </doc>
+#     </field>
+#     <field name="oscillating_N" type="NX_BOOLEAN" nameType="partial">
+#         <doc>
+#             If the scan probe oscillates over the scan point, use True.
+#             The default value is False.
+#         </doc>
+#     </field>
+#     <field name="oscillation_frequency" type="NX_NUMBER">
+#         <doc>
+#             The number of oscillations on each scanning point per second.
+#         </doc>
+#     </field>
+#     <group name="SCAN_data" type="NXdata" nameType="partial">
+#         <doc>
+#             The scan data is the data collected during the scan.
+#             If the scan has several channels or derivatives from the channel data, please
+#             duplicate this NXdata group for each.
+#         </doc>
+#         <field name="DATA" type="NX_NUMBER" units="NX_ANY">
+#             <doc>
+#                 The scan data is the data collected during the scan.
+#             </doc>
+#         </field>
+#     </group>
+# </definition>

--- a/contributed_definitions/nyaml/NXscan_pattern.yaml
+++ b/contributed_definitions/nyaml/NXscan_pattern.yaml
@@ -90,8 +90,8 @@ NXscan_pattern(NXobject):
         The scan data is the data collected during the scan.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 0c97e5b837956b48132ee203bc7a3f35380f47dcbd7068adf76441f382de30f0
-# <?xml version='1.0' encoding='UTF-8'?>
+# 02f0f36e5ef61f293ea3c61106ec6231a4eb1deeb608b827938a2dcbd89e2708
+# <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
 # # NeXus - Neutron and X-ray Common Data Format
@@ -135,6 +135,7 @@ NXscan_pattern(NXobject):
 #     <field name="total_repetitions" type="NX_NUMBER">
 #         <doc>
 #             The total number of repetitions of the scan over the same scan region.
+#             In that case, this base class will be duplicated for each repetition.
 #         </doc>
 #     </field>
 #     <field name="scan_order" type="NX_CHAR_OR_NUMBER">

--- a/contributed_definitions/nyaml/NXscan_pattern.yaml
+++ b/contributed_definitions/nyaml/NXscan_pattern.yaml
@@ -18,6 +18,7 @@ NXscan_pattern(NXobject):
   total_repetitions(NX_NUMBER):
     doc: |
       The total number of repetitions of the scan over the same scan region.
+      In that case, this base class will be duplicated for each repetition.
   scan_order(NX_CHAR_OR_NUMBER):
     doc: |
       On the same scan region a scan can be repeated over several times and the mesh scan group

--- a/contributed_definitions/nyaml/NXscan_pattern.yaml
+++ b/contributed_definitions/nyaml/NXscan_pattern.yaml
@@ -15,6 +15,9 @@ NXscan_pattern(NXobject):
   repeats(NX_BOOLEAN):
     doc: |
       If scan repeats over the same scan region, use True, else False by default.
+  total_repetitions(NX_NUMBER):
+    doc: |
+      The total number of repetitions of the scan over the same scan region.
   scan_order(NX_CHAR_OR_NUMBER):
     doc: |
       On the same scan region a scan can be repeated over several times and the mesh scan group
@@ -86,7 +89,7 @@ NXscan_pattern(NXobject):
         The scan data is the data collected during the scan.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# d3c69715fcef0d61f4f387a90d1145230b6286ac7181cf312298422e98a57ef8
+# 0c97e5b837956b48132ee203bc7a3f35380f47dcbd7068adf76441f382de30f0
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -119,13 +122,18 @@ NXscan_pattern(NXobject):
 #         <doc>
 #             Define the scan speed in the different directions (e.g. forward or backward) along the axis.
 #             
-#             Rename the field, according to the name of the dimension or direction (e.g. forward_speed_x, 
+#             Rename the field, according to the name of the dimension or direction (e.g. forward_speed_x,
 #             forward_speed_y).
 #         </doc>
 #     </field>
 #     <field name="repeats" type="NX_BOOLEAN">
 #         <doc>
 #             If scan repeats over the same scan region, use True, else False by default.
+#         </doc>
+#     </field>
+#     <field name="total_repetitions" type="NX_NUMBER">
+#         <doc>
+#             The total number of repetitions of the scan over the same scan region.
 #         </doc>
 #     </field>
 #     <field name="scan_order" type="NX_CHAR_OR_NUMBER">

--- a/contributed_definitions/nyaml/NXscan_region.yaml
+++ b/contributed_definitions/nyaml/NXscan_region.yaml
@@ -1,0 +1,120 @@
+category: base
+doc: |
+  The scan region is the area of phase space or sub-phase space where the scan is
+  performed. The region could be N-dimensional and is defined by the minimum and
+  maximum values of the scan axes.
+type: group
+NXscan_region(NXobject):
+  scan_offset_N(NX_NUMBER):
+    nameType: partial
+    unit: NX_ANY
+    doc: |
+      The offset of center of the scan region from the origin along the specific scan axis.
+      
+      'N' denotes the name of the specific scan axis. (Offset, start and end positions are related)
+  scan_range_N(NX_NUMBER):
+    nameType: partial
+    unit: NX_ANY
+    doc: |
+      The range of the scan is the difference start and end values of the scan region
+      along the dimension 'N'.
+  scan_angle_N(NX_NUMBER):
+    nameType: partial
+    unit: NX_ANGLE
+    doc: |
+      The orientation of the scan region or subspace. Usually, the scan_offset and scan_range are enough
+      to define the scan region. This field defines how the spatial space is oriented with respect to
+      the frame of reference.
+      
+      Rename the field describing the angle with an axis of the spatial space (e.g. scan_angle_x).
+  scan_start_N(NX_NUMBER):
+    nameType: partial
+    unit: NX_ANY
+    doc: |
+      The start of the scan is the starting point of the scan region (phase space or sub-phase space)
+      for each independent scan axis.
+      
+      For N-dimensional, it is a list of N numbers.
+  scan_end_N(NX_NUMBER):
+    nameType: partial
+    unit: NX_ANY
+    doc: |
+      The end of the scan is the ending point of the scan region (phase space or sub-phase space)
+      for each independent scan axis.
+      
+      Note: The scan_offset and scan_range are equivalent to the scan_start and scan_end.
+      
+      For N-dimensional, it is a list of N numbers.
+
+# ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
+# a0a23b6e845cc245aaf2e15c51f1d80eee57930e5ef98c9930a23cf3d8a9752d
+# <?xml version='1.0' encoding='UTF-8'?>
+# <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+# <!--
+# # NeXus - Neutron and X-ray Common Data Format
+# #
+# # Copyright (C) 2025-2025 NeXus International Advisory Committee (NIAC)
+# #
+# # This library is free software; you can redistribute it and/or
+# # modify it under the terms of the GNU Lesser General Public
+# # License as published by the Free Software Foundation; either
+# # version 3 of the License, or (at your option) any later version.
+# #
+# # This library is distributed in the hope that it will be useful,
+# # but WITHOUT ANY WARRANTY; without even the implied warranty of
+# # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# # Lesser General Public License for more details.
+# #
+# # You should have received a copy of the GNU Lesser General Public
+# # License along with this library; if not, write to the Free Software
+# # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# #
+# # For further information, see http://www.nexusformat.org
+# -->
+# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXscan_region" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+#     <doc>
+#         The scan region is the area of phase space or sub-phase space where the scan is
+#         performed. The region could be N-dimensional and is defined by the minimum and
+#         maximum values of the scan axes.
+#     </doc>
+#     <field name="scan_offset_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
+#         <doc>
+#             The offset of center of the scan region from the origin along the specific scan axis.
+#             
+#             'N' denotes the name of the specific scan axis. (Offset, start and end positions are related)
+#         </doc>
+#     </field>
+#     <field name="scan_range_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
+#         <doc>
+#             The range of the scan is the difference start and end values of the scan region
+#             along the dimension 'N'.
+#         </doc>
+#     </field>
+#     <field name="scan_angle_N" type="NX_NUMBER" nameType="partial" units="NX_ANGLE">
+#         <doc>
+#             The orientation of the scan region or subspace. Usually, the scan_offset and scan_range are enough
+#             to define the scan region. This field defines how the spatial space is oriented with respect to
+#             the frame of reference.
+#             
+#             Rename the field describing the angle with an axis of the spatial space (e.g. scan_angle_x).
+#         </doc>
+#     </field>
+#     <field name="scan_start_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
+#         <doc>
+#             The start of the scan is the starting point of the scan region (phase space or sub-phase space)
+#             for each independent scan axis.
+#             
+#             For N-dimensional, it is a list of N numbers.
+#         </doc>
+#     </field>
+#     <field name="scan_end_N" type="NX_NUMBER" nameType="partial" units="NX_ANY">
+#         <doc>
+#             The end of the scan is the ending point of the scan region (phase space or sub-phase space)
+#             for each independent scan axis.
+#             
+#             Note: The scan_offset and scan_range are equivalent to the scan_start and scan_end.
+#             
+#             For N-dimensional, it is a list of N numbers.
+#         </doc>
+#     </field>
+# </definition>


### PR DESCRIPTION
## Two new base claases:
1. `NXscan_region` -> Mainly all fields are from mesh_scan group of NXscan_control
2. `NXscan_pattern` -> Handles common fields from all types of scan patterns like `mesh_SCAN`, `snake_SCAN`, `spiral_SCAN`, and so on. 
3. Addition of some new fields considering multiple scans on the same region.

## Summary by Sourcery

Enhance the NXscan_control definition to support multiple scans on the same confined phase space by adding new fields for scan repetition and ordering.

New Features:
- Add support for repeated scans over the same scan region
- Introduce a scan order parameter to distinguish between multiple scans in the same region

Enhancements:
- Improve scan metadata by adding fields to track scan repetitions and ordering