### PR TITLE
remove `@reference` from `NXmpes_arpes` in `fairmat` branch

### DIFF
--- a/contributed_definitions/NXmpes_arpes.nxdl.xml
+++ b/contributed_definitions/NXmpes_arpes.nxdl.xml
@@ -340,7 +340,7 @@
                 </field>
             </group>
         </group>
-        <group name="data" type="NXdata">
+        <group type="NXdata">
             <attribute name="signal">
                 <doc>
                     There is a field named data that contains the signal.
@@ -366,50 +366,18 @@
                     Values on the energy axis. Could be linked from the respective ``@reference``
                     field.
                 </doc>
-                <attribute name="reference" recommended="true">
-                    <doc>
-                        Points to the path of a field defining the calibrated axis which the energy axis refers.
-                        
-                        For example:
-                          @reference: '/entry/instrument/detector/sensor_y' for a 2D detector
-                          @reference: '/entry/instrument/energydispersion/center_kinetic_energy' for a swept scan
-                          @reference: '/entry/process/calibration/energy_calibration/calibrated_axis' for a preprocessed axis.
-                    </doc>
-                </attribute>
             </field>
             <field name="angular0" type="NX_NUMBER" units="NX_ANGLE">
                 <doc>
                     Trace of the first angular axis. Could be linked from the respective
                     ``@reference`` field.
                 </doc>
-                <attribute name="reference" recommended="true">
-                    <doc>
-                        Points to the path of a field defining the calibrated axis which the ``angular0`` axis refers.
-                        
-                        For example:
-                          @reference: '/entry/sample/transformations/sample_tilt' for a manipulator angular scan
-                          @reference: '/entry/instrument/detector/sensor_x' for a 2D detector
-                          @reference: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
-                          @reference: '/entry/process/calibration/angular0_calibration/calibrated_axis' for a preprocessed axis.
-                    </doc>
-                </attribute>
             </field>
             <field name="angular1" type="NX_NUMBER" units="NX_ANGLE">
                 <doc>
                     Trace of the second axis. Could be linked from the respective ``@reference``
                     field.
                 </doc>
-                <attribute name="reference" recommended="true">
-                    <doc>
-                        Points to the path of a field defining the calibrated axis which the ``angular1`` axis refers.
-                        
-                        For example:
-                          @reference: '/entry/sample/transformations/sample_polar' for a manipulator angular scan
-                          @reference: '/entry/instrument/detector/sensor_y' for a 2D detector
-                          @reference: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
-                          @reference: '/entry/process/calibration/angular1_calibration/calibrated_axis' for a preprocessed axis.
-                    </doc>
-                </attribute>
             </field>
             <field name="data" type="NX_NUMBER" units="NX_ANY">
                 <doc>

--- a/contributed_definitions/nyaml/NXmpes_arpes.yaml
+++ b/contributed_definitions/nyaml/NXmpes_arpes.yaml
@@ -198,7 +198,7 @@ NXmpes_arpes(NXmpes):
             doc: |
               Path to a transformation that places the sample surface
               into the origin of the arpes_geometry coordinate system.
-    data(NXdata):
+    (NXdata):
       \@signal:
         doc: |
           There is a field named data that contains the signal.
@@ -216,45 +216,16 @@ NXmpes_arpes(NXmpes):
         doc: |
           Values on the energy axis. Could be linked from the respective ``@reference``
           field.
-        \@reference:
-          exists: recommended
-          doc: |
-            Points to the path of a field defining the calibrated axis which the energy axis refers.
-            
-            For example:
-              @reference: '/entry/instrument/detector/sensor_y' for a 2D detector
-              @reference: '/entry/instrument/energydispersion/center_kinetic_energy' for a swept scan
-              @reference: '/entry/process/calibration/energy_calibration/calibrated_axis' for a preprocessed axis.
       angular0(NX_NUMBER):
         unit: NX_ANGLE
         doc: |
           Trace of the first angular axis. Could be linked from the respective
           ``@reference`` field.
-        \@reference:
-          exists: recommended
-          doc: |
-            Points to the path of a field defining the calibrated axis which the ``angular0`` axis refers.
-            
-            For example:
-              @reference: '/entry/sample/transformations/sample_tilt' for a manipulator angular scan
-              @reference: '/entry/instrument/detector/sensor_x' for a 2D detector
-              @reference: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
-              @reference: '/entry/process/calibration/angular0_calibration/calibrated_axis' for a preprocessed axis.
       angular1(NX_NUMBER):
         unit: NX_ANGLE
         doc: |
           Trace of the second axis. Could be linked from the respective ``@reference``
           field.
-        \@reference:
-          exists: recommended
-          doc: |
-            Points to the path of a field defining the calibrated axis which the ``angular1`` axis refers.
-            
-            For example:
-              @reference: '/entry/sample/transformations/sample_polar' for a manipulator angular scan
-              @reference: '/entry/instrument/detector/sensor_y' for a 2D detector
-              @reference: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
-              @reference: '/entry/process/calibration/angular1_calibration/calibrated_axis' for a preprocessed axis.
       data(NX_NUMBER):
         unit: NX_ANY
         doc: |
@@ -263,7 +234,7 @@ NXmpes_arpes(NXmpes):
           should be linked to the actual encoder position in NXinstrument or calibrated axes in NXprocess.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# be205e74f9e24661f703d4e56a2b877d5d2122d28f387e75bd2518acb977f937
+# 26d8c817699ec26995fa2484483db96ce42253df7afb57c52bdcf6d5a7a6b730
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -606,7 +577,7 @@ NXmpes_arpes(NXmpes):
 #                 </field>
 #             </group>
 #         </group>
-#         <group name="data" type="NXdata">
+#         <group type="NXdata">
 #             <attribute name="signal">
 #                 <doc>
 #                     There is a field named data that contains the signal.
@@ -632,50 +603,18 @@ NXmpes_arpes(NXmpes):
 #                     Values on the energy axis. Could be linked from the respective ``@reference``
 #                     field.
 #                 </doc>
-#                 <attribute name="reference" recommended="true">
-#                     <doc>
-#                         Points to the path of a field defining the calibrated axis which the energy axis refers.
-#                         
-#                         For example:
-#                           @reference: '/entry/instrument/detector/sensor_y' for a 2D detector
-#                           @reference: '/entry/instrument/energydispersion/center_kinetic_energy' for a swept scan
-#                           @reference: '/entry/process/calibration/energy_calibration/calibrated_axis' for a preprocessed axis.
-#                     </doc>
-#                 </attribute>
 #             </field>
 #             <field name="angular0" type="NX_NUMBER" units="NX_ANGLE">
 #                 <doc>
 #                     Trace of the first angular axis. Could be linked from the respective
 #                     ``@reference`` field.
 #                 </doc>
-#                 <attribute name="reference" recommended="true">
-#                     <doc>
-#                         Points to the path of a field defining the calibrated axis which the ``angular0`` axis refers.
-#                         
-#                         For example:
-#                           @reference: '/entry/sample/transformations/sample_tilt' for a manipulator angular scan
-#                           @reference: '/entry/instrument/detector/sensor_x' for a 2D detector
-#                           @reference: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
-#                           @reference: '/entry/process/calibration/angular0_calibration/calibrated_axis' for a preprocessed axis.
-#                     </doc>
-#                 </attribute>
 #             </field>
 #             <field name="angular1" type="NX_NUMBER" units="NX_ANGLE">
 #                 <doc>
 #                     Trace of the second axis. Could be linked from the respective ``@reference``
 #                     field.
 #                 </doc>
-#                 <attribute name="reference" recommended="true">
-#                     <doc>
-#                         Points to the path of a field defining the calibrated axis which the ``angular1`` axis refers.
-#                         
-#                         For example:
-#                           @reference: '/entry/sample/transformations/sample_polar' for a manipulator angular scan
-#                           @reference: '/entry/instrument/detector/sensor_y' for a 2D detector
-#                           @reference: '/entry/instrument/collectioncolumn/deflector' for a deflector scan
-#                           @reference: '/entry/process/calibration/angular1_calibration/calibrated_axis' for a preprocessed axis.
-#                     </doc>
-#                 </attribute>
 #             </field>
 #             <field name="data" type="NX_NUMBER" units="NX_ANY">
 #                 <doc>


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Simplified the NXmpes_arpes definition by removing recommended reference attributes from energy, angular0, and angular1 fields