### PR TITLE
remove `@reference` attribute from `NXxps`

### DIFF
--- a/contributed_definitions/NXxps.nxdl.xml
+++ b/contributed_definitions/NXxps.nxdl.xml
@@ -728,10 +728,8 @@
                 </field>
             </group>
         </group>
-        <group name="data" type="NXdata">
-            <field name="energy" type="NX_NUMBER">
-                <attribute name="reference" recommended="true"/>
-            </field>
+        <group type="NXdata">
+            <field name="energy" type="NX_NUMBER"/>
             <attribute name="energy_indices" type="NX_INT"/>
         </group>
     </group>

--- a/contributed_definitions/nyaml/NXxps.yaml
+++ b/contributed_definitions/nyaml/NXxps.yaml
@@ -591,14 +591,12 @@ NXxps(NXmpes):
           \@depends_on:
             doc: |
               This should point to the coordinate system defined in /entry/xps_coordinate_system.
-    data(NXdata):
+    (NXdata):
       energy(NX_NUMBER):
-        \@reference:
-          exists: recommended
       \@energy_indices(NX_INT):
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 2ba1c928d4f4a52655f7c8c8c536f37be97b3afc2546bfb3d9c7f4f8979b54df
+# 2ebcb98c8e539f321453d9a63c0fd5ff16e48abbcad0955c08c34f9143adba58
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -1329,10 +1327,8 @@ NXxps(NXmpes):
 #                 </field>
 #             </group>
 #         </group>
-#         <group name="data" type="NXdata">
-#             <field name="energy" type="NX_NUMBER">
-#                 <attribute name="reference" recommended="true"/>
-#             </field>
+#         <group type="NXdata">
+#             <field name="energy" type="NX_NUMBER"/>
 #             <attribute name="energy_indices" type="NX_INT"/>
 #         </group>
 #     </group>


### PR DESCRIPTION
@rettigl I found one more usage of the `@reference` attribute, which we wanted to remove for now, in the `NXxps` appdef. Also we had a named "data" group there vs. an unnamed one in `NXmpes`. I will talk to NIAC people how we can incorporate this change into the existing vote, usually just a tiny change related to inconsistencies can be put into the ongoing vote without any problems.

## Summary by Sourcery

Enhancements:
- Simplified the NXxps definition by removing the named 'data' group and the recommended 'reference' attribute