### PR TITLE
add optional NXcite to NXoptical_spectroscopy

### DIFF
--- a/applications/NXoptical_spectroscopy.nxdl.xml
+++ b/applications/NXoptical_spectroscopy.nxdl.xml
@@ -142,6 +142,14 @@ TODO:
                 <item value="pump-probe"/>
             </enumeration>
         </field>
+        <group name="citeID" type="NXcite" nameType="partial" optional="true">
+            <doc>
+                Citation information for the experiment. This may be a DOI or a reference
+                to a publication, which describes the experiment in more detail.
+            </doc>
+            <field name="author" type="NX_CHAR" recommended="true"/>
+            <field name="doi" type="NX_CHAR" recommended="true"/>
+        </group>
         <group name="beam_ref_frame" type="NXcoordinate_system" optional="true">
             <field name="depends_on" type="NX_CHAR">
                 <doc>

--- a/applications/nyaml/NXoptical_spectroscopy.yaml
+++ b/applications/nyaml/NXoptical_spectroscopy.yaml
@@ -95,6 +95,16 @@ NXoptical_spectroscopy(NXobject):
       \enumeration:
         \open: true
         \items: [time resolved, imaging, pump-probe]
+    citeID(NXcite):
+      \nameType: partial
+      \exists: optional
+      \doc: |
+        Citation information for the experiment. This may be a DOI or a reference
+        to a publication, which describes the experiment in more detail.
+      author(NX_CHAR):
+        \exists: recommended
+      doi(NX_CHAR):
+        \exists: recommended
     beam_ref_frame(NXcoordinate_system):
       \exists: optional
       depends_on(NX_CHAR):
@@ -860,7 +870,7 @@ NXoptical_spectroscopy(NXobject):
           \@version:
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 0edac3987e1d67bedcde2ca7a36e7558e38601608ea79ca33bc682da0c7d4309
+# d0eb528b7e1e24fcc0dd77d0f49e6a5dadc40518582b37e4e5b10ae49e7b5431
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -1005,6 +1015,14 @@ NXoptical_spectroscopy(NXobject):
 #                 <item value="pump-probe"/>
 #             </enumeration>
 #         </field>
+#         <group name="citeID" type="NXcite" nameType="partial" optional="true">
+#             <doc>
+#                 Citation information for the experiment. This may be a DOI or a reference
+#                 to a publication, which describes the experiment in more detail.
+#             </doc>
+#             <field name="author" type="NX_CHAR" recommended="true"/>
+#             <field name="doi" type="NX_CHAR" recommended="true"/>
+#         </group>
 #         <group name="beam_ref_frame" type="NXcoordinate_system" optional="true">
 #             <field name="depends_on" type="NX_CHAR">
 #                 <doc>


### PR DESCRIPTION
This adds an optional `NXcite` group to `NXoptical_spectroscopy`. 

This is a prerequisite for the reprocessing of the Raman Open Database, see https://github.com/FAIRmat-NFDI/pynxtools-raman/issues/58.