### PR TITLE
remove dim for NX_CHAR field in NXmicrostructure_score_config

### DIFF
--- a/contributed_definitions/NXmicrostructure_score_config.nxdl.xml
+++ b/contributed_definitions/NXmicrostructure_score_config.nxdl.xml
@@ -564,9 +564,6 @@ like showing a r(t) plot-->
                 <doc>
                     Given name of a texture component.
                 </doc>
-                <dimensions rank="1">
-                    <dim index="1" value="n_ori"/>
-                </dimensions>
             </field>
             <field name="bunge_euler" type="NX_FLOAT" units="NX_ANGLE">
                 <doc>

--- a/contributed_definitions/nyaml/NXmicrostructure_score_config.yaml
+++ b/contributed_definitions/nyaml/NXmicrostructure_score_config.yaml
@@ -418,9 +418,6 @@ NXmicrostructure_score_config(NXobject):
       name(NX_CHAR):
         \doc: |
           Given name of a texture component.
-        \dimensions:
-          \rank: 1
-          \dim: (n_ori,)
       bunge_euler(NX_FLOAT):
         \unit: NX_ANGLE
         \doc: |
@@ -589,7 +586,7 @@ NXmicrostructure_score_config(NXobject):
           during post-processing the results with the solitary unit modeling approach.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 1a1d41a0f0db0ad0ba8b5bfb93ff57771ef2c029b3076e57df14720f81c63b95
+# 703774d6737e0f154544a9dcda8d994ad212e91ab8d8d88b47a854fea4970f44
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -1156,9 +1153,6 @@ NXmicrostructure_score_config(NXobject):
 #                 <doc>
 #                     Given name of a texture component.
 #                 </doc>
-#                 <dimensions rank="1">
-#                     <dim index="1" value="n_ori"/>
-#                 </dimensions>
 #             </field>
 #             <field name="bunge_euler" type="NX_FLOAT" units="NX_ANGLE">
 #                 <doc>


### PR DESCRIPTION
This fixes a minor issue: an `NX_CHAR` field in `NXmicrostructure_score_config` had a dimension. I don't think that should be the case.