### PR TITLE
Connect more intricate concepts from NXmicrostructure

### DIFF
--- a/applications/NXapm.nxdl.xml
+++ b/applications/NXapm.nxdl.xml
@@ -361,6 +361,11 @@
             </doc>
         </field>
         <group name="citeID" type="NXcite" minOccurs="0" maxOccurs="unbounded" nameType="partial">
+            <field name="author" type="NX_CHAR" optional="true">
+                <doc>
+                    The author(s) of that reference.
+                </doc>
+            </field>
             <field name="doi" type="NX_CHAR"/>
         </group>
         <group name="noteID" type="NXnote" minOccurs="0" maxOccurs="unbounded" nameType="partial">

--- a/applications/NXem.nxdl.xml
+++ b/applications/NXem.nxdl.xml
@@ -1747,7 +1747,7 @@ not wish to duplicate all payload data-->
                             <group name="map" type="NXdata">
                                 <attribute name="signal" type="NX_CHAR"/>
                                 <attribute name="axes" type="NX_CHAR"/>
-                                <attribute name="AXISNAME_indices" type="NX_UINT"/>
+                                <attribute name="AXISNAME_indices" type="NX_UINT" nameType="partial"/>
                                 <field name="title" type="NX_CHAR" recommended="true"/>
                                 <field name="data" type="NX_NUMBER">
                                     <attribute name="long_name" type="NX_CHAR"/>
@@ -1765,7 +1765,7 @@ not wish to duplicate all payload data-->
                             <group name="legend" type="NXdata">
                                 <attribute name="signal" type="NX_CHAR"/>
                                 <attribute name="axes" type="NX_CHAR"/>
-                                <attribute name="AXISNAME_indices" type="NX_UINT"/>
+                                <attribute name="AXISNAME_indices" type="NX_UINT" nameType="partial"/>
                                 <field name="title" type="NX_CHAR" recommended="true"/>
                                 <field name="data" type="NX_NUMBER">
                                     <attribute name="long_name" type="NX_CHAR"/>
@@ -1792,7 +1792,7 @@ not wish to duplicate all payload data-->
                             <group name="phi_two_plot" type="NXdata">
                                 <attribute name="signal" type="NX_CHAR"/>
                                 <attribute name="axes" type="NX_CHAR"/>
-                                <attribute name="AXISNAME_indices" type="NX_UINT"/>
+                                <attribute name="AXISNAME_indices" type="NX_UINT" nameType="partial"/>
                                 <field name="title" type="NX_CHAR" recommended="true"/>
                                 <field name="intensity" type="NX_NUMBER">
                                     <attribute name="long_name" type="NX_CHAR"/>
@@ -1813,7 +1813,7 @@ not wish to duplicate all payload data-->
                     <group name="roi" type="NXdata" recommended="true">
                         <attribute name="signal" type="NX_CHAR"/>
                         <attribute name="axes" type="NX_CHAR"/>
-                        <attribute name="AXISNAME_indices" type="NX_UINT"/>
+                        <attribute name="AXISNAME_indices" type="NX_UINT" nameType="partial"/>
                         <field name="title" type="NX_CHAR" recommended="true"/>
                         <field name="descriptor" type="NX_CHAR" recommended="true"/>
                         <field name="data" type="NX_NUMBER"/>

--- a/applications/NXem.nxdl.xml
+++ b/applications/NXem.nxdl.xml
@@ -1680,6 +1680,45 @@ is required to provide such information in this way!-->
                 <group name="indexing" type="NXprocess" optional="true">
                     <field name="number_of_scan_points" type="NX_UINT"/>
                     <field name="indexing_rate" type="NX_NUMBER" recommended="true"/>
+                    <group name="microstructureID" type="NXmicrostructure" nameType="partial" minOccurs="0" maxOccurs="unbounded">
+                        <group name="configuration" type="NXprocess">
+                            <field name="dimensionality" type="NX_POSINT"/>
+                            <field name="algorithm" type="NX_CHAR"/>
+                            <field name="disorientation_threshold" type="NX_NUMBER"/>
+                            <group name="programID" type="NXprogram" nameType="partial" recommended="true">
+                                <field name="program" type="NX_CHAR">
+                                    <attribute name="version" type="NX_CHAR"/>
+                                </field>
+                                <group name="mtex" type="NXmicrostructure_mtex_config" optional="true"/>
+                            </group>
+                        </group>
+                        <group name="grid" type="NXcg_grid" optional="true"/>
+                        <group name="points" type="NXcg_point" optional="true"/>
+                        <group name="polylines" type="NXcg_polyline" optional="true"/>
+                        <group name="triangles" type="NXcg_triangle" optional="true"/>
+                        <group name="polygons" type="NXcg_polygon" optional="true"/>
+                        <group name="polyhedra" type="NXcg_polyhedron" optional="true"/>
+                        <group name="crystals" type="NXmicrostructure_feature" optional="true">
+                            <field name="representation" type="NX_CHAR" recommended="true"/>
+                            <field name="number_of_crystals" type="NX_UINT"/>
+                            <field name="index_offset" type="NX_INT"/>
+                        </group>
+                        <group name="interfaces" type="NXmicrostructure_feature" optional="true">
+                            <field name="representation" type="NX_CHAR" recommended="true"/>
+                            <field name="number_of_interfaces" type="NX_UINT"/>
+                            <field name="index_offset" type="NX_INT"/>
+                        </group>
+                        <group name="triple_junctions" type="NXmicrostructure_feature" optional="true">
+                            <field name="representation" type="NX_CHAR" recommended="true"/>
+                            <field name="number_of_junctions" type="NX_UINT"/>
+                            <field name="index_offset" type="NX_INT"/>
+                        </group>
+                        <group name="quadruple_junctions" type="NXmicrostructure_feature" optional="true">
+                            <field name="representation" type="NX_CHAR" recommended="true"/>
+                            <field name="number_of_junctions" type="NX_UINT"/>
+                            <field name="index_offset" type="NX_INT"/>
+                        </group>
+                    </group>
                     <group name="source" type="NXnote" optional="true">
                         <field name="type" type="NX_CHAR" recommended="true"/>
                         <field name="file_name" type="NX_CHAR"/>
@@ -1708,7 +1747,7 @@ not wish to duplicate all payload data-->
                             <group name="map" type="NXdata">
                                 <attribute name="signal" type="NX_CHAR"/>
                                 <attribute name="axes" type="NX_CHAR"/>
-                                <attribute name="AXISNAME_indices" type="NX_UINT" nameType="partial"/>
+                                <attribute name="AXISNAME_indices" type="NX_UINT"/>
                                 <field name="title" type="NX_CHAR" recommended="true"/>
                                 <field name="data" type="NX_NUMBER">
                                     <attribute name="long_name" type="NX_CHAR"/>
@@ -1726,7 +1765,7 @@ not wish to duplicate all payload data-->
                             <group name="legend" type="NXdata">
                                 <attribute name="signal" type="NX_CHAR"/>
                                 <attribute name="axes" type="NX_CHAR"/>
-                                <attribute name="AXISNAME_indices" type="NX_UINT" nameType="partial"/>
+                                <attribute name="AXISNAME_indices" type="NX_UINT"/>
                                 <field name="title" type="NX_CHAR" recommended="true"/>
                                 <field name="data" type="NX_NUMBER">
                                     <attribute name="long_name" type="NX_CHAR"/>
@@ -1739,15 +1778,42 @@ not wish to duplicate all payload data-->
                                 </field>
                             </group>
                         </group>
-                        <group name="odfID" type="NXmicrostructure_odf" nameType="partial" optional="true"/>
-                        <group name="pfID" type="NXmicrostructure_pf" nameType="partial" optional="true"/>
+                        <group name="odfID" type="NXmicrostructure_odf" nameType="partial" minOccurs="0" maxOccurs="unbounded">
+                            <group name="configuration" type="NXparameters" recommended="true">
+                                <field name="crystal_symmetry_point_group" type="NX_CHAR"/>
+                                <field name="specimen_symmetry_point_group" type="NX_CHAR"/>
+                                <field name="kernel_halfwidth" type="NX_NUMBER"/>
+                                <field name="kernel_name" type="NX_CHAR"/>
+                                <field name="resolution" type="NX_NUMBER"/>
+                            </group>
+                            <group name="characteristics" type="NXprocess" optional="true">
+                                <field name="texture_index" type="NX_FLOAT"/>
+                            </group>
+                            <group name="phi_two_plot" type="NXdata">
+                                <attribute name="signal" type="NX_CHAR"/>
+                                <attribute name="axes" type="NX_CHAR"/>
+                                <attribute name="AXISNAME_indices" type="NX_UINT"/>
+                                <field name="title" type="NX_CHAR" recommended="true"/>
+                                <field name="intensity" type="NX_NUMBER">
+                                    <attribute name="long_name" type="NX_CHAR"/>
+                                </field>
+                                <field name="varphi_one" type="NX_NUMBER">
+                                    <attribute name="long_name" type="NX_CHAR"/>
+                                </field>
+                                <field name="capital_phi" type="NX_NUMBER">
+                                    <attribute name="long_name" type="NX_CHAR"/>
+                                </field>
+                                <field name="varphi_two" type="NX_NUMBER">
+                                    <attribute name="long_name" type="NX_CHAR"/>
+                                </field>
+                            </group>
+                        </group>
+                        <group name="pfID" type="NXmicrostructure_pf" nameType="partial" minOccurs="0" maxOccurs="unbounded"/>
                     </group>
-                    <!--microstructure of the entire ROI-->
-                    <group name="microstructureID" type="NXmicrostructure" nameType="partial" optional="true"/>
                     <group name="roi" type="NXdata" recommended="true">
                         <attribute name="signal" type="NX_CHAR"/>
                         <attribute name="axes" type="NX_CHAR"/>
-                        <attribute name="AXISNAME_indices" type="NX_UINT" nameType="partial"/>
+                        <attribute name="AXISNAME_indices" type="NX_UINT"/>
                         <field name="title" type="NX_CHAR" recommended="true"/>
                         <field name="descriptor" type="NX_CHAR" recommended="true"/>
                         <field name="data" type="NX_NUMBER"/>

--- a/applications/NXem.nxdl.xml
+++ b/applications/NXem.nxdl.xml
@@ -231,7 +231,14 @@
                 start_time and end_time together.
             </doc>
         </field>
-        <group name="citeID" type="NXcite" minOccurs="0" maxOccurs="unbounded" nameType="partial"/>
+        <group name="citeID" type="NXcite" minOccurs="0" maxOccurs="unbounded" nameType="partial">
+            <field name="author" type="NX_CHAR" optional="true">
+                <doc>
+                    The author(s) of that reference.
+                </doc>
+            </field>
+            <field name="doi" type="NX_CHAR"/>
+        </group>
         <group name="noteID" type="NXnote" minOccurs="0" maxOccurs="unbounded" nameType="partial">
             <doc>
                 Collection of serialized resources associated with the experiment.
@@ -1725,7 +1732,7 @@ is required to provide such information in this way!-->
                         <field name="checksum" type="NX_CHAR" recommended="true"/>
                         <field name="algorithm" type="NX_CHAR" recommended="true"/>
                     </group>
-                    <!--per scan point quantities (identifier_phase, matching_phase, positions, etc.)
+                    <!--per scan point quantities (phase_id, matching_phase, positions, etc.)
 just using the implicit optional, for the database example in NOMAD we do
 not wish to duplicate all payload data-->
                     <group name="phaseID" type="NXphase" nameType="partial" minOccurs="0" maxOccurs="unbounded">

--- a/applications/nyaml/NXapm.yaml
+++ b/applications/nyaml/NXapm.yaml
@@ -308,6 +308,10 @@ NXapm(NXobject):
     citeID(NXcite):
       exists: ['min', '0', 'max', 'unbounded']
       nameType: partial
+      author(NX_CHAR):
+        exists: optional
+        doc: |
+          The author(s) of that reference.
       doi(NX_CHAR):
     noteID(NXnote):
       exists: ['min', '0', 'max', 'unbounded']
@@ -1531,7 +1535,7 @@ NXapm(NXobject):
               dim: (n,)
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 7bec46bfcbbb372ad9c37859e21fe81ecdd1e4ca1c8502c0fdcbf71e757f898c
+# 2642b118e31af3d0c5cf93a12ba96d32f0458074c69b36c51821bfa5307ef97c
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -1895,6 +1899,11 @@ NXapm(NXobject):
 #             </doc>
 #         </field>
 #         <group name="citeID" type="NXcite" minOccurs="0" maxOccurs="unbounded" nameType="partial">
+#             <field name="author" type="NX_CHAR" optional="true">
+#                 <doc>
+#                     The author(s) of that reference.
+#                 </doc>
+#             </field>
 #             <field name="doi" type="NX_CHAR"/>
 #         </group>
 #         <group name="noteID" type="NXnote" minOccurs="0" maxOccurs="unbounded" nameType="partial">

--- a/applications/nyaml/NXem.yaml
+++ b/applications/nyaml/NXem.yaml
@@ -1638,6 +1638,56 @@ NXem(NXobject):
           number_of_scan_points(NX_UINT):
           indexing_rate(NX_NUMBER):
             exists: recommended
+          microstructureID(NXmicrostructure):
+            nameType: partial
+            exists: ['min', '0', 'max', 'unbounded']
+            configuration(NXprocess):
+              dimensionality(NX_POSINT):
+              algorithm(NX_CHAR):
+              disorientation_threshold(NX_NUMBER):
+              programID(NXprogram):
+                nameType: partial
+                exists: recommended
+                program(NX_CHAR):
+                  \@version(NX_CHAR):
+                mtex(NXmicrostructure_mtex_config):
+                  exists: optional
+            grid(NXcg_grid):
+              exists: optional
+            points(NXcg_point):
+              exists: optional
+            polylines(NXcg_polyline):
+              exists: optional
+            triangles(NXcg_triangle):
+              exists: optional
+            polygons(NXcg_polygon):
+              exists: optional
+            polyhedra(NXcg_polyhedron):
+              exists: optional
+            crystals(NXmicrostructure_feature):
+              exists: optional
+              representation(NX_CHAR):
+                exists: recommended
+              number_of_crystals(NX_UINT):
+              index_offset(NX_INT):
+            interfaces(NXmicrostructure_feature):
+              exists: optional
+              representation(NX_CHAR):
+                exists: recommended
+              number_of_interfaces(NX_UINT):
+              index_offset(NX_INT):
+            triple_junctions(NXmicrostructure_feature):
+              exists: optional
+              representation(NX_CHAR):
+                exists: recommended
+              number_of_junctions(NX_UINT):
+              index_offset(NX_INT):
+            quadruple_junctions(NXmicrostructure_feature):
+              exists: optional
+              representation(NX_CHAR):
+                exists: recommended
+              number_of_junctions(NX_UINT):
+              index_offset(NX_INT):
           source(NXnote):
             exists: optional
             type(NX_CHAR):
@@ -1676,7 +1726,6 @@ NXem(NXobject):
                 \@signal(NX_CHAR):
                 \@axes(NX_CHAR):
                 \@AXISNAME_indices(NX_UINT):
-                  nameType: partial
                 title(NX_CHAR):
                   exists: recommended
                 data(NX_NUMBER):
@@ -1693,7 +1742,6 @@ NXem(NXobject):
                 \@signal(NX_CHAR):
                 \@axes(NX_CHAR):
                 \@AXISNAME_indices(NX_UINT):
-                  nameType: partial
                 title(NX_CHAR):
                   exists: recommended
                 data(NX_NUMBER):
@@ -1704,21 +1752,39 @@ NXem(NXobject):
                   \@long_name(NX_CHAR):
             odfID(NXmicrostructure_odf):
               nameType: partial
-              exists: optional
+              exists: ['min', '0', 'max', 'unbounded']
+              configuration(NXparameters):
+                exists: recommended
+                crystal_symmetry_point_group(NX_CHAR):
+                specimen_symmetry_point_group(NX_CHAR):
+                kernel_halfwidth(NX_NUMBER):
+                kernel_name(NX_CHAR):
+                resolution(NX_NUMBER):
+              characteristics(NXprocess):
+                exists: optional
+                texture_index(NX_FLOAT):
+              phi_two_plot(NXdata):
+                \@signal(NX_CHAR):
+                \@axes(NX_CHAR):
+                \@AXISNAME_indices(NX_UINT):
+                title(NX_CHAR):
+                  exists: recommended
+                intensity(NX_NUMBER):
+                  \@long_name(NX_CHAR):
+                varphi_one(NX_NUMBER):
+                  \@long_name(NX_CHAR):
+                capital_phi(NX_NUMBER):
+                  \@long_name(NX_CHAR):
+                varphi_two(NX_NUMBER):
+                  \@long_name(NX_CHAR):
             pfID(NXmicrostructure_pf):
               nameType: partial
-              exists: optional
-          
-          # microstructure of the entire ROI
-          microstructureID(NXmicrostructure):
-            nameType: partial
-            exists: optional
+              exists: ['min', '0', 'max', 'unbounded']
           roi(NXdata):
             exists: recommended
             \@signal(NX_CHAR):
             \@axes(NX_CHAR):
             \@AXISNAME_indices(NX_UINT):
-              nameType: partial
             title(NX_CHAR):
               exists: recommended
             descriptor(NX_CHAR):
@@ -1774,7 +1840,7 @@ NXem(NXobject):
   # in https://github.com/FAIRmat-NFDI/nexus_definitions/commit/0b928c4352bc5636f673b5fb25ce990f1af8a099
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# e2e9a591eeb4374c8a4a83fcaf92d3f8f56b5c6ccb8c6c10d6a0d3c8b7a1ce9b
+# 801b22fc61ac0924c2e0e18853c55a6577f460cd628aa949a4bcabacc6e9764b
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -3457,6 +3523,45 @@ NXem(NXobject):
 #                 <group name="indexing" type="NXprocess" optional="true">
 #                     <field name="number_of_scan_points" type="NX_UINT"/>
 #                     <field name="indexing_rate" type="NX_NUMBER" recommended="true"/>
+#                     <group name="microstructureID" type="NXmicrostructure" nameType="partial" minOccurs="0" maxOccurs="unbounded">
+#                         <group name="configuration" type="NXprocess">
+#                             <field name="dimensionality" type="NX_POSINT"/>
+#                             <field name="algorithm" type="NX_CHAR"/>
+#                             <field name="disorientation_threshold" type="NX_NUMBER"/>
+#                             <group name="programID" type="NXprogram" nameType="partial" recommended="true">
+#                                 <field name="program" type="NX_CHAR">
+#                                     <attribute name="version" type="NX_CHAR"/>
+#                                 </field>
+#                                 <group name="mtex" type="NXmicrostructure_mtex_config" optional="true"/>
+#                             </group>
+#                         </group>
+#                         <group name="grid" type="NXcg_grid" optional="true"/>
+#                         <group name="points" type="NXcg_point" optional="true"/>
+#                         <group name="polylines" type="NXcg_polyline" optional="true"/>
+#                         <group name="triangles" type="NXcg_triangle" optional="true"/>
+#                         <group name="polygons" type="NXcg_polygon" optional="true"/>
+#                         <group name="polyhedra" type="NXcg_polyhedron" optional="true"/>
+#                         <group name="crystals" type="NXmicrostructure_feature" optional="true">
+#                             <field name="representation" type="NX_CHAR" recommended="true"/>
+#                             <field name="number_of_crystals" type="NX_UINT"/>
+#                             <field name="index_offset" type="NX_INT"/>
+#                         </group>
+#                         <group name="interfaces" type="NXmicrostructure_feature" optional="true">
+#                             <field name="representation" type="NX_CHAR" recommended="true"/>
+#                             <field name="number_of_interfaces" type="NX_UINT"/>
+#                             <field name="index_offset" type="NX_INT"/>
+#                         </group>
+#                         <group name="triple_junctions" type="NXmicrostructure_feature" optional="true">
+#                             <field name="representation" type="NX_CHAR" recommended="true"/>
+#                             <field name="number_of_junctions" type="NX_UINT"/>
+#                             <field name="index_offset" type="NX_INT"/>
+#                         </group>
+#                         <group name="quadruple_junctions" type="NXmicrostructure_feature" optional="true">
+#                             <field name="representation" type="NX_CHAR" recommended="true"/>
+#                             <field name="number_of_junctions" type="NX_UINT"/>
+#                             <field name="index_offset" type="NX_INT"/>
+#                         </group>
+#                     </group>
 #                     <group name="source" type="NXnote" optional="true">
 #                         <field name="type" type="NX_CHAR" recommended="true"/>
 #                         <field name="file_name" type="NX_CHAR"/>
@@ -3485,7 +3590,7 @@ NXem(NXobject):
 #                             <group name="map" type="NXdata">
 #                                 <attribute name="signal" type="NX_CHAR"/>
 #                                 <attribute name="axes" type="NX_CHAR"/>
-#                                 <attribute name="AXISNAME_indices" type="NX_UINT" nameType="partial"/>
+#                                 <attribute name="AXISNAME_indices" type="NX_UINT"/>
 #                                 <field name="title" type="NX_CHAR" recommended="true"/>
 #                                 <field name="data" type="NX_NUMBER">
 #                                     <attribute name="long_name" type="NX_CHAR"/>
@@ -3503,7 +3608,7 @@ NXem(NXobject):
 #                             <group name="legend" type="NXdata">
 #                                 <attribute name="signal" type="NX_CHAR"/>
 #                                 <attribute name="axes" type="NX_CHAR"/>
-#                                 <attribute name="AXISNAME_indices" type="NX_UINT" nameType="partial"/>
+#                                 <attribute name="AXISNAME_indices" type="NX_UINT"/>
 #                                 <field name="title" type="NX_CHAR" recommended="true"/>
 #                                 <field name="data" type="NX_NUMBER">
 #                                     <attribute name="long_name" type="NX_CHAR"/>
@@ -3516,15 +3621,42 @@ NXem(NXobject):
 #                                 </field>
 #                             </group>
 #                         </group>
-#                         <group name="odfID" type="NXmicrostructure_odf" nameType="partial" optional="true"/>
-#                         <group name="pfID" type="NXmicrostructure_pf" nameType="partial" optional="true"/>
+#                         <group name="odfID" type="NXmicrostructure_odf" nameType="partial" minOccurs="0" maxOccurs="unbounded">
+#                             <group name="configuration" type="NXparameters" recommended="true">
+#                                 <field name="crystal_symmetry_point_group" type="NX_CHAR"/>
+#                                 <field name="specimen_symmetry_point_group" type="NX_CHAR"/>
+#                                 <field name="kernel_halfwidth" type="NX_NUMBER"/>
+#                                 <field name="kernel_name" type="NX_CHAR"/>
+#                                 <field name="resolution" type="NX_NUMBER"/>
+#                             </group>
+#                             <group name="characteristics" type="NXprocess" optional="true">
+#                                 <field name="texture_index" type="NX_FLOAT"/>
+#                             </group>
+#                             <group name="phi_two_plot" type="NXdata">
+#                                 <attribute name="signal" type="NX_CHAR"/>
+#                                 <attribute name="axes" type="NX_CHAR"/>
+#                                 <attribute name="AXISNAME_indices" type="NX_UINT"/>
+#                                 <field name="title" type="NX_CHAR" recommended="true"/>
+#                                 <field name="intensity" type="NX_NUMBER">
+#                                     <attribute name="long_name" type="NX_CHAR"/>
+#                                 </field>
+#                                 <field name="varphi_one" type="NX_NUMBER">
+#                                     <attribute name="long_name" type="NX_CHAR"/>
+#                                 </field>
+#                                 <field name="capital_phi" type="NX_NUMBER">
+#                                     <attribute name="long_name" type="NX_CHAR"/>
+#                                 </field>
+#                                 <field name="varphi_two" type="NX_NUMBER">
+#                                     <attribute name="long_name" type="NX_CHAR"/>
+#                                 </field>
+#                             </group>
+#                         </group>
+#                         <group name="pfID" type="NXmicrostructure_pf" nameType="partial" minOccurs="0" maxOccurs="unbounded"/>
 #                     </group>
-#                     <!--microstructure of the entire ROI-->
-#                     <group name="microstructureID" type="NXmicrostructure" nameType="partial" optional="true"/>
 #                     <group name="roi" type="NXdata" recommended="true">
 #                         <attribute name="signal" type="NX_CHAR"/>
 #                         <attribute name="axes" type="NX_CHAR"/>
-#                         <attribute name="AXISNAME_indices" type="NX_UINT" nameType="partial"/>
+#                         <attribute name="AXISNAME_indices" type="NX_UINT"/>
 #                         <field name="title" type="NX_CHAR" recommended="true"/>
 #                         <field name="descriptor" type="NX_CHAR" recommended="true"/>
 #                         <field name="data" type="NX_NUMBER"/>

--- a/applications/nyaml/NXem.yaml
+++ b/applications/nyaml/NXem.yaml
@@ -202,6 +202,11 @@ NXem(NXobject):
     citeID(NXcite):
       exists: ['min', '0', 'max', 'unbounded']
       nameType: partial
+      author(NX_CHAR):
+        exists: optional
+        doc: |
+          The author(s) of that reference.
+      doi(NX_CHAR):
     noteID(NXnote):
       exists: ['min', '0', 'max', 'unbounded']
       nameType: partial
@@ -1698,7 +1703,7 @@ NXem(NXobject):
             algorithm(NX_CHAR):
               exists: recommended
           
-          # per scan point quantities (identifier_phase, matching_phase, positions, etc.)
+          # per scan point quantities (phase_id, matching_phase, positions, etc.)
           # just using the implicit optional, for the database example in NOMAD we do
           # not wish to duplicate all payload data
           phaseID(NXphase):
@@ -1844,7 +1849,7 @@ NXem(NXobject):
   # in https://github.com/FAIRmat-NFDI/nexus_definitions/commit/0b928c4352bc5636f673b5fb25ce990f1af8a099
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 10bb99fb256ecd540dbd108c048d465f1d3c5e68bc4cab13a3cf1421d09b40a0
+# 2cbc5e6b4ca32e7bcf5ca322b46262d8747500d9eef98317c795079ead77f779
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -2078,7 +2083,14 @@ NXem(NXobject):
 #                 start_time and end_time together.
 #             </doc>
 #         </field>
-#         <group name="citeID" type="NXcite" minOccurs="0" maxOccurs="unbounded" nameType="partial"/>
+#         <group name="citeID" type="NXcite" minOccurs="0" maxOccurs="unbounded" nameType="partial">
+#             <field name="author" type="NX_CHAR" optional="true">
+#                 <doc>
+#                     The author(s) of that reference.
+#                 </doc>
+#             </field>
+#             <field name="doi" type="NX_CHAR"/>
+#         </group>
 #         <group name="noteID" type="NXnote" minOccurs="0" maxOccurs="unbounded" nameType="partial">
 #             <doc>
 #                 Collection of serialized resources associated with the experiment.
@@ -3572,7 +3584,7 @@ NXem(NXobject):
 #                         <field name="checksum" type="NX_CHAR" recommended="true"/>
 #                         <field name="algorithm" type="NX_CHAR" recommended="true"/>
 #                     </group>
-#                     <!--per scan point quantities (identifier_phase, matching_phase, positions, etc.)
+#                     <!--per scan point quantities (phase_id, matching_phase, positions, etc.)
 # just using the implicit optional, for the database example in NOMAD we do
 # not wish to duplicate all payload data-->
 #                     <group name="phaseID" type="NXphase" nameType="partial" minOccurs="0" maxOccurs="unbounded">

--- a/applications/nyaml/NXem.yaml
+++ b/applications/nyaml/NXem.yaml
@@ -1726,6 +1726,7 @@ NXem(NXobject):
                 \@signal(NX_CHAR):
                 \@axes(NX_CHAR):
                 \@AXISNAME_indices(NX_UINT):
+                  nameType: partial
                 title(NX_CHAR):
                   exists: recommended
                 data(NX_NUMBER):
@@ -1742,6 +1743,7 @@ NXem(NXobject):
                 \@signal(NX_CHAR):
                 \@axes(NX_CHAR):
                 \@AXISNAME_indices(NX_UINT):
+                  nameType: partial
                 title(NX_CHAR):
                   exists: recommended
                 data(NX_NUMBER):
@@ -1767,6 +1769,7 @@ NXem(NXobject):
                 \@signal(NX_CHAR):
                 \@axes(NX_CHAR):
                 \@AXISNAME_indices(NX_UINT):
+                  nameType: partial
                 title(NX_CHAR):
                   exists: recommended
                 intensity(NX_NUMBER):
@@ -1785,6 +1788,7 @@ NXem(NXobject):
             \@signal(NX_CHAR):
             \@axes(NX_CHAR):
             \@AXISNAME_indices(NX_UINT):
+              nameType: partial
             title(NX_CHAR):
               exists: recommended
             descriptor(NX_CHAR):
@@ -1840,7 +1844,7 @@ NXem(NXobject):
   # in https://github.com/FAIRmat-NFDI/nexus_definitions/commit/0b928c4352bc5636f673b5fb25ce990f1af8a099
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 801b22fc61ac0924c2e0e18853c55a6577f460cd628aa949a4bcabacc6e9764b
+# 10bb99fb256ecd540dbd108c048d465f1d3c5e68bc4cab13a3cf1421d09b40a0
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -3590,7 +3594,7 @@ NXem(NXobject):
 #                             <group name="map" type="NXdata">
 #                                 <attribute name="signal" type="NX_CHAR"/>
 #                                 <attribute name="axes" type="NX_CHAR"/>
-#                                 <attribute name="AXISNAME_indices" type="NX_UINT"/>
+#                                 <attribute name="AXISNAME_indices" type="NX_UINT" nameType="partial"/>
 #                                 <field name="title" type="NX_CHAR" recommended="true"/>
 #                                 <field name="data" type="NX_NUMBER">
 #                                     <attribute name="long_name" type="NX_CHAR"/>
@@ -3608,7 +3612,7 @@ NXem(NXobject):
 #                             <group name="legend" type="NXdata">
 #                                 <attribute name="signal" type="NX_CHAR"/>
 #                                 <attribute name="axes" type="NX_CHAR"/>
-#                                 <attribute name="AXISNAME_indices" type="NX_UINT"/>
+#                                 <attribute name="AXISNAME_indices" type="NX_UINT" nameType="partial"/>
 #                                 <field name="title" type="NX_CHAR" recommended="true"/>
 #                                 <field name="data" type="NX_NUMBER">
 #                                     <attribute name="long_name" type="NX_CHAR"/>
@@ -3635,7 +3639,7 @@ NXem(NXobject):
 #                             <group name="phi_two_plot" type="NXdata">
 #                                 <attribute name="signal" type="NX_CHAR"/>
 #                                 <attribute name="axes" type="NX_CHAR"/>
-#                                 <attribute name="AXISNAME_indices" type="NX_UINT"/>
+#                                 <attribute name="AXISNAME_indices" type="NX_UINT" nameType="partial"/>
 #                                 <field name="title" type="NX_CHAR" recommended="true"/>
 #                                 <field name="intensity" type="NX_NUMBER">
 #                                     <attribute name="long_name" type="NX_CHAR"/>
@@ -3656,7 +3660,7 @@ NXem(NXobject):
 #                     <group name="roi" type="NXdata" recommended="true">
 #                         <attribute name="signal" type="NX_CHAR"/>
 #                         <attribute name="axes" type="NX_CHAR"/>
-#                         <attribute name="AXISNAME_indices" type="NX_UINT"/>
+#                         <attribute name="AXISNAME_indices" type="NX_UINT" nameType="partial"/>
 #                         <field name="title" type="NX_CHAR" recommended="true"/>
 #                         <field name="descriptor" type="NX_CHAR" recommended="true"/>
 #                         <field name="data" type="NX_NUMBER"/>

--- a/base_classes/NXem_ebsd.nxdl.xml
+++ b/base_classes/NXem_ebsd.nxdl.xml
@@ -529,34 +529,33 @@
                 In another example users may have skipped some scan points (not indexed
                 them at all) or used differing numbers of phases for indexing different scan points.
                 
-                The cumulated of this array decodes how identifier_phase and matching_phase
+                The cumulated of this array decodes how phase_id and matching_phase
                 arrays have to be interpreted. In the simplest case (one pattern per scan
                 point, and all scan points indexed using that same single phase model),
-                identifier_phase has as many entries as scan points
+                phase_id has as many entries as scan points
                 and matching_phase has also as many entries as scan points.
             </doc>
             <dimensions rank="1">
                 <dim index="1" value="n_sc"/>
             </dimensions>
         </field>
-        <field name="identifier_phase" type="NX_INT" units="NX_UNITLESS">
+        <field name="phase_id" type="NX_INT" units="NX_UNITLESS">
             <doc>
-                The array phases_per_scan_point details how the identifier_phase
+                The array phases_per_scan_point details how the phase_id
                 and the matching_phase arrays have to be interpreted.
                 
-                For the example with a single phase identifier_phase has trivial
+                For the example of a single-phase material phase_id has trivial
                 values either 0 (no solution) or 1 (solution matching
-                sufficiently significant with the model for phase 1).
+                sufficiently significant with the model for phase1, an instance of :ref:`NXphase`).
                 
-                When there are multiple phases, it is possible (although not frequently
-                required) that a pattern matches eventually (not equally well) sufficiently
-                significant with multiple patterns. This can especially happen in cases of
-                pseudosymmetry and more frequently with an improperly calibrated system
-                or false or inaccurate phase models. Having such field is especially relevant
+                For the example of multi-phase material, it is possible (although not frequently
+                required) that a pattern agrees significantly with multiple patterns. Examples are
+                cases of pseudosymmetry, insufficiently precise and accurate calibrated systems,
+                or usage of inaccurate phase models. Having such field is especially relevant
                 for recent dictionary- or artificial intelligence-based indexing methods to communicate
                 the results in a model-agnostic way in combination with matching_phase.
                 
-                Depending on the phases_per_scan_point value, identifier_phase and
+                Depending on the phases_per_scan_point value, phase_id and
                 matching_phase arrays represent a collection of concatenated tuples.
                 These are organized in sequence: The solutions for the 0-th scan point,
                 the 1-th scan point, the n_sc - 1 th scan point and omitting tuples
@@ -568,10 +567,10 @@
         </field>
         <field name="matching_phase" type="NX_INT" units="NX_UNITLESS">
             <doc>
-                One-dimensional array, pattern by pattern labelling the solutions found.
+                One-dimensional array, pattern-by-pattern labelling the solutions found.
                 The array phases_per_scan_point has to be specified because it details
-                how the identifier_phase and the matching_phase arrays are interpreted.
-                See documentation of identifier_phase for further details.
+                how the phase_id and the matching_phase arrays are interpreted.
+                See documentation of phase_id for further details.
             </doc>
             <dimensions rank="1">
                 <dim index="1" value="n_solutions"/>
@@ -610,6 +609,19 @@
                 Number of scan points in the original mapping.
             </doc>
         </field>
+        <field name="pixel_shape" type="NX_CHAR">
+            <doc>
+                The shape of the polygon or polyhedron that was used for the tiling
+                respectively tessellation of the region-of-interest into scan points.
+            </doc>
+            <enumeration>
+                <item value="square"/>
+                <item value="hexagon"/>
+                <item value="cube"/>
+                <item value="other"/>
+            </enumeration>
+        </field>
+        <!--use NXcg_grid in the future-->
         <group type="NXmicrostructure"/>
         <group name="roi" type="NXdata">
             <doc>

--- a/base_classes/NXphase.nxdl.xml
+++ b/base_classes/NXphase.nxdl.xml
@@ -35,7 +35,7 @@
             null-model (no sufficiently significant information available).
             In other words, the phase_name is n/a aka notIndexed.
             
-            The identifier_phase value should match with the integer suffix of the
+            The  phase_id value should match with the integer suffix of the
             group name which represents that instance in a NeXus/HDF5 file, i.e.
             if three phases were used e.g. 0, 1, and 2, three instances of
             :ref:`NXphase` named phase0, phase1, and phase2 should be stored
@@ -46,7 +46,7 @@
         <doc>
             Given name as an alias for identifying this phase.
             
-            If the identifier_phase is 0 and one would like to use
+            If the  phase_id is 0 and one would like to use
             the field name, the value should be n/a or notIndexed.
         </doc>
     </field>

--- a/base_classes/nyaml/NXem_ebsd.yaml
+++ b/base_classes/nyaml/NXem_ebsd.yaml
@@ -383,33 +383,32 @@ NXem_ebsd(NXprocess):
         In another example users may have skipped some scan points (not indexed
         them at all) or used differing numbers of phases for indexing different scan points.
         
-        The cumulated of this array decodes how identifier_phase and matching_phase
+        The cumulated of this array decodes how phase_id and matching_phase
         arrays have to be interpreted. In the simplest case (one pattern per scan
         point, and all scan points indexed using that same single phase model),
-        identifier_phase has as many entries as scan points
+        phase_id has as many entries as scan points
         and matching_phase has also as many entries as scan points.
       dimensions:
         rank: 1
         dim: (n_sc,)
-    identifier_phase(NX_INT):
+    phase_id(NX_INT):
       unit: NX_UNITLESS
       doc: |
-        The array phases_per_scan_point details how the identifier_phase
+        The array phases_per_scan_point details how the phase_id
         and the matching_phase arrays have to be interpreted.
         
-        For the example with a single phase identifier_phase has trivial
+        For the example of a single-phase material phase_id has trivial
         values either 0 (no solution) or 1 (solution matching
-        sufficiently significant with the model for phase 1).
+        sufficiently significant with the model for phase1, an instance of :ref:`NXphase`).
         
-        When there are multiple phases, it is possible (although not frequently
-        required) that a pattern matches eventually (not equally well) sufficiently
-        significant with multiple patterns. This can especially happen in cases of
-        pseudosymmetry and more frequently with an improperly calibrated system
-        or false or inaccurate phase models. Having such field is especially relevant
+        For the example of multi-phase material, it is possible (although not frequently
+        required) that a pattern agrees significantly with multiple patterns. Examples are
+        cases of pseudosymmetry, insufficiently precise and accurate calibrated systems,
+        or usage of inaccurate phase models. Having such field is especially relevant
         for recent dictionary- or artificial intelligence-based indexing methods to communicate
         the results in a model-agnostic way in combination with matching_phase.
         
-        Depending on the phases_per_scan_point value, identifier_phase and
+        Depending on the phases_per_scan_point value, phase_id and
         matching_phase arrays represent a collection of concatenated tuples.
         These are organized in sequence: The solutions for the 0-th scan point,
         the 1-th scan point, the n_sc - 1 th scan point and omitting tuples
@@ -420,10 +419,10 @@ NXem_ebsd(NXprocess):
     matching_phase(NX_INT):
       unit: NX_UNITLESS
       doc: |
-        One-dimensional array, pattern by pattern labelling the solutions found.
+        One-dimensional array, pattern-by-pattern labelling the solutions found.
         The array phases_per_scan_point has to be specified because it details
-        how the identifier_phase and the matching_phase arrays are interpreted.
-        See documentation of identifier_phase for further details.
+        how the phase_id and the matching_phase arrays are interpreted.
+        See documentation of phase_id for further details.
       dimensions:
         rank: 1
         dim: (n_solutions,)
@@ -450,6 +449,13 @@ NXem_ebsd(NXprocess):
       unit: NX_UNITLESS
       doc: |
         Number of scan points in the original mapping.
+    pixel_shape(NX_CHAR):
+      doc: |
+        The shape of the polygon or polyhedron that was used for the tiling
+        respectively tessellation of the region-of-interest into scan points.
+      enumeration: [square, hexagon, cube, other]
+    
+    # use NXcg_grid in the future
     (NXmicrostructure):
     roi(NXdata):
       doc: |
@@ -493,7 +499,7 @@ NXem_ebsd(NXprocess):
             Label for the x axis
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# e4d80825f51ecf58aa6b84c18e9d949b54e644e91bf3a7f60ddd2250b6a96dae
+# 2fea464c04385d524fe1b66c6df1f111f4d73bff32a2db6db6ac8a7550b792bb
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -1025,34 +1031,33 @@ NXem_ebsd(NXprocess):
 #                 In another example users may have skipped some scan points (not indexed
 #                 them at all) or used differing numbers of phases for indexing different scan points.
 #                 
-#                 The cumulated of this array decodes how identifier_phase and matching_phase
+#                 The cumulated of this array decodes how phase_id and matching_phase
 #                 arrays have to be interpreted. In the simplest case (one pattern per scan
 #                 point, and all scan points indexed using that same single phase model),
-#                 identifier_phase has as many entries as scan points
+#                 phase_id has as many entries as scan points
 #                 and matching_phase has also as many entries as scan points.
 #             </doc>
 #             <dimensions rank="1">
 #                 <dim index="1" value="n_sc"/>
 #             </dimensions>
 #         </field>
-#         <field name="identifier_phase" type="NX_INT" units="NX_UNITLESS">
+#         <field name="phase_id" type="NX_INT" units="NX_UNITLESS">
 #             <doc>
-#                 The array phases_per_scan_point details how the identifier_phase
+#                 The array phases_per_scan_point details how the phase_id
 #                 and the matching_phase arrays have to be interpreted.
 #                 
-#                 For the example with a single phase identifier_phase has trivial
+#                 For the example of a single-phase material phase_id has trivial
 #                 values either 0 (no solution) or 1 (solution matching
-#                 sufficiently significant with the model for phase 1).
+#                 sufficiently significant with the model for phase1, an instance of :ref:`NXphase`).
 #                 
-#                 When there are multiple phases, it is possible (although not frequently
-#                 required) that a pattern matches eventually (not equally well) sufficiently
-#                 significant with multiple patterns. This can especially happen in cases of
-#                 pseudosymmetry and more frequently with an improperly calibrated system
-#                 or false or inaccurate phase models. Having such field is especially relevant
+#                 For the example of multi-phase material, it is possible (although not frequently
+#                 required) that a pattern agrees significantly with multiple patterns. Examples are
+#                 cases of pseudosymmetry, insufficiently precise and accurate calibrated systems,
+#                 or usage of inaccurate phase models. Having such field is especially relevant
 #                 for recent dictionary- or artificial intelligence-based indexing methods to communicate
 #                 the results in a model-agnostic way in combination with matching_phase.
 #                 
-#                 Depending on the phases_per_scan_point value, identifier_phase and
+#                 Depending on the phases_per_scan_point value, phase_id and
 #                 matching_phase arrays represent a collection of concatenated tuples.
 #                 These are organized in sequence: The solutions for the 0-th scan point,
 #                 the 1-th scan point, the n_sc - 1 th scan point and omitting tuples
@@ -1064,10 +1069,10 @@ NXem_ebsd(NXprocess):
 #         </field>
 #         <field name="matching_phase" type="NX_INT" units="NX_UNITLESS">
 #             <doc>
-#                 One-dimensional array, pattern by pattern labelling the solutions found.
+#                 One-dimensional array, pattern-by-pattern labelling the solutions found.
 #                 The array phases_per_scan_point has to be specified because it details
-#                 how the identifier_phase and the matching_phase arrays are interpreted.
-#                 See documentation of identifier_phase for further details.
+#                 how the phase_id and the matching_phase arrays are interpreted.
+#                 See documentation of phase_id for further details.
 #             </doc>
 #             <dimensions rank="1">
 #                 <dim index="1" value="n_solutions"/>
@@ -1106,6 +1111,19 @@ NXem_ebsd(NXprocess):
 #                 Number of scan points in the original mapping.
 #             </doc>
 #         </field>
+#         <field name="pixel_shape" type="NX_CHAR">
+#             <doc>
+#                 The shape of the polygon or polyhedron that was used for the tiling
+#                 respectively tessellation of the region-of-interest into scan points.
+#             </doc>
+#             <enumeration>
+#                 <item value="square"/>
+#                 <item value="hexagon"/>
+#                 <item value="cube"/>
+#                 <item value="other"/>
+#             </enumeration>
+#         </field>
+#         <!--use NXcg_grid in the future-->
 #         <group type="NXmicrostructure"/>
 #         <group name="roi" type="NXdata">
 #             <doc>

--- a/base_classes/nyaml/NXphase.yaml
+++ b/base_classes/nyaml/NXphase.yaml
@@ -14,7 +14,7 @@ NXphase(NXobject):
       null-model (no sufficiently significant information available).
       In other words, the phase_name is n/a aka notIndexed.
       
-      The identifier_phase value should match with the integer suffix of the
+      The  phase_id value should match with the integer suffix of the
       group name which represents that instance in a NeXus/HDF5 file, i.e.
       if three phases were used e.g. 0, 1, and 2, three instances of
       :ref:`NXphase` named phase0, phase1, and phase2 should be stored
@@ -23,7 +23,7 @@ NXphase(NXobject):
     doc: |
       Given name as an alias for identifying this phase.
       
-      If the identifier_phase is 0 and one would like to use
+      If the  phase_id is 0 and one would like to use
       the field name, the value should be n/a or notIndexed.
   (NXunit_cell):
   (NXatom):
@@ -33,7 +33,7 @@ NXphase(NXobject):
   (NXmicrostructure):
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# cc674989be959932845b2c4f88f6a4a164e554172145b1337f99859d6c51717b
+# 2a599a9d3e679914db9687c01a84542bb9273586d50622dbdee9ac1adfe5fca7
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -71,7 +71,7 @@ NXphase(NXobject):
 #             null-model (no sufficiently significant information available).
 #             In other words, the phase_name is n/a aka notIndexed.
 #             
-#             The identifier_phase value should match with the integer suffix of the
+#             The  phase_id value should match with the integer suffix of the
 #             group name which represents that instance in a NeXus/HDF5 file, i.e.
 #             if three phases were used e.g. 0, 1, and 2, three instances of
 #             :ref:`NXphase` named phase0, phase1, and phase2 should be stored
@@ -82,7 +82,7 @@ NXphase(NXobject):
 #         <doc>
 #             Given name as an alias for identifying this phase.
 #             
-#             If the identifier_phase is 0 and one would like to use
+#             If the  phase_id is 0 and one would like to use
 #             the field name, the value should be n/a or notIndexed.
 #         </doc>
 #     </field>

--- a/contributed_definitions/NXmicrostructure.nxdl.xml
+++ b/contributed_definitions/NXmicrostructure.nxdl.xml
@@ -312,9 +312,9 @@ examples for specific frequently discussed microstructural features-->
             <doc>
                 Reference to an instance of:
                 
-                * :ref:`NXcg_polyline` for a one-dimensional representation as only a projection is available (like in linear intercept analysis)
-                * :ref:`NXcg_polygon` for a two-dimensional representation as only a projection is available (like in most experiments)
-                * :ref:`NXcg_polyhedron` or :ref:`NXcg_grid` for regularly pixelated (in 1D, 2D) or voxelated representations (in 3D)
+                * :ref:`NXcg_polyline` for a one- or two-dimensional representation as only a projection is available (like in linear intercept analysis)
+                * :ref:`NXcg_polygon`, :ref:`NXcg_triangle`, or :ref:`NXcg_polyhedron` for a two- or three-dimensional representation as only a projection is available (like in most experiments)
+                * :ref:`NXcg_grid` for regularly pixelated (in 1D, 2D) or voxelated representations (in 3D)
                 
                 which represent the geometrical entities of the discretization.
             </doc>

--- a/contributed_definitions/NXmicrostructure_feature.nxdl.xml
+++ b/contributed_definitions/NXmicrostructure_feature.nxdl.xml
@@ -30,8 +30,8 @@
     </doc>
     <group name="chemical_composition" type="NXchemical_composition">
         <doc>
-            The chemical composition of this microstructural feature or this set of
-            features.
+            The chemical composition of this microstructural feature
+            or set such features.
         </doc>
     </group>
 </definition>

--- a/contributed_definitions/NXmicrostructure_feature.nxdl.xml
+++ b/contributed_definitions/NXmicrostructure_feature.nxdl.xml
@@ -31,7 +31,7 @@
     <group name="chemical_composition" type="NXchemical_composition">
         <doc>
             The chemical composition of this microstructural feature
-            or set such features.
+            or set of such features.
         </doc>
     </group>
 </definition>

--- a/contributed_definitions/NXmicrostructure_ipf.nxdl.xml
+++ b/contributed_definitions/NXmicrostructure_ipf.nxdl.xml
@@ -120,7 +120,7 @@
             Inverse pole figure mapping.
             
             Instances named phase0 should by definition refer to the null phase notIndexed.
-            Inspect the definition of :ref:`NXphase` and its field identifier_phase
+            Inspect the definition of :ref:`NXphase` and its field  phase_id
             for further details.
             
             Details about possible regridding and associated interpolation

--- a/contributed_definitions/NXmicrostructure_mtex_config.nxdl.xml
+++ b/contributed_definitions/NXmicrostructure_mtex_config.nxdl.xml
@@ -21,7 +21,7 @@
 #
 # For further information, see http://www.nexusformat.org
 -->
-<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXmicrostructure_mtex_config" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXmicrostructure_mtex_config" extends="NXparameters" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
     <symbols>
         <symbol name="n_def_color_map">
             <doc>

--- a/contributed_definitions/NXmicrostructure_odf.nxdl.xml
+++ b/contributed_definitions/NXmicrostructure_odf.nxdl.xml
@@ -91,6 +91,19 @@
             </doc>
         </field>
     </group>
+    <group name="characteristics" type="NXprocess">
+        <doc>
+            Group to store descriptors for a rough classification of an ODF.
+        </doc>
+        <field name="texture_index" type="NX_FLOAT" units="NX_DIMENSIONLESS">
+            <doc>
+                The texture index :math:`t = \int_{\mathcal{SO(3)}} f(R)^{2}dR` with :math:`f(R)`, denoting the ODF
+                is evaluated in orientation space :math:`\mathcal{SO(3)}`.
+                
+                The higher it is the texture index the sharper it is the ODF.
+            </doc>
+        </field>
+    </group>
     <!--specific values and typical results-->
     <group name="kth_extrema" type="NXprocess">
         <doc>
@@ -178,11 +191,6 @@
             Mind that the orientation space is a distorted space when it using an Euler angle parameterization.
             Therefore, equivalent orientations show intensity contributions in eventually multiple locations.
         </doc>
-        <!--\@signal: intensity
-\@axes: [varphi_two, capital_phi, varphi_one]
-\@varphi_one_indices: 0
-\@capital_phi: 1
-\@varphi_two_indices: 2-->
         <field name="intensity" type="NX_NUMBER" units="NX_DIMENSIONLESS">
             <doc>
                 ODF intensity at probed locations relative to the intensity of the null model of

--- a/contributed_definitions/nyaml/NXmicrostructure.yaml
+++ b/contributed_definitions/nyaml/NXmicrostructure.yaml
@@ -225,9 +225,9 @@ NXmicrostructure(NXobject):
       doc: |
         Reference to an instance of:
         
-        * :ref:`NXcg_polyline` for a one-dimensional representation as only a projection is available (like in linear intercept analysis)
-        * :ref:`NXcg_polygon` for a two-dimensional representation as only a projection is available (like in most experiments)
-        * :ref:`NXcg_polyhedron` or :ref:`NXcg_grid` for regularly pixelated (in 1D, 2D) or voxelated representations (in 3D)
+        * :ref:`NXcg_polyline` for a one- or two-dimensional representation as only a projection is available (like in linear intercept analysis)
+        * :ref:`NXcg_polygon`, :ref:`NXcg_triangle`, or :ref:`NXcg_polyhedron` for a two- or three-dimensional representation as only a projection is available (like in most experiments)
+        * :ref:`NXcg_grid` for regularly pixelated (in 1D, 2D) or voxelated representations (in 3D)
         
         which represent the geometrical entities of the discretization.
     number_of_crystals(NX_UINT):
@@ -672,7 +672,7 @@ NXmicrostructure(NXobject):
         dim: (n_qj,)
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 0043e320305db51c18feb24e529294bd74cf4df5daff3ffae0df536873e16c70
+# b9eac6a925d2c340ac26c59737ccb42dfc4d9732586375d489c128057c101359
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -987,9 +987,9 @@ NXmicrostructure(NXobject):
 #             <doc>
 #                 Reference to an instance of:
 #                 
-#                 * :ref:`NXcg_polyline` for a one-dimensional representation as only a projection is available (like in linear intercept analysis)
-#                 * :ref:`NXcg_polygon` for a two-dimensional representation as only a projection is available (like in most experiments)
-#                 * :ref:`NXcg_polyhedron` or :ref:`NXcg_grid` for regularly pixelated (in 1D, 2D) or voxelated representations (in 3D)
+#                 * :ref:`NXcg_polyline` for a one- or two-dimensional representation as only a projection is available (like in linear intercept analysis)
+#                 * :ref:`NXcg_polygon`, :ref:`NXcg_triangle`, or :ref:`NXcg_polyhedron` for a two- or three-dimensional representation as only a projection is available (like in most experiments)
+#                 * :ref:`NXcg_grid` for regularly pixelated (in 1D, 2D) or voxelated representations (in 3D)
 #                 
 #                 which represent the geometrical entities of the discretization.
 #             </doc>

--- a/contributed_definitions/nyaml/NXmicrostructure_feature.yaml
+++ b/contributed_definitions/nyaml/NXmicrostructure_feature.yaml
@@ -8,11 +8,11 @@ type: group
 NXmicrostructure_feature(NXobject):
   chemical_composition(NXchemical_composition):
     doc: |
-      The chemical composition of this microstructural feature or this set of
-      features.
+      The chemical composition of this microstructural feature
+      or set such features.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# ae1fc0ea51acf0cf515d8d19dd52c36005553f4ff8c4926460a6ad3dad9c853c
+# 597db5870bcad78792b354f34d78c922dcff57309787958f6081bf13bb211be3
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -45,8 +45,8 @@ NXmicrostructure_feature(NXobject):
 #     </doc>
 #     <group name="chemical_composition" type="NXchemical_composition">
 #         <doc>
-#             The chemical composition of this microstructural feature or this set of
-#             features.
+#             The chemical composition of this microstructural feature
+#             or set such features.
 #         </doc>
 #     </group>
 # </definition>

--- a/contributed_definitions/nyaml/NXmicrostructure_feature.yaml
+++ b/contributed_definitions/nyaml/NXmicrostructure_feature.yaml
@@ -9,10 +9,10 @@ NXmicrostructure_feature(NXobject):
   chemical_composition(NXchemical_composition):
     doc: |
       The chemical composition of this microstructural feature
-      or set such features.
+      or set of such features.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 597db5870bcad78792b354f34d78c922dcff57309787958f6081bf13bb211be3
+# 004014295f45d97e0aae78c9bbac93d6bf090fd390dc36d8aa1a22b6ea7ec0f9
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -46,7 +46,7 @@ NXmicrostructure_feature(NXobject):
 #     <group name="chemical_composition" type="NXchemical_composition">
 #         <doc>
 #             The chemical composition of this microstructural feature
-#             or set such features.
+#             or set of such features.
 #         </doc>
 #     </group>
 # </definition>

--- a/contributed_definitions/nyaml/NXmicrostructure_ipf.yaml
+++ b/contributed_definitions/nyaml/NXmicrostructure_ipf.yaml
@@ -61,7 +61,7 @@ NXmicrostructure_ipf(NXprocess):
       Inverse pole figure mapping.
       
       Instances named phase0 should by definition refer to the null phase notIndexed.
-      Inspect the definition of :ref:`NXphase` and its field identifier_phase
+      Inspect the definition of :ref:`NXphase` and its field  phase_id
       for further details.
       
       Details about possible regridding and associated interpolation
@@ -176,7 +176,7 @@ NXmicrostructure_ipf(NXprocess):
   # https://github.com/FAIRmat-NFDI/nexus_definitions/commit/26d4faa5c6950161e48f0672f3fdfd8c9bc907e2
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 77a3f07c431a994ce35036efe626a026e4071d506fd0d999d66fcfffdd4ee133
+# 083fd06414e83ed2371c49391079cac1644057c0cf3cf9c30d17b43ad1db2668
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -299,7 +299,7 @@ NXmicrostructure_ipf(NXprocess):
 #             Inverse pole figure mapping.
 #             
 #             Instances named phase0 should by definition refer to the null phase notIndexed.
-#             Inspect the definition of :ref:`NXphase` and its field identifier_phase
+#             Inspect the definition of :ref:`NXphase` and its field  phase_id
 #             for further details.
 #             
 #             Details about possible regridding and associated interpolation

--- a/contributed_definitions/nyaml/NXmicrostructure_mtex_config.yaml
+++ b/contributed_definitions/nyaml/NXmicrostructure_mtex_config.yaml
@@ -11,7 +11,7 @@ symbols:
   n_color_map: |
     Number of entries in color map
 type: group
-NXmicrostructure_mtex_config(NXobject):
+NXmicrostructure_mtex_config(NXparameters):
   conventions(NXcollection):
     doc: |
       MTex reference frame and orientation conventions.
@@ -203,7 +203,7 @@ NXmicrostructure_mtex_config(NXobject):
   # version as an instance of (NXprogram) one for MTex one for Matlab
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 69087abba8fd927cf17ad7bfd2cc2cd7f5cc4c103a401a1ecd38ca6809b4acf1
+# 901921f0acbb4d44350ad17c509969aa83bf4cad9c34a5bc606aa9ede4381812
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -227,7 +227,7 @@ NXmicrostructure_mtex_config(NXobject):
 # #
 # # For further information, see http://www.nexusformat.org
 # -->
-# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXmicrostructure_mtex_config" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXmicrostructure_mtex_config" extends="NXparameters" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
 #     <symbols>
 #         <symbol name="n_def_color_map">
 #             <doc>

--- a/contributed_definitions/nyaml/NXmicrostructure_odf.yaml
+++ b/contributed_definitions/nyaml/NXmicrostructure_odf.yaml
@@ -43,6 +43,16 @@ NXmicrostructure_odf(NXprocess):
       unit: NX_ANGLE
       doc: |
         Resolution of the kernel.
+  characteristics(NXprocess):
+    doc: |
+      Group to store descriptors for a rough classification of an ODF.
+    texture_index(NX_FLOAT):
+      unit: NX_DIMENSIONLESS
+      doc: |
+        The texture index :math:`t = \int_{\mathcal{SO(3)}} f(R)^{2}dR` with :math:`f(R)`, denoting the ODF
+        is evaluated in orientation space :math:`\mathcal{SO(3)}`.
+        
+        The higher it is the texture index the sharper it is the ODF.
   
   # specific values and typical results
   kth_extrema(NXprocess):
@@ -113,12 +123,6 @@ NXmicrostructure_odf(NXprocess):
       
       Mind that the orientation space is a distorted space when it using an Euler angle parameterization.
       Therefore, equivalent orientations show intensity contributions in eventually multiple locations.
-    
-    # \@signal: intensity
-    # \@axes: [varphi_two, capital_phi, varphi_one]
-    # \@varphi_one_indices: 0
-    # \@capital_phi: 1
-    # \@varphi_two_indices: 2
     intensity(NX_NUMBER):
       unit: NX_DIMENSIONLESS
       doc: |
@@ -150,7 +154,7 @@ NXmicrostructure_odf(NXprocess):
         dim: (n_varphi_two,)
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 243a65e23623a0bc9a66f1041e4358c0618fc1e7d740eb7fdd81edc48865ada1
+# 6114794aa8ae148316c93ba3a4ce3c0e831110d194f032dcf2cc947b2bd4d9d4
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -244,6 +248,19 @@ NXmicrostructure_odf(NXprocess):
 #             </doc>
 #         </field>
 #     </group>
+#     <group name="characteristics" type="NXprocess">
+#         <doc>
+#             Group to store descriptors for a rough classification of an ODF.
+#         </doc>
+#         <field name="texture_index" type="NX_FLOAT" units="NX_DIMENSIONLESS">
+#             <doc>
+#                 The texture index :math:`t = \int_{\mathcal{SO(3)}} f(R)^{2}dR` with :math:`f(R)`, denoting the ODF
+#                 is evaluated in orientation space :math:`\mathcal{SO(3)}`.
+#                 
+#                 The higher it is the texture index the sharper it is the ODF.
+#             </doc>
+#         </field>
+#     </group>
 #     <!--specific values and typical results-->
 #     <group name="kth_extrema" type="NXprocess">
 #         <doc>
@@ -331,11 +348,6 @@ NXmicrostructure_odf(NXprocess):
 #             Mind that the orientation space is a distorted space when it using an Euler angle parameterization.
 #             Therefore, equivalent orientations show intensity contributions in eventually multiple locations.
 #         </doc>
-#         <!--\@signal: intensity
-# \@axes: [varphi_two, capital_phi, varphi_one]
-# \@varphi_one_indices: 0
-# \@capital_phi: 1
-# \@varphi_two_indices: 2-->
 #         <field name="intensity" type="NX_NUMBER" units="NX_DIMENSIONLESS">
 #             <doc>
 #                 ODF intensity at probed locations relative to the intensity of the null model of


### PR DESCRIPTION
exemplified for EBSD:
- [x] Microstructure
- [x] ODF
- [x] IPF

## Summary by Sourcery

Extend the NXem schema to fully integrate microstructure, ODF, and pole figure data for EBSD workflows by adding repeating groups for microstructureID, odfID, and pfID, while refining related definitions and documentation.

New Features:
- Introduce repeating microstructureID group under NXem indexing to capture detailed microstructure configuration, geometry, and feature information
- Enable multiple ODF entries (odfID) in NXem with full parameter configuration, texture index characteristics, and phi-two plot data
- Allow multiple pole figure entries (pfID) in NXem for extended IPF support

Enhancements:
- Remove redundant nameType attributes on AXISNAME_indices and align attribute definitions across maps and legends
- Adjust NXmicrostructure and NXmicrostructure_odf definitions to include a characteristics group for texture index and refine geometry entity documentation
- Change NXmicrostructure_mtex_config group to extend NXparameters instead of NXobject