### PR TITLE
Write nameType for DATA field.

### DIFF
--- a/contributed_definitions/NXbias_spectroscopy.nxdl.xml
+++ b/contributed_definitions/NXbias_spectroscopy.nxdl.xml
@@ -108,7 +108,7 @@ each other (e.g. spiral)-->
         </field>
         <field name="sweep_number" type="NX_NUMBER">
             <doc>
-                The number of sweeps (a full scan from starting bias to end bias) 
+                The number of sweeps (a full scan from starting bias to end bias)
                 taken during the bias spectroscopy.
             </doc>
         </field>
@@ -209,7 +209,7 @@ each other (e.g. spiral)-->
                     value after the sweep is completed.
                 </doc>
             </field>
-            <group name="SCAN_data" type="NXdata" nameType="partial">
+            <group name="SCAN_DATA" type="NXdata" nameType="any">
                 <doc>
                     The scan data is the data collected during the scan.
                     If the scan has several channels or derivatives from the channel data,

--- a/contributed_definitions/NXbias_spectroscopy.nxdl.xml
+++ b/contributed_definitions/NXbias_spectroscopy.nxdl.xml
@@ -215,6 +215,16 @@ each other (e.g. spiral)-->
                     If the scan has several channels or derivatives from the channel data,
                     please duplicate this NXdata group for each.
                 </doc>
+                <field name="DATA" nameType="any" units="NX_ANY">
+                    <doc>
+                        The plottable data collected during the scan.
+                    </doc>
+                </field>
+                <field name="AXISNAME" nameType="any" units="NX_VOLTAGE">
+                    <doc>
+                        The voltage axis name of the data collected during the scan.
+                    </doc>
+                </field>
             </group>
         </group>
     </group>

--- a/contributed_definitions/NXscan_control.nxdl.xml
+++ b/contributed_definitions/NXscan_control.nxdl.xml
@@ -220,8 +220,8 @@
                 The number of oscillations on each scanning point per second.
             </doc>
         </field>
-        <group name="SCAN_data" type="NXdata" nameType="partial">
-            <field name="DATA" type="NX_NUMBER" units="NX_ANY">
+        <group name="SCAN_DATA" type="NXdata" nameType="any">
+            <field name="DATA" type="NX_NUMBER" nameType="any" units="NX_ANY">
                 <doc>
                     The scan data is the data collected during the scan.
                     If the scan has several channels or derivatives from the channel data, please
@@ -329,13 +329,13 @@
                 Number of oscillation on each scanning point per second.
             </doc>
         </field>
-        <group name="SCAN_data" type="NXdata" nameType="partial">
+        <group name="SCAN_DATA" type="NXdata" nameType="any">
             <doc>
                 The scan data is the data collected during the scan.
                 If the scan has several channels or derivatives from the channel data, please
                 duplicate this NXdata group for each.
             </doc>
-            <field name="DATA" type="NX_NUMBER" units="NX_ANY">
+            <field name="DATA" type="NX_NUMBER" nameType="any" units="NX_ANY">
                 <doc>
                     The scan data is the data collected during the scan.
                 </doc>
@@ -425,13 +425,13 @@
                 The number of oscillations on each scanning point per second.
             </doc>
         </field>
-        <group name="SCAN_data" type="NXdata" nameType="partial">
+        <group name="SCAN_DATA" type="NXdata" nameType="any">
             <doc>
                 The scan data is the data collected during the scan.
                 If the scan has several channels or derivatives from the channel data, please
                 duplicate this NXdata group for each.
             </doc>
-            <field name="DATA" type="NX_NUMBER" units="NX_ANY">
+            <field name="DATA" type="NX_NUMBER" nameType="any" units="NX_ANY">
                 <doc>
                     The scan data is the data collected during the scan.
                 </doc>
@@ -528,13 +528,13 @@
                 The number of oscillations on each scanning point per second.
             </doc>
         </field>
-        <group name="SCAN_data" type="NXdata" nameType="partial">
+        <group name="SCAN_DATA" type="NXdata" nameType="any">
             <doc>
                 The scan data is the data collected during the scan.
                 If the scan has several channels or derivatives from the channel data, please
                 duplicate this NXdata group for each.
             </doc>
-            <field name="DATA" type="NX_NUMBER" units="NX_ANY">
+            <field name="DATA" type="NX_NUMBER" nameType="any" units="NX_ANY">
                 <doc>
                     The scan data is the data collected during the scan.
                 </doc>
@@ -613,13 +613,13 @@
                 The number of oscillations on each scanning point per second.
             </doc>
         </field>
-        <group name="SCAN_data" type="NXdata" nameType="partial">
+        <group name="SCAN_DATA" type="NXdata" nameType="any">
             <doc>
                 The scan data is the data collected during the scan.
                 If the scan has several channels or derivatives from the channel data, please
                 duplicate this NXdata group for each.
             </doc>
-            <field name="DATA" type="NX_NUMBER" units="NX_ANY">
+            <field name="DATA" type="NX_NUMBER" nameType="any" units="NX_ANY">
                 <doc>
                     The scan data is the data collected during the scan.
                 </doc>

--- a/contributed_definitions/NXspm.nxdl.xml
+++ b/contributed_definitions/NXspm.nxdl.xml
@@ -596,7 +596,7 @@
             <doc>
                 The data group.
             </doc>
-            <field name="DATA" type="NX_NUMBER" units="NX_ANY">
+            <field name="DATA" type="NX_NUMBER" nameType="any" units="NX_ANY">
                 <doc>
                     The plot able data (e.g. current, voltage, temperature) field in against of the
                     axis.

--- a/contributed_definitions/nyaml/NXbias_spectroscopy.yaml
+++ b/contributed_definitions/nyaml/NXbias_spectroscopy.yaml
@@ -156,15 +156,15 @@ NXbias_spectroscopy(NXobject):
         doc: |
           The reset_bias defines whether the bias voltage should be reset to the starting
           value after the sweep is completed.
-      SCAN_data(NXdata):
-        nameType: partial
+      SCAN_DATA(NXdata):
+        nameType: any
         doc: |
           The scan data is the data collected during the scan.
           If the scan has several channels or derivatives from the channel data,
           please duplicate this NXdata group for each.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# a188255eb75a80c88990404bac985811eda905af9c2215bb65f15cda8d0ad2e1
+# acf75c279de793751a9dea7fdd407fba63bca10a9109ead9a444d602505e3c1d
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -275,7 +275,7 @@ NXbias_spectroscopy(NXobject):
 #         </field>
 #         <field name="sweep_number" type="NX_NUMBER">
 #             <doc>
-#                 The number of sweeps (a full scan from starting bias to end bias) 
+#                 The number of sweeps (a full scan from starting bias to end bias)
 #                 taken during the bias spectroscopy.
 #             </doc>
 #         </field>
@@ -376,7 +376,7 @@ NXbias_spectroscopy(NXobject):
 #                     value after the sweep is completed.
 #                 </doc>
 #             </field>
-#             <group name="SCAN_data" type="NXdata" nameType="partial">
+#             <group name="SCAN_DATA" type="NXdata" nameType="any">
 #                 <doc>
 #                     The scan data is the data collected during the scan.
 #                     If the scan has several channels or derivatives from the channel data,

--- a/contributed_definitions/nyaml/NXbias_spectroscopy.yaml
+++ b/contributed_definitions/nyaml/NXbias_spectroscopy.yaml
@@ -162,9 +162,19 @@ NXbias_spectroscopy(NXobject):
           The scan data is the data collected during the scan.
           If the scan has several channels or derivatives from the channel data,
           please duplicate this NXdata group for each.
+        DATA:
+          nameType: any
+          unit: NX_ANY
+          doc: |
+            The plottable data collected during the scan.
+        AXISNAME:
+          nameType: any
+          unit: NX_VOLTAGE
+          doc: |
+            The voltage axis name of the data collected during the scan.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# acf75c279de793751a9dea7fdd407fba63bca10a9109ead9a444d602505e3c1d
+# d12157e94f772b23219f5fd7c4da6f0a7ca1236f5e87f947b37b03999bd49ce8
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -382,6 +392,16 @@ NXbias_spectroscopy(NXobject):
 #                     If the scan has several channels or derivatives from the channel data,
 #                     please duplicate this NXdata group for each.
 #                 </doc>
+#                 <field name="DATA" nameType="any" units="NX_ANY">
+#                     <doc>
+#                         The plottable data collected during the scan.
+#                     </doc>
+#                 </field>
+#                 <field name="AXISNAME" nameType="any" units="NX_VOLTAGE">
+#                     <doc>
+#                         The voltage axis name of the data collected during the scan.
+#                     </doc>
+#                 </field>
 #             </group>
 #         </group>
 #     </group>

--- a/contributed_definitions/nyaml/NXscan_control.yaml
+++ b/contributed_definitions/nyaml/NXscan_control.yaml
@@ -170,9 +170,10 @@ NXscan_control(NXobject):
     oscillation_frequency(NX_NUMBER):
       doc: |
         The number of oscillations on each scanning point per second.
-    SCAN_data(NXdata):
-      nameType: partial
+    SCAN_DATA(NXdata):
+      nameType: any
       DATA(NX_NUMBER):
+        nameType: any
         unit: NX_ANY
         doc: |
           The scan data is the data collected during the scan.
@@ -265,13 +266,14 @@ NXscan_control(NXobject):
       unit: NX_FREQUENCY
       doc: |
         Number of oscillation on each scanning point per second.
-    SCAN_data(NXdata):
-      nameType: partial
+    SCAN_DATA(NXdata):
+      nameType: any
       doc: |
         The scan data is the data collected during the scan.
         If the scan has several channels or derivatives from the channel data, please
         duplicate this NXdata group for each.
       DATA(NX_NUMBER):
+        nameType: any
         unit: NX_ANY
         doc: |
           The scan data is the data collected during the scan.
@@ -348,13 +350,14 @@ NXscan_control(NXobject):
       unit: NX_FREQUENCY
       doc: |
         The number of oscillations on each scanning point per second.
-    SCAN_data(NXdata):
-      nameType: partial
+    SCAN_DATA(NXdata):
+      nameType: any
       doc: |
         The scan data is the data collected during the scan.
         If the scan has several channels or derivatives from the channel data, please
         duplicate this NXdata group for each.
       DATA(NX_NUMBER):
+        nameType: any
         unit: NX_ANY
         doc: |
           The scan data is the data collected during the scan.
@@ -430,13 +433,14 @@ NXscan_control(NXobject):
       unit: NX_FREQUENCY
       doc: |
         The number of oscillations on each scanning point per second.
-    SCAN_data(NXdata):
-      nameType: partial
+    SCAN_DATA(NXdata):
+      nameType: any
       doc: |
         The scan data is the data collected during the scan.
         If the scan has several channels or derivatives from the channel data, please
         duplicate this NXdata group for each.
       DATA(NX_NUMBER):
+        nameType: any
         unit: NX_ANY
         doc: |
           The scan data is the data collected during the scan.
@@ -501,19 +505,20 @@ NXscan_control(NXobject):
       unit: NX_FREQUENCY
       doc: |
         The number of oscillations on each scanning point per second.
-    SCAN_data(NXdata):
-      nameType: partial
+    SCAN_DATA(NXdata):
+      nameType: any
       doc: |
         The scan data is the data collected during the scan.
         If the scan has several channels or derivatives from the channel data, please
         duplicate this NXdata group for each.
       DATA(NX_NUMBER):
+        nameType: any
         unit: NX_ANY
         doc: |
           The scan data is the data collected during the scan.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 5e415856e99e3a0c659457686cc1f98d94349f4043b28517e474ba23d19ffbe4
+# e1d63e6a9fabe8ec4e5a96775fc0ab1e542f86ef3c11fc8348745b7bbd300054
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -736,8 +741,8 @@ NXscan_control(NXobject):
 #                 The number of oscillations on each scanning point per second.
 #             </doc>
 #         </field>
-#         <group name="SCAN_data" type="NXdata" nameType="partial">
-#             <field name="DATA" type="NX_NUMBER" units="NX_ANY">
+#         <group name="SCAN_DATA" type="NXdata" nameType="any">
+#             <field name="DATA" type="NX_NUMBER" nameType="any" units="NX_ANY">
 #                 <doc>
 #                     The scan data is the data collected during the scan.
 #                     If the scan has several channels or derivatives from the channel data, please
@@ -845,13 +850,13 @@ NXscan_control(NXobject):
 #                 Number of oscillation on each scanning point per second.
 #             </doc>
 #         </field>
-#         <group name="SCAN_data" type="NXdata" nameType="partial">
+#         <group name="SCAN_DATA" type="NXdata" nameType="any">
 #             <doc>
 #                 The scan data is the data collected during the scan.
 #                 If the scan has several channels or derivatives from the channel data, please
 #                 duplicate this NXdata group for each.
 #             </doc>
-#             <field name="DATA" type="NX_NUMBER" units="NX_ANY">
+#             <field name="DATA" type="NX_NUMBER" nameType="any" units="NX_ANY">
 #                 <doc>
 #                     The scan data is the data collected during the scan.
 #                 </doc>
@@ -941,13 +946,13 @@ NXscan_control(NXobject):
 #                 The number of oscillations on each scanning point per second.
 #             </doc>
 #         </field>
-#         <group name="SCAN_data" type="NXdata" nameType="partial">
+#         <group name="SCAN_DATA" type="NXdata" nameType="any">
 #             <doc>
 #                 The scan data is the data collected during the scan.
 #                 If the scan has several channels or derivatives from the channel data, please
 #                 duplicate this NXdata group for each.
 #             </doc>
-#             <field name="DATA" type="NX_NUMBER" units="NX_ANY">
+#             <field name="DATA" type="NX_NUMBER" nameType="any" units="NX_ANY">
 #                 <doc>
 #                     The scan data is the data collected during the scan.
 #                 </doc>
@@ -1044,13 +1049,13 @@ NXscan_control(NXobject):
 #                 The number of oscillations on each scanning point per second.
 #             </doc>
 #         </field>
-#         <group name="SCAN_data" type="NXdata" nameType="partial">
+#         <group name="SCAN_DATA" type="NXdata" nameType="any">
 #             <doc>
 #                 The scan data is the data collected during the scan.
 #                 If the scan has several channels or derivatives from the channel data, please
 #                 duplicate this NXdata group for each.
 #             </doc>
-#             <field name="DATA" type="NX_NUMBER" units="NX_ANY">
+#             <field name="DATA" type="NX_NUMBER" nameType="any" units="NX_ANY">
 #                 <doc>
 #                     The scan data is the data collected during the scan.
 #                 </doc>
@@ -1129,13 +1134,13 @@ NXscan_control(NXobject):
 #                 The number of oscillations on each scanning point per second.
 #             </doc>
 #         </field>
-#         <group name="SCAN_data" type="NXdata" nameType="partial">
+#         <group name="SCAN_DATA" type="NXdata" nameType="any">
 #             <doc>
 #                 The scan data is the data collected during the scan.
 #                 If the scan has several channels or derivatives from the channel data, please
 #                 duplicate this NXdata group for each.
 #             </doc>
-#             <field name="DATA" type="NX_NUMBER" units="NX_ANY">
+#             <field name="DATA" type="NX_NUMBER" nameType="any" units="NX_ANY">
 #                 <doc>
 #                     The scan data is the data collected during the scan.
 #                 </doc>

--- a/contributed_definitions/nyaml/NXspm.yaml
+++ b/contributed_definitions/nyaml/NXspm.yaml
@@ -459,6 +459,7 @@ NXspm(NXsensor_scan):
       doc: |
         The data group.
       DATA(NX_NUMBER):
+        nameType: any
         unit: NX_ANY
         doc: |
           The plot able data (e.g. current, voltage, temperature) field in against of the
@@ -475,7 +476,7 @@ NXspm(NXsensor_scan):
         are used to measure the resolution of the experiment results.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# ec815a2395dd77b6a10fed84565c90c9ce9e9f879f2188d3875b329ed483a253
+# ea9b3630baa989bed2622e53fb8f11cdc9b0160b514b3d19f15eda39b720bdc1
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -1074,7 +1075,7 @@ NXspm(NXsensor_scan):
 #             <doc>
 #                 The data group.
 #             </doc>
-#             <field name="DATA" type="NX_NUMBER" units="NX_ANY">
+#             <field name="DATA" type="NX_NUMBER" nameType="any" units="NX_ANY">
 #                 <doc>
 #                     The plot able data (e.g. current, voltage, temperature) field in against of the
 #                     axis.


### PR DESCRIPTION
## Summary by Sourcery

Update nameType for SCAN_DATA and DATA fields in multiple NeXus definition files

Enhancements:
- Change nameType from 'partial' to 'any' for SCAN_DATA group
- Add nameType 'any' to DATA field in multiple NeXus definition files