### PR TITLE
fix units for `beam_direction` transformation in `NXxps`

### DIFF
--- a/contributed_definitions/NXxps.nxdl.xml
+++ b/contributed_definitions/NXxps.nxdl.xml
@@ -147,7 +147,7 @@
                     </doc>
                 </field>
                 <group name="transformations" type="NXtransformations" recommended="true">
-                    <field name="beam_direction" type="NX_NUMBER" units="NX_ANGLE">
+                    <field name="beam_direction" type="NX_NUMBER" units="NX_TRANSFORMATION">
                         <doc>
                             Beam direction in the XPS coordinate system after rotation.
                         </doc>

--- a/contributed_definitions/nyaml/NXxps.yaml
+++ b/contributed_definitions/nyaml/NXxps.yaml
@@ -106,7 +106,7 @@ NXxps(NXmpes):
         transformations(NXtransformations):
           exists: recommended
           beam_direction(NX_NUMBER):
-            unit: NX_ANGLE
+            unit: NX_TRANSFORMATION
             doc: |
               Beam direction in the XPS coordinate system after rotation.
             \@vector(NX_NUMBER):
@@ -596,7 +596,7 @@ NXxps(NXmpes):
       \@energy_indices(NX_INT):
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 4fca3c5f4a0ffb41e8d2ee06d095c976e8ac5cf9f6a849e48d4add97b0862eed
+# 6a3c058b2fd7544192eae0315c2a01887391ef5bcb3eff14c430064bb79f507a
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -746,7 +746,7 @@ NXxps(NXmpes):
 #                     </doc>
 #                 </field>
 #                 <group name="transformations" type="NXtransformations" recommended="true">
-#                     <field name="beam_direction" type="NX_NUMBER" units="NX_ANGLE">
+#                     <field name="beam_direction" type="NX_NUMBER" units="NX_TRANSFORMATION">
 #                         <doc>
 #                             Beam direction in the XPS coordinate system after rotation.
 #                         </doc>


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the unit of the beam_direction field in NXxps transformations from NX_ANGLE to NX_TRANSFORMATION in both YAML and XML definitions.