### PR TITLE
remove remaining reference attribute from `NXxps` and `NXmpes`

### DIFF
--- a/applications/NXmpes_arpes.nxdl.xml
+++ b/applications/NXmpes_arpes.nxdl.xml
@@ -340,7 +340,7 @@
                 </field>
             </group>
         </group>
-        <group name="data" type="NXdata">
+        <group type="NXdata">
             <attribute name="signal">
                 <doc>
                     There is a field named data that contains the signal.
@@ -366,50 +366,18 @@
                     Values on the energy axis. Could be linked from the respective ``@reference``
                     field.
                 </doc>
-                <attribute name="reference" recommended="true">
-                    <doc>
-                        Points to the path of a field defining the calibrated axis which the energy axis refers.
-                        
-                        For example:
-                          @reference: '/entry/instrument/detector/sensor_y' for a 2D detector
-                          @reference: '/entry/instrument/energydispersion/center_kinetic_energy' for a swept scan
-                          @reference: '/entry/process/calibration/energy_calibration/calibrated_axis' for a preprocessed axis.
-                    </doc>
-                </attribute>
             </field>
             <field name="angular0" type="NX_NUMBER" units="NX_ANGLE">
                 <doc>
                     Trace of the first angular axis. Could be linked from the respective
                     ``@reference`` field.
                 </doc>
-                <attribute name="reference" recommended="true">
-                    <doc>
-                        Points to the path of a field defining the calibrated axis which the ``angular0`` axis refers.
-                        
-                        For example:
-                          @reference: '/entry/sample/transformations/sample_tilt' for a manipulator angular scan
-                          @reference: '/entry/instrument/detector/sensor_x' for a 2D detector
-                          @reference: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
-                          @reference: '/entry/process/calibration/angular0_calibration/calibrated_axis' for a preprocessed axis.
-                    </doc>
-                </attribute>
             </field>
             <field name="angular1" type="NX_NUMBER" units="NX_ANGLE">
                 <doc>
                     Trace of the second axis. Could be linked from the respective ``@reference``
                     field.
                 </doc>
-                <attribute name="reference" recommended="true">
-                    <doc>
-                        Points to the path of a field defining the calibrated axis which the ``angular1`` axis refers.
-                        
-                        For example:
-                          @reference: '/entry/sample/transformations/sample_polar' for a manipulator angular scan
-                          @reference: '/entry/instrument/detector/sensor_y' for a 2D detector
-                          @reference: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
-                          @reference: '/entry/process/calibration/angular1_calibration/calibrated_axis' for a preprocessed axis.
-                    </doc>
-                </attribute>
             </field>
             <field name="data" type="NX_NUMBER" units="NX_ANY">
                 <doc>

--- a/applications/NXmpes_arpes.nxdl.xml
+++ b/applications/NXmpes_arpes.nxdl.xml
@@ -363,14 +363,12 @@
             <attribute name="angular1_indices" type="NX_INT"/>
             <field name="energy" type="NX_NUMBER" units="NX_ENERGY">
                 <doc>
-                    Values on the energy axis. Could be linked from the respective ``@reference``
-                    field.
+                    Values on the energy axis.
                 </doc>
             </field>
             <field name="angular0" type="NX_NUMBER" units="NX_ANGLE">
                 <doc>
-                    Trace of the first angular axis. Could be linked from the respective
-                    ``@reference`` field.
+                    Trace of the first angular axis.
                 </doc>
             </field>
             <field name="angular1" type="NX_NUMBER" units="NX_ANGLE">

--- a/applications/NXxps.nxdl.xml
+++ b/applications/NXxps.nxdl.xml
@@ -728,10 +728,8 @@
                 </field>
             </group>
         </group>
-        <group name="data" type="NXdata">
-            <field name="energy" type="NX_NUMBER">
-                <attribute name="reference" recommended="true"/>
-            </field>
+        <group type="NXdata">
+            <field name="energy" type="NX_NUMBER"/>
             <attribute name="energy_indices" type="NX_INT"/>
         </group>
     </group>


### PR DESCRIPTION
In https://github.com/nexusformat/definitions/pull/1424, following discussion in https://github.com/nexusformat/definitions/pull/1410, it was suggested that we remove the initially proposed `@reference` attribute in `NXdata`. Additionally, the reviewers suggested to not use a named `data(NXdata)` group, but rather go with an unnamed `NXdata` to enable multiple views on the data.

These two suggestions were implemented in https://github.com/nexusformat/definitions/pull/1424 for the application definition `NXmpes`, but not for the extending application definitions `NXxps` and `NXmpes_arpes`. This PR points to that branch and fixes these issues also in the extending application definitions.

cc @phyy-nx