### PR TITLE
Pynx apm bugfixes

### DIFF
--- a/applications/NXapm.nxdl.xml
+++ b/applications/NXapm.nxdl.xml
@@ -1313,7 +1313,7 @@
                         <field name="name" type="NX_CHAR"/>
                     </group>
                 </group>
-                <field name="mass_to_charge" type="NX_FLOAT">
+                <field name="mass_to_charge" type="NX_FLOAT" units="NX_ANY">
                     <dimensions rank="1">
                         <dim index="1" value="n"/>
                     </dimensions>

--- a/applications/NXapm.nxdl.xml
+++ b/applications/NXapm.nxdl.xml
@@ -1265,7 +1265,7 @@
                     <field name="checksum" type="NX_CHAR" recommended="true"/>
                     <field name="algorithm" type="NX_CHAR" recommended="true"/>
                 </group>
-                <group name="config" type="NXparameters">
+                <group name="config" type="NXparameters" recommended="true">
                     <field name="mass_calibration" type="NX_FLOAT" recommended="true" units="NX_ANY">
                         <doc>
                             Mass calibration with unit peaks/interp. as mentioned by `T. Blum et al.

--- a/applications/nyaml/NXapm.yaml
+++ b/applications/nyaml/NXapm.yaml
@@ -1189,6 +1189,7 @@ NXapm(NXobject):
           algorithm(NX_CHAR):
             exists: recommended
         config(NXparameters):
+          exists: recommended
           mass_calibration(NX_FLOAT):
             exists: recommended
             unit: NX_ANY

--- a/applications/nyaml/NXapm.yaml
+++ b/applications/nyaml/NXapm.yaml
@@ -1237,6 +1237,7 @@ NXapm(NXobject):
               exists: recommended
             name(NX_CHAR):
         mass_to_charge(NX_FLOAT):
+          unit: NX_ANY
           dimensions:
             rank: 1
             dim: (n,)

--- a/base_classes/NXapm_reconstruction.nxdl.xml
+++ b/base_classes/NXapm_reconstruction.nxdl.xml
@@ -130,9 +130,10 @@
                 field of a CamecaRoot ROOT file.
             </doc>
         </field>
-        <field name="kfactor" type="NX_FLOAT" units="NX_VOLUME">
+        <field name="kfactor" type="NX_FLOAT" units="NX_UNITLESS">
             <doc>
-                Sum of ion volumes
+                The factor :math:`k` in :math:`R_0 = \frac{V}{kF}` with :math:`R_0` tip_radius_zero
+                :math:`V` the voltage and :math:`F` the evaporation field.
                 
                 The value can be extracted from the CAnalysis.CSpatial.fKfactor
                 field of a CamecaRoot ROOT file.
@@ -186,6 +187,9 @@
                 performed with APSuite / IVAS see also `B. Gault et al. &lt;https://doi.org/10.1093/mam/ozae081&gt;_`
                 and `T. Blum et al. &lt;https://doi.org/10.1002/9781119227250.ch18&gt;`_ (page 371).
                 for best practices on the reporting of metadata in atom probe tomography.
+                
+                The value can be extracted from the CAnalysis.CResults.fComments
+                field of a CamecaRoot ROOT file.
             </doc>
         </field>
     </group>
@@ -203,6 +207,14 @@
                 The instance of :ref:`NXcoordinate_system` in which the positions are defined.
             </doc>
         </attribute>
+    </field>
+    <field name="quality" type="NX_CHAR">
+        <doc>
+            Qualitative statement about the reconstruction.
+            
+            The value can be extracted from the CAnalysis.CResults.fQuality
+            field of a CamecaRoot ROOT file.
+        </doc>
     </field>
     <!--plots and statistics about the reconstructed volume-->
     <group name="naive_discretization" type="NXprocess">

--- a/base_classes/nyaml/NXapm_reconstruction.yaml
+++ b/base_classes/nyaml/NXapm_reconstruction.yaml
@@ -91,9 +91,10 @@ NXapm_reconstruction(NXprocess):
         The value can be extracted from the CAnalysis.CSpatial.fImageCompression
         field of a CamecaRoot ROOT file.
     kfactor(NX_FLOAT):
-      unit: NX_VOLUME
+      unit: NX_UNITLESS
       doc: |
-        Sum of ion volumes
+        The factor :math:`k` in :math:`R_0 = \frac{V}{kF}` with :math:`R_0` tip_radius_zero
+        :math:`V` the voltage and :math:`F` the evaporation field.
         
         The value can be extracted from the CAnalysis.CSpatial.fKfactor
         field of a CamecaRoot ROOT file.
@@ -138,7 +139,9 @@ NXapm_reconstruction(NXprocess):
         performed with APSuite / IVAS see also `B. Gault et al. <https://doi.org/10.1093/mam/ozae081>_`
         and `T. Blum et al. <https://doi.org/10.1002/9781119227250.ch18>`_ (page 371).
         for best practices on the reporting of metadata in atom probe tomography.
-  
+        
+        The value can be extracted from the CAnalysis.CResults.fComments
+        field of a CamecaRoot ROOT file.  
   # results
   reconstructed_positions(NX_FLOAT):
     unit: NX_LENGTH
@@ -150,7 +153,12 @@ NXapm_reconstruction(NXprocess):
     \@depends_on(NX_CHAR):
       doc: |
         The instance of :ref:`NXcoordinate_system` in which the positions are defined.
-  
+  quality(NX_CHAR):
+    doc: |
+      Qualitative statement about the reconstruction.
+      
+      The value can be extracted from the CAnalysis.CResults.fQuality
+      field of a CamecaRoot ROOT file.
   # plots and statistics about the reconstructed volume
   naive_discretization(NXprocess):
     (NXprogram):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Prepare for Documentation
 lxml>=4.9.1 
 pyyaml
-nyaml==0.2.2
+nyaml==0.2.3
 
 # Documentation building
 sphinx>=5


### PR DESCRIPTION
## Summary by Sourcery

Update APM reconstruction and application schemas to refine metadata representation and recommendations.

New Features:
- Add 'quality' field to NXapm_reconstruction schema for qualitative reconstruction metadata.

Enhancements:
- Change kfactor unit from NX_VOLUME to NX_UNITLESS and expand its documentation with formula and extraction source.
- Document extraction of comments from CAnalysis.CResults.fComments in reconstruction metadata.
- Mark 'config' group as recommended in NXapm application schema.
- Specify NX_ANY units for the mass_to_charge field in NXapm application schema.
- Mirror XML updates in corresponding YAML definitions for consistency.